### PR TITLE
Refactoring of roomba & talisman autobuyers for performance

### DIFF
--- a/src/Research.ts
+++ b/src/Research.ts
@@ -13,9 +13,10 @@ const getResearchCost = (index: number, buyAmount = 1, linGrowth = 0): [number, 
  * Buys Research of index.
  * @param index 
  * @param auto 
- * @param linGrowth 
+ * @param linGrowth
+ * @return boolean Whether the player can afford the current research
  */
-export const buyResearch = (index: number, auto = false, linGrowth = 0) => {
+export const buyResearch = (index: number, auto = false, linGrowth = 0): boolean => {
     // Handles background color of the currently focused research if auto research is upgrading something else
     if (player.autoResearchToggle && player.autoResearch > 0 && !auto) {
         const p = player.autoResearch
@@ -42,8 +43,9 @@ export const buyResearch = (index: number, auto = false, linGrowth = 0) => {
     // Buys Research. metaData returns amount of levels to buy and cost, array
     const buyamount = (G['maxbuyresearch'] || auto) ? 1e5 : 1;
     const metaData = getResearchCost(index, buyamount, linGrowth)
+    const canAfford = player.researchPoints >= metaData[1];
 
-    if ((auto || !player.autoResearchToggle) && isResearchUnlocked(index) && !isResearchMaxed(index) && player.researchPoints >= metaData[1]) {
+    if ((auto || !player.autoResearchToggle) && isResearchUnlocked(index) && !isResearchMaxed(index) && canAfford) {
         player.researchPoints -= metaData[1]
         player.researches[index] = metaData[0];
 
@@ -68,6 +70,10 @@ export const buyResearch = (index: number, auto = false, linGrowth = 0) => {
             player.unlocks.rrow4 = true;
             revealStuff()
         }
+
+        // Some researches update Rune and Ant values, so these recalculations are necessary if we bought research
+        calculateRuneLevels();
+        calculateAnts();
     }
 
     // Updates research background color to green if you purchased to max level
@@ -96,9 +102,7 @@ export const buyResearch = (index: number, auto = false, linGrowth = 0) => {
         }
     }
 
-    // Some researches update Rune and Ant values, so these recalculations are sometimes necessary
-    calculateRuneLevels();
-    calculateAnts();
+    return canAfford;
 }
 
 /**

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3011,7 +3011,9 @@ function tack(dt: number) {
                 while (counter < maxCount) {
                     if (player.autoResearch > 0) {
                         const linGrowth = (player.autoResearch === 200) ? 0.01 : 0;
-                        buyResearch(player.autoResearch, true, linGrowth)
+                        if (!buyResearch(player.autoResearch, true, linGrowth)) {
+                            break;
+                        }
                     }
                     else {
                         break;

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3034,51 +3034,43 @@ function tack(dt: number) {
         }
 
         if (player.researches[130] > 0 || player.researches[135] > 0) {
-            if (player.researches[135] > 0 && player.autoEnhanceToggle == true) {
-                if (player.achievements[119] > 0) {
-                    buyTalismanEnhance(1, true)
-                }
-                if (player.achievements[126] > 0) {
-                    buyTalismanEnhance(2, true)
-                }
-                if (player.achievements[133] > 0) {
-                    buyTalismanEnhance(3, true)
-                }
-                if (player.achievements[140] > 0) {
-                    buyTalismanEnhance(4, true)
-                }
-                if (player.achievements[147] > 0) {
-                    buyTalismanEnhance(5, true)
-                }
-                if (player.antUpgrades[12-1] > 0 || player.ascensionCount > 0) {
-                    buyTalismanEnhance(6, true)
-                }
-                if (player.shopUpgrades.talismanBought) {
-                    buyTalismanEnhance(7, true)
+            const talismansUnlocked = [
+                player.achievements[119] > 0,
+                player.achievements[126] > 0,
+                player.achievements[133] > 0,
+                player.achievements[140] > 0,
+                player.achievements[147] > 0,
+                player.antUpgrades[12-1] > 0 || player.ascensionCount > 0,
+                player.shopUpgrades.talismanBought,
+            ];
+            let upgradedTalisman = false;
+
+            // First, we need to enhance all of the talismans. Then, we can fortify all of the talismans.
+            // If we were to do this in one loop, the players resources would be drained on individual expensive levels
+            // of early talismans before buying important enhances for the later ones. This results in drastically
+            // reduced overall gains when talisman resources are scarce.
+            if (player.autoEnhanceToggle) {
+                for (let i = 0; i < talismansUnlocked.length; ++i) {
+                    if (talismansUnlocked[i]) {
+                        // TODO: Remove + 1 here when talismans are fully zero-indexed
+                        upgradedTalisman = buyTalismanEnhance(i + 1, true) || upgradedTalisman;
+                    }
                 }
             }
-            if (player.researches[130] > 0 && player.autoFortifyToggle == true) {
-                if (player.achievements[119] > 0) {
-                    buyTalismanLevels(1, true)
+
+            if (player.autoFortifyToggle) {
+                for (let i = 0; i < talismansUnlocked.length; ++i) {
+                    if (talismansUnlocked[i]) {
+                        // TODO: Remove + 1 here when talismans are fully zero-indexed
+                        upgradedTalisman = buyTalismanLevels(i + 1, true) || upgradedTalisman;
+                    }
                 }
-                if (player.achievements[126] > 0) {
-                    buyTalismanLevels(2, true)
-                }
-                if (player.achievements[133] > 0) {
-                    buyTalismanLevels(3, true)
-                }
-                if (player.achievements[140] > 0) {
-                    buyTalismanLevels(4, true)
-                }
-                if (player.achievements[147] > 0) {
-                    buyTalismanLevels(5, true)
-                }
-                if (player.antUpgrades[12-1] > 0 || player.ascensionCount > 0) {
-                    buyTalismanLevels(6, true)
-                }
-                if (player.shopUpgrades.talismanBought) {
-                    buyTalismanLevels(7, true)
-                }
+            }
+
+            // Recalculate talisman-related upgrades and display on success
+            if (upgradedTalisman) {
+                updateTalismanInventory();
+                calculateRuneLevels();
             }
         }
 

--- a/src/Talismans.ts
+++ b/src/Talismans.ts
@@ -405,7 +405,7 @@ export const updateTalismanAppearance = (i: number) => {
     }
 }
 
-export const buyTalismanLevels = (i: number, auto = false) => {
+export const buyTalismanLevels = (i: number, auto = false): boolean => {
     let max = 1;
     if (player.ascensionCount > 0) {
         max = 30
@@ -457,21 +457,22 @@ export const buyTalismanLevels = (i: number, auto = false) => {
             player.mythicalFragments -= priceMult * Math.max(0, Math.floor(1 + 1 / 1280 * Math.pow(player.talismanLevels[i-1] - 150, 3)))
             player.talismanLevels[i-1] += 1;
 
-        }
-
-        if (checkSum !== 7) {
-            break
+        } else {
+            return false;
         }
     }
-    updateTalismanInventory();
+
     if (!auto) {
         showTalismanPrices(i);
+        // When adding game state recalculations, update the talisman autobuyer in tack() as well
+        updateTalismanInventory();
+        calculateRuneLevels();
     }
 
-    calculateRuneLevels();
+    return true;
 }
 
-export const buyTalismanEnhance = (i: number, auto = false) => {
+export const buyTalismanEnhance = (i: number, auto = false): boolean => {
     let checkSum = 0;
     if (player.talismanRarity[i-1] < 6) {
         const priceMult = G['talismanLevelCostMultiplier'][i];
@@ -506,14 +507,18 @@ export const buyTalismanEnhance = (i: number, auto = false) => {
             player.legendaryFragments -= (priceMult * costArray[6])
             player.mythicalFragments -= (priceMult * costArray[7])
             player.talismanRarity[i-1] += 1
-        }
 
-        updateTalismanAppearance(i);
-        updateTalismanInventory();
-        if (!auto) {
-            showEnhanceTalismanPrices(i);
-        }
+            // Appearance always needs updating if bought
+            updateTalismanAppearance(i);
+            if (!auto) {
+                showEnhanceTalismanPrices(i);
+                // When adding game state recalculations, update the talisman autobuyer in tack() as well
+                updateTalismanInventory();
+                calculateRuneLevels();
+            }
 
-        calculateRuneLevels();
+            return true;
+        }
     }
+    return false;
 }


### PR DESCRIPTION
Currently, both the roomba and talisman autobuyers will end up calling `calculateRuneLevels()` and various other recalculations a couple of times each tick. This is extremely wasteful:
![Screenshot_20210130_183725](https://user-images.githubusercontent.com/67972089/106363974-195a6f00-632c-11eb-8d9b-34174f2ca362.png)

This PR changes these so that the recalculations are only ran if a level is successfully bought, and if the roomba can't buy a research, it stops trying instead of failing an additional `player.challengecompletions[14]` times per second.