### PR TITLE
History refactoring for TS

### DIFF
--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -88,7 +88,7 @@ export const checkVariablesOnLoad = (data: Player) => {
         player.roombaResearchIndex = 0;
     }
     if (data.history === undefined) {
-        player.history = {};
+        player.history = { ants: [], ascend: [], reset: [] };
         player.cubesThisAscension = {
             "challenges": 0,
             "reincarnation": 0,

--- a/src/History.ts
+++ b/src/History.ts
@@ -367,7 +367,7 @@ export const resetHistoryTogglePerSecond = () => {
 
 // Helper function to format the corruption display in the ascension table.
 const resetHistoryFormatCorruptions = (data: ResetHistoryEntryAscend): [string, string] => {
-    let score = "Score: " + format(data.corruptionScore, 0, true);
+    let score = "Score: " + format(data.corruptionScore, 0, false);
     let corruptions = "";
     for (let i = 0; i < resetHistoryCorruptionImages.length; ++i) {
         const corruptionIdx = i + 1;

--- a/src/History.ts
+++ b/src/History.ts
@@ -300,16 +300,6 @@ const resetHistoryRenderFullTable = (categoryToRender: Category, targetTable: HT
         }
     }
 }
-
-export const resetHistoryClearAll = () => {
-    Object.keys(player.history).forEach(key => {
-        if (Array.isArray(player.history[key])) {
-            delete player.history[key];
-        }
-    });
-    resetHistoryRenderAllTables();
-}
-
 export const resetHistoryRenderAllTables = () => {
     (Object.keys(resetHistoryTableMapping) as Category[]).forEach(
         key => resetHistoryRenderFullTable(key, document.getElementById(resetHistoryTableMapping[key]))

--- a/src/History.ts
+++ b/src/History.ts
@@ -191,7 +191,7 @@ const resetHistoryAdd = (
 
     // Convert Decimal objects to string representation, so that the data is loaded properly after a refresh
     for (const k in data) {
-        if (isDecimal(data[k])) {
+        if (Object.prototype.hasOwnProperty.call(data, k) && isDecimal(data[k])) {
             data[k] = data[k].toString();
         }
     }

--- a/src/History.ts
+++ b/src/History.ts
@@ -106,11 +106,13 @@ const conditionalFormatPerSecond = (numOrStr: DecimalSource, data: ResetHistoryE
         return formatDecimalSource(numOrStr);
     }
 
-    if (typeof (numOrStr) === "number" && player.historyShowPerSecond) {
+    if (typeof (numOrStr) === "number" && player.historyShowPerSecond && data.seconds !== 0) {
         if (numOrStr === 0) { // work around format(0, 3) return 0 instead of 0.000, for consistency
             return "0.000/s";
         }
-        return format(numOrStr / ((data.seconds && data.seconds > 0) ? data.seconds : 1), 3, true) + "/s";
+        // Use "long" display for smaller numbers, but once it exceeds 1000, use the "short" display.
+        // This'll keep decimals intact until 1000 instead of 10 without creating unwieldy numbers between e6-e13.
+        return format(numOrStr / data.seconds, 3, numOrStr < 1000) + "/s";
     }
     return format(numOrStr);
 }

--- a/src/History.ts
+++ b/src/History.ts
@@ -168,12 +168,6 @@ const extractStringExponent = (str: string) => {
     return (m = str.match(/e\+?(.+)/)) !== null ? `e${m[1]}` : str;
 }
 
-/**
- * Add a history entry to the storage.
- * @param {string} category One of "ants", "reset" or "ascend"
- * @param {string} kind One of "antsacrifice", "prestige", "transcend", "reincarnate" or "ascend"
- * @param {object} data Applicable gains and poorly documented extra data
- */
 const resetHistoryAdd = (
     category: Category,
     kind: Kind,

--- a/src/History.ts
+++ b/src/History.ts
@@ -81,17 +81,17 @@ const historyGains: Record<
     },
     particles: {
         img: "Pictures/Particle.png",
-        formatter: (s: DecimalSource) => extractStringExponent(formatDecimalString(s)),
+        formatter: formatDecimalString,
         imgTitle: "Particles"
     },
     diamonds: {
         img: "Pictures/Diamond.png",
-        formatter: (s: DecimalSource) => extractStringExponent(formatDecimalString(s)),
+        formatter: formatDecimalString,
         imgTitle: "Diamonds"
     },
     mythos: {
         img: "Pictures/Mythos.png",
-        formatter: (s: DecimalSource) => extractStringExponent(formatDecimalString(s)),
+        formatter: formatDecimalString,
         imgTitle: "Mythos"
     },
     wowTesseracts: {

--- a/src/History.ts
+++ b/src/History.ts
@@ -228,12 +228,12 @@ const resetHistoryRenderRow = (
     const gains = [];
     for (let gainIdx = 0; gainIdx < historyGainsOrder.length; ++gainIdx) {
         const showing = historyGainsOrder[gainIdx];
-        if (data.hasOwnProperty(showing)) {
+        if (Object.prototype.hasOwnProperty.call(data, showing)) {
             const gainInfo = historyGains[showing as keyof typeof historyGains];
             if (gainInfo.onlyif && !gainInfo.onlyif(data)) {
                 continue;
             }
-            const formatter = gainInfo.formatter || (() => {});
+            const formatter = gainInfo.formatter || (() => {/* If no formatter is specified, don't display. */});
             const str = `<img src="${gainInfo.img}" title="${gainInfo.imgTitle || ''}">${formatter(data[showing], data)}`;
 
             gains.push(str);

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -288,8 +288,8 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
     player.prestigecounter = 0;
     G['autoResetTimers'].prestige = 0;
 
-    if (input === "transcension" || input === "transcensionChallenge" || input == "reincarnation" || input == "reincarnationChallenge"
-        || input === "ascension" || input === "ascensionChallenge") {
+    const types = ['transcension', 'transcensionChallenge', 'reincarnation', 'reincarnationChallenge', 'ascension', 'ascensionChallenge'];
+    if (types.includes(input)) {
         resetUpgrades(2);
         player.coinsThisTranscension = new Decimal("100");
         player.firstOwnedDiamonds = 0;

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -574,7 +574,7 @@ export const player: Player = {
     corruptionShowStats: true,
 
     constantUpgrades: [null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    history: {},
+    history: { ants: [], ascend: [], reset: [] },
     historyCountMax: 10,
     historyShowPerSecond: false,
 
@@ -1019,7 +1019,7 @@ export const loadSynergy = (): void => {
         }
 
         if (data.history === undefined || player.history === undefined) {
-            player.history = {};
+            player.history = { ants: [], ascend: [], reset: [] };
         }
         if (data.historyShowPerSecond === undefined || player.historyShowPerSecond === undefined) {
             player.historyShowPerSecond = false;

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -1,5 +1,5 @@
 import type Decimal from 'break_infinity.js';
-import { Category, Kind, ResetHistoryAscend, ResetHistoryDate } from '../History';
+import { Category, ResetHistoryEntryUnion } from '../History';
 import { IPlatBaseCost } from '../Platonic';
 
 export interface Player {
@@ -853,7 +853,7 @@ export interface GlobalVariables {
 
 export interface SynergismEvents {
     achievement: [ number ]
-    historyAdd: [ Category, Kind, ResetHistoryAscend | ResetHistoryDate ]
+    historyAdd: [ Category, ResetHistoryEntryUnion ]
     promocode: [ string ]
     boughtPlatonicUpgrade: [ IPlatBaseCost ],
     openPlatonic: [ number ]

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -467,7 +467,7 @@ export interface Player {
     corruptionShowStats: boolean,
 
     constantUpgrades: number[]
-    history: Record<string, any>,
+    history: Record<Category, ResetHistoryEntryUnion[]>
     historyCountMax: number
     historyShowPerSecond: boolean,
 


### PR DESCRIPTION
This PR cleans up the history stuff to be more TypeScript-friendly. It also re-adds the full display of diamonds/mythos/particles instead of only showing the exponent (this was done because they didn't fit at some point in the past, but it's now hiding useful info for lategame players).

Submitted as draft because I want to fix the last remaining use of `any` and test it a bit more before having it merged.