### PR TITLE
Patch 4

### DIFF
--- a/src/Ants.ts
+++ b/src/Ants.ts
@@ -76,7 +76,7 @@ const antUpgradeTexts = [
     () => "Global timer is sped up by a factor of " + format(calculateSigmoid(2, player.antUpgrades[12-1] + G['bonusant12'], 69), 4)
 ]
 
-let repeatAnt: NodeJS.Timeout = null;
+let repeatAnt: ReturnType<typeof setTimeout> = null;
 
 export const antRepeat = (i: number) => {
     clearInt(repeatAnt);

--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -675,7 +675,7 @@ export const buyRuneBonusLevels = (type: 'Blessings' | 'Spirits', index: number)
         (baseCost = G['blessingBaseCost'], baseLevels = player.runeBlessingLevels[index], levelCap = player.runeBlessingBuyAmount);
 
     const [level, cost] = calculateSummationLinear(baseLevels, baseCost, player.runeshards, levelCap);
-    (type === 'Blessings') ?
+    (type === 'Spirits') ?
         player.runeSpiritLevels[index] = level :
         player.runeBlessingLevels[index] = level;
 

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -435,7 +435,7 @@ export const challengeRequirement = (challenge: number, completion: number, spec
     } else if (challenge <= 10) {
         let c10Reduction = 0;
         if (challenge === 10) {
-            c10Reduction = (1e8 * (player.researches[140] + player.researches[155] + player.researches[170] + player.researches[185]) + 2e7 * player.shopUpgrades.challenge10Tomes)
+            c10Reduction = (1e8 * (player.researches[140] + player.researches[155] + player.researches[170] + player.researches[185]) + 2e7 * player.shopUpgrades.challengeTome)
         }
         return Decimal.pow(10, (base - c10Reduction) * calculateChallengeRequirementMultiplier('reincarnation', completion, special))
     } else if (challenge <= 14) {

--- a/src/Plugins/Dashboard.ts
+++ b/src/Plugins/Dashboard.ts
@@ -200,8 +200,8 @@ button.style.height = '30px';
 button.style.width = '150px';
 button.style.margin = '9px 0';
 
-let dashboardLoopRefFast: NodeJS.Timeout | null = null;
-let dashboardLoopRefSlow: NodeJS.Timeout | null = null;
+let dashboardLoopRefFast: ReturnType<typeof setTimeout> | null = null;
+let dashboardLoopRefSlow: ReturnType<typeof setTimeout> | null = null;
 let activeTab: HTMLElement | null = null;
 let open = false
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -21,7 +21,7 @@ import { challengeRequirement } from './Challenges';
 import { Synergism } from './Events';
 import { resetNames } from './types/Synergism';
 
-let repeatreset: NodeJS.Timeout;
+let repeatreset: ReturnType<typeof setTimeout>;
 
 export const resetrepeat = (input: resetNames) => {
     clearInt(repeatreset);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -37,7 +37,7 @@ import { addTimers, automaticTools } from './Helper';
  */
 export const isTesting = true;
 
-export const intervalHold: NodeJS.Timeout[] = [];
+export const intervalHold: ReturnType<typeof setTimeout>[] = [];
 export const interval = new Proxy(setInterval, {
     apply(target, thisArg, args) {
         const set = target.apply(thisArg, args);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -806,7 +806,7 @@ export const loadSynergy = (): void => {
             player.researches[92] = 0;
         }
 
-        if (data.achievements[169] === undefined || player.achievements[169] === undefined || data.shopUpgrades.antSpeed === undefined || player.shopUpgrades.antSpeed === undefined || data.loaded1010 === undefined || data.loaded1010 === false) {
+        if (data.achievements[169] === undefined || player.achievements[169] === undefined || (data.shopUpgrades.antSpeed === undefined && data.shopUpgrades.antSpeedLevel === undefined) || (player.shopUpgrades.antSpeed === undefined && player.shopUpgrades.antSpeedLevel === undefined) || data.loaded1010 === undefined || data.loaded1010 === false) {
             player.loaded1010 = true;
             player.codes.set(21, false);
 


### PR DESCRIPTION
1. fixed antSpeedLevel rename in loaded1010 check on data load
The line starts to be a bit long but this is the easiest fix I've found: check if both `antSpeed` and `antSpeedLevel` are undefined. Due to the rename, a recent save pre-v2.5 was treated as if `loaded1010` was false and thus notably erased talisman levels among other things.
2. Fixed TS2322: Type 'number' is not assignable to type 'Timeout' errors
in the browser setTimeout return type is number contrary to the Timeout
object in nodejs. Using ReturnType<typeof setTimeout> works both for the
browser and node.
(Errors appeared when the webpack dev server recompiled the code after a
change)
3. Fixed spirits buying blessings and vice-versa
4. Fixed challenge10Tomes renamed to challengeTome in challengeRequirement
Otherwise c10Reduction is undefined and c10 requirement ends up equal to 0.


