### PR TITLE
Patch 5

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1408,20 +1408,20 @@ export const format = (input: Decimal | number, accuracy = 0, long = false): str
         // If the power is less than 6 or format long and less than 13 use standard formatting (123,456,789)
         // Gets the standard representation of the number, safe as power is guaranteed to be > -12 and < 13
         let standard = mantissa * Math.pow(10, power);
+        let standardString;
         // Rounds up if the number experiences a rounding error
         if (standard - Math.floor(standard) > 0.9999999) {
             standard = Math.ceil(standard);
         }
         // If the power is less than 1 or format long and less than 3 apply toFixed(accuracy) to get decimal places
         if ((power < 1 || (long && power < 3)) && accuracy > 0) {
-            standard = Number(standard.toFixed(accuracy));
+            standardString = standard.toFixed(accuracy);
         } else {
             // If it doesn't fit those criteria drop the decimal places
             standard = Math.floor(standard);
+            standardString = standard.toString();
         }
 
-        // Turn the number to string
-        const standardString = standard.toString();
         // Split it on the decimal place
         const [front, back] = standardString.split('.');
         // Apply a number group 3 comma regex to the front


### PR DESCRIPTION
1. Fixed format error raised on format(1e-8, 9)
![Capture d’écran de 2021-02-04 17-19-58](https://user-images.githubusercontent.com/542233/106922898-ce66a000-670d-11eb-97db-3cd00aa099a8.png)
Someone reported that the md6 corruption couldn't be selected in the corruption panel. This was due to a line of pre v2.5 code being incompatible with TS:
Current live version: `standard = standard.toFixed(accuracy)` (causes TS2322: Type 'string' is not assignable to type 'number' error in TS)
Current alpha code:  `standard = Number(standard.toFixed(accuracy));` (ts error fixed but breaks format behavior)
Fixed code: `standardString = standard.toFixed(accuracy)`