### PR TITLE
Cleanup unused player variables

### DIFF
--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -90,16 +90,6 @@ export const checkVariablesOnLoad = (data: Player) => {
     }
     if (data.history === undefined) {
         player.history = { ants: [], ascend: [], reset: [] };
-        player.cubesThisAscension = {
-            "challenges": 0,
-            "reincarnation": 0,
-            "ascension": 0,
-            "maxCubesPerSec": 0,
-            "maxAllTime": 0,
-            "cpsOnC10Comp": 0,
-            "tesseracts": 0,
-            "hypercubes": 0
-        };
         player.historyCountMax = 10;
     }
     if (data.autoChallengeRunning === undefined) {

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1,5 +1,5 @@
 import { player, clearInt, interval, format } from './Synergism';
-import { calculateOfferings, CalcCorruptionStuff, calculateCubeBlessings, calculateRuneLevels, calculateAnts, calculateCubeMultiplier, calculateObtainium, calculateTalismanEffects, calculateAntSacrificeELO } from './Calculate';
+import { calculateOfferings, CalcCorruptionStuff, calculateCubeBlessings, calculateRuneLevels, calculateAnts, calculateObtainium, calculateTalismanEffects, calculateAntSacrificeELO } from './Calculate';
 import { resetofferings } from './Runes';
 import { updateTalismanInventory, updateTalismanAppearance } from './Talismans';
 import { calculateTesseractBlessings } from './Tesseracts';
@@ -556,12 +556,6 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
         calculateObtainium();
         ascensionAchievementCheck(1);
         
-        player.cubesThisAscension.challenges = 0;
-        player.cubesThisAscension.reincarnation = 0;
-        player.cubesThisAscension.maxCubesPerSec = 0;
-        player.cubesThisAscension.tesseracts = 0;
-        player.cubesThisAscension.hypercubes = 0;
-        player.cubesThisAscension.ascension = 100 / 100 * calculateCubeMultiplier() * 250;
         player.ascensionCounter = 0;
 
         updateTalismanInventory();

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -621,8 +621,6 @@ const resetUpgrades = (i: number) => {
             player.upgrades[46] = 0;
         }
 
-        player.keepUpgrades.autobuyers = false;
-
         if (player.researches[41] < 0.5) {
             player.upgrades[88] = 0;
         }
@@ -631,15 +629,12 @@ const resetUpgrades = (i: number) => {
         }
         if (player.researches[42] < 0.5) {
             player.upgrades[90] = 0;
-            player.keepUpgrades.generators = false;
         }
         if (player.researches[43] < 0.5) {
             player.upgrades[91] = 0;
-            player.keepUpgrades.coinUpgrades = false;
         }
         if (player.researches[44] < 0.5) {
             player.upgrades[92] = 0;
-            player.keepUpgrades.prestigeUpgrades = false;
         }
         if (player.researches[45] < 0.5) {
             player.upgrades[93] = 0;

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -638,7 +638,6 @@ const resetUpgrades = (i: number) => {
         }
         if (player.researches[45] < 0.5) {
             player.upgrades[93] = 0;
-            player.resourceGenerators.diamonds = false;
         }
 
         player.upgrades[116] = 0;

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -300,15 +300,6 @@ export const player: Player = {
         mythos: false,
     },
 
-    keepUpgrades: {
-        coinUpgrades: false,
-        prestigeUpgrades: false,
-        crystalUpgrades: false,
-        transcendUpgrades: false,
-        autobuyers: false,
-        generators: false
-    },
-
     challengecompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     highestchallengecompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     challenge15Exponent: 0,

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -374,7 +374,6 @@ export const player: Player = {
     fastestprestige: 9999999999,
     fastesttranscend: 99999999999,
     fastestreincarnate: 999999999999,
-    fastestAscend: 999999999999,
 
     resettoggle1: 1,
     resettoggle2: 1,

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -322,7 +322,6 @@ export const player: Player = {
     },
     researchPoints: 0,
     obtainiumtimer: 0,
-    obtainiumlocktoggle: false,
     obtainiumpersecond: 0,
     maxobtainiumpersecond: 0,
     maxobtainium: 0,
@@ -374,7 +373,6 @@ export const player: Player = {
     runelevels: [1, 1, 1, 1, 1],
     runeexp: [0, 0, 0, 0, 0,],
     runeshards: 0,
-    offeringlocktoggle: false,
     maxofferings: 0,
     offeringpersecond: 0,
 
@@ -733,8 +731,6 @@ export const loadSynergy = (): void => {
             player.maxobtainium = player.researchPoints;
             player.researchPoints += 51200 * player.researches[50];
             player.researches[50] = 0;
-            player.offeringlocktoggle = false;
-            player.obtainiumlocktoggle = false;
         }
 
         player.maxofferings = player.maxofferings || 0;

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -295,11 +295,6 @@ export const player: Player = {
         33: false,
     },
 
-    resourceGenerators: {
-        diamonds: false,
-        mythos: false,
-    },
-
     challengecompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     highestchallengecompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     challenge15Exponent: 0,

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -573,7 +573,6 @@ export const player: Player = {
     autoTesseracts: [false, false, false, false, false, false],
 
     saveString: "Synergism-$VERSION$-$TIME$.txt",
-    brokenfile1: false,
     exporttest: false,
     kongregatetest: "NO!",
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -550,16 +550,6 @@ export const player: Player = {
     autoAscendMode: "c10Completions",
     autoAscendThreshold: 1,
     roombaResearchIndex: 0,
-    cubesThisAscension: {
-        "challenges": 0,
-        "reincarnation": 0,
-        "ascension": 0,
-        "maxCubesPerSec": 0,
-        "maxAllTime": 0,
-        "cpsOnC10Comp": 0,
-        "tesseracts": 0,
-        "hypercubes": 0
-    },
     ascStatToggles: { // false here means show per second
         1: false,
         2: false,
@@ -969,14 +959,6 @@ export const loadSynergy = (): void => {
                 talismanBonus: 0,
                 globalSpeed: 0
             }
-            player.cubesThisAscension.challenges = 0;
-            player.cubesThisAscension.reincarnation = 0;
-            player.cubesThisAscension.ascension = 0;
-            player.cubesThisAscension.maxCubesPerSec = 0;
-            player.cubesThisAscension.maxAllTime = 0;
-            player.cubesThisAscension.cpsOnC10Comp = 0;
-            player.cubesThisAscension.tesseracts = 0;
-            player.cubesThisAscension.hypercubes = 0;
         }
         if (data.autoAntSacTimer === undefined) {
             player.autoAntSacTimer = 900;
@@ -1090,14 +1072,6 @@ export const loadSynergy = (): void => {
         getElementById<HTMLInputElement>("saveStringInput").value = player.saveString
 
         player.wowCubes = player.wowCubes || 0;
-        if (!player.cubesThisAscension.maxAllTime) // Initializes the value if it doesn't exist
-            player.cubesThisAscension.maxAllTime = 0
-        if (!player.cubesThisAscension.cpsOnC10Comp)
-            player.cubesThisAscension.cpsOnC10Comp = 0
-        if (!player.cubesThisAscension.tesseracts)
-            player.cubesThisAscension.tesseracts = 0
-        if (!player.cubesThisAscension.hypercubes)
-            player.cubesThisAscension.hypercubes = 0
 
         for (let j = 1; j < 126; j++) {
             upgradeupdate(j);
@@ -1529,21 +1503,6 @@ export const formatTimeShort = (seconds: number, msMaxSeconds?: number): string 
         ((msMaxSeconds && seconds < msMaxSeconds)
             ? "." + (Math.floor((seconds % 1) * 1000).toString().padStart(3, '0'))
             : '') + "s";
-}
-
-export const updateCubesPerSec = (): void => {
-    const c = player.cubesThisAscension.challenges, 
-          r = player.cubesThisAscension.reincarnation,
-          a = player.cubesThisAscension.ascension;
-
-    if (player.challengecompletions[10] > 0) {
-        if (player.challengecompletions[10] === 1) {
-            player.cubesThisAscension.cpsOnC10Comp = (c + r + a) / player.ascensionCounter;
-        }
-
-        player.cubesThisAscension.maxCubesPerSec = Math.max(player.cubesThisAscension.maxCubesPerSec, (c + r + a) / player.ascensionCounter)
-        player.cubesThisAscension.maxAllTime = Math.max(player.cubesThisAscension.maxAllTime, player.cubesThisAscension.maxCubesPerSec)
-    }
 }
 
 export const updateAllTick = (): void => {
@@ -2453,7 +2412,6 @@ export const resetCheck = (i: string, manual = true, leaving = false): void => {
                     challengeDisplay(y, false)
                     updateChallengeLevel(y)
                     highestChallengeRewards(q, player.highestchallengecompletions[q])
-                    updateCubesPerSec()
                     calculateCubeBlessings();
                 }
 
@@ -2519,7 +2477,6 @@ export const resetCheck = (i: string, manual = true, leaving = false): void => {
             while (player.challengecompletions[q] > player.highestchallengecompletions[q]) {
                 player.highestchallengecompletions[q] += 1;
                 highestChallengeRewards(q, player.highestchallengecompletions[q])
-                updateCubesPerSec()
                 calculateHypercubeBlessings();
                 calculateTesseractBlessings();
                 calculateCubeBlessings();

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -574,7 +574,6 @@ export const player: Player = {
 
     saveString: "Synergism-$VERSION$-$TIME$.txt",
     exporttest: false,
-    kongregatetest: "NO!",
 
     dayCheck: null,
     dayTimer: 0,

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -278,7 +278,6 @@ export interface Player {
     fastestprestige: number
     fastesttranscend: number
     fastestreincarnate: number
-    fastestAscend: number
 
     resettoggle1: number
     resettoggle2: number

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -458,7 +458,6 @@ export interface Player {
     autoTesseracts: boolean[]
 
     saveString: string
-    brokenfile1: boolean
     exporttest: string | boolean
     kongregatetest: string
 

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -459,7 +459,6 @@ export interface Player {
 
     saveString: string
     exporttest: string | boolean
-    kongregatetest: string
 
     dayCheck: Date | null
     dayTimer: number

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -206,11 +206,6 @@ export interface Player {
 
     toggles: Record<number, boolean>
 
-    resourceGenerators: {
-        diamonds: boolean,
-        mythos: boolean,
-    },
-
     challengecompletions: number[]
     highestchallengecompletions: number[]
     challenge15Exponent: number

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -211,15 +211,6 @@ export interface Player {
         mythos: boolean,
     },
 
-    keepUpgrades: {
-        coinUpgrades: boolean,
-        prestigeUpgrades: boolean,
-        crystalUpgrades: boolean,
-        transcendUpgrades: boolean,
-        autobuyers: boolean,
-        generators: boolean
-    },
-
     challengecompletions: number[]
     highestchallengecompletions: number[]
     challenge15Exponent: number

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -448,16 +448,6 @@ export interface Player {
     autoAscendMode: string
     autoAscendThreshold: number
     roombaResearchIndex: number
-    cubesThisAscension: {
-        "challenges": number
-        "reincarnation": number
-        "ascension": number
-        "maxCubesPerSec": number
-        "maxAllTime": number
-        "cpsOnC10Comp": number
-        "tesseracts": number
-        "hypercubes": number
-    },
     ascStatToggles: Record<number, boolean>
 
     prototypeCorruptions: number[]

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -233,7 +233,6 @@ export interface Player {
     },
     researchPoints: number
     obtainiumtimer: number
-    obtainiumlocktoggle: boolean,
     obtainiumpersecond: number
     maxobtainiumpersecond: number
     maxobtainium: number
@@ -278,7 +277,6 @@ export interface Player {
     runelevels: number[]
     runeexp: number[]
     runeshards: number
-    offeringlocktoggle: boolean,
     maxofferings: number
     offeringpersecond: number
 


### PR DESCRIPTION
This cleans up a bunch of legacy variables in the `player` object/`Player` type that are never read from in the game's code, making it pointless to keep them around.