### PR TITLE
some degree of css cleanup

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -1,11 +1,9 @@
 html {
 	min-width: 1250px;
-	max-width: 1400px;
 	position: relative;
 	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
 }
-body {background-color: #111111 ;
-	transform: scale(0.9);
+body {background-color: #111111;
 	transform-origin: 0 0;
 	overflow-x: hidden;
 	/*overflow-y: hidden;*/
@@ -147,22 +145,37 @@ a {color: white;}
 	z-index: 4;
 }
 
-#resetrow {
-	grid-column: buttons / end;
-	grid-row: row1;
+.resetInformationContainer {
+	display: flex;
+	flex-direction: column;
+	width: 50%;
+}
+
+.resetsContainer {
 	display: flex;
 }
 
+.resetbtn {
+	cursor: pointer;
+	margin-right: 5px;
+}
+
+#resetrow {
+	display: flex;
+	margin-left: -2px;
+}
+
 #resetrow img {
+	height: 32px;
+	width: 32px;
 	margin-left: 3px;
 }
 
 #resetinfo {
-	grid-column: buttons;
-	grid-row: row1space / row2;
-	text-align: center;
-	font-size: 15px;
-	font-variant-numeric: tabular-nums;
+    text-align: center;
+    font-size: 15px;
+    font-variant-numeric: tabular-nums;
+    width: 600px;
 }
 #resetrewards > div {
 	display: flex;
@@ -173,31 +186,43 @@ a {color: white;}
 	margin-left: 3px;
 }
 
-header nav {
-	grid-column: leftspace / rightspace;
-	grid-row: nav
-}
-
 #tabrow {
 	text-align: center;
-	/* height: 30px; */
+	width: 100%;
 	list-style: none;
 	margin:  0;
 	margin-inline: unset;
 	margin-block: unset;
 	padding-inline: unset;
 	display: flex;
-	justify-content: space-between;
+    justify-content: center;
+}
+
+.navbar {
+    display: flex;
+	justify-content: center;
+    width: 100%;
 }
 
 nav li {
     display: inline-block;
     border: 1px solid;
     width: 100px;
-    color:white;
+	min-width: 100px;
+    color: white;
+	background-color: #171717;
     cursor: pointer;
     line-height: 21px;
     height: 21px;
+	margin-right: 5px;
+	border-top-left-radius: 5px;
+    border-top-right-radius: 5px;
+    border-bottom: none;
+	transition-duration: 0.15s;
+}
+
+nav li:hover {
+	background-color: #333;
 }
 
 #buildingstab {
@@ -230,6 +255,10 @@ nav li {
 
 #shoptab {
 	border-color: white;
+	background-color: purple;
+}
+#shoptab:hover {
+    background-color: #b300b2;
 }
 
 #anttab {
@@ -249,7 +278,7 @@ nav li {
 .subTabWrapper {
 	display: flex;
 	flex-direction: row;
-	margin-left: 8.75%;
+	justify-content: center;
 	margin-top: 10px;
 }
 
@@ -258,14 +287,17 @@ nav li {
 	width: 150px;
 	text-align: center;
 	margin-right: 17px;
+	transition-duration: 0.15s;
+}
+
+.subTabWrapper > button:hover {
+	background-color: #333;
 }
 
 #buyamountcoin {
 	position: absolute;
-	padding: 0;
-	font-size: 0;
+	top: 0;
 	left: 80%;
-	top: 194.5px;
 }
 #togglecoinbuy{
 	color: white;
@@ -446,16 +478,18 @@ nav li {
 }
 
 .buttonRow {
+	display: flex;
+    flex-direction: column;
+    justify-content: center;
 	margin-top: 30px;
 	margin-left: 8.5%;
 }
 
 .buttonRow > div {
-	display: grid;
-	grid-template-columns: [image] 40px [imagedesc] 300px 50px [button] 170px [autobuy] 90px [stats];
-	justify-items: center;
-	text-align: left;
-	height: 35px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 35px;
 }
 
 .buttonRow > div > p {
@@ -463,35 +497,45 @@ nav li {
 }
 
 .buttonRow > div > .image {
-	grid-column: image 1 / 1;
+    height: 32px;
+    width: 32px;
 }
 
 .buttonRow > div > .desc {
-	grid-column: imagedesc 1 / 2;
-	text-align: left;
-	width: 100%;
-	margin-left: 40px;
+    width: 350px;
+	min-width: 350px;
+    margin-left: 10px;
 }
 
-.buttonRow > div > .buy {
-	grid-column: button 1 / 4;
-	width: 150px;
-	height: 30px;
-	border-radius: 8px;
-	border: 1px solid white;
+.buildingPurchaseBtn {
+    width: 150px;
+	min-width: 150px;
+    height: 30px;
+    border-radius: 8px;
+    border: 1px solid white !important;
+	background-color: #171717;
+	transition-duration: 0.15s;
+	cursor: default;
+}
+
+.buildingPurchaseBtnAvailable {
+	cursor: pointer;
+	background-color: #555555;
+}
+
+.buildingPurchaseBtnAvailable:hover {
+	background-color: #666666;
 }
 
 .buttonRow > div > .auto {
-	grid-column: autobuy 1 / 5;
-	width: 80px;
-	height: 30px;
-	margin-left: 35px;
+    width: 80px;
+    height: 30px;
+    margin-left: 15px;
 }
 
 .buttonRow > div > .stats {
-	grid-column: stats 1 / 6;
-	width: 100%;
-	margin-left: 45px;
+    width: 400px;
+    margin-left: 10px;
 }
 
 #taxinfo {
@@ -554,11 +598,8 @@ nav li {
 
 #buyamountcrystal {
 	position: absolute;
-	padding: 0;
-	font-size: 0;
+	top: 0;
 	left: 80%;
-	/* Absolute positioning is horrible */
-	top: -8.1%;
 }
 #buyamountoffering {
 	position: absolute;
@@ -576,24 +617,18 @@ nav li {
 }
 #buyamountmythos {
 	position: absolute;
-	padding: 0;
-	font-size: 0;
+	top: 0;
 	left: 80%;
-	top: -8.1%;
 }
 #buyamountparticle {
 	position: absolute;
-	padding: 0;
-	font-size: 0;
+	top: 0;
 	left: 80%;
-	top: -8.1%;
 }
 #buyAmountTesseract{	
-	position: absolute;	
-	padding: 0;
-	font-size: 0;
-	left: 80%;	
-	top: -8.1%;	
+	position: absolute;
+	top: 0;
+	left: 80%;
 }
 #togglecrystalbuy{
 	color: white;
@@ -650,6 +685,11 @@ nav li {
 	margin-left: -87px;	
 }
 
+#coinBuildings {
+    position: relative;
+	padding: 0;
+}
+
 #prestige {
     position: relative;
 	padding: 0;
@@ -699,6 +739,11 @@ nav li {
 	width: 100px;
 	margin: 0 7px;
 	text-align: center;
+	transition-duration: 0.15s;
+}
+
+#runesToggle > button:hover {
+	background-color: #333;
 }
 
 #offeringDetails {
@@ -803,11 +848,21 @@ nav li {
 	color: white
 }
 
-.talismanbtn {
+.talismanBtn {
 	height: 30px;
 	width: 108px;
 	text-align: center;
-	color: orange
+	color: orange;
+	background-color: #171717;
+	cursor: default;
+	transition-duration: 0.15s;
+}
+.talisminBtnAvailable {
+	background-color: purple;
+	cursor: pointer;
+}
+.talisminBtnAvailable:hover {
+    background-color: #b300b2;
 }
 #TaxTalisman{
 	position: absolute;
@@ -1799,6 +1854,20 @@ nav li {
 	border-spacing: 0;
 }
 
+.antBtn {
+	background-color: #171717;
+}
+
+.antTierBtnAvailable {
+	cursor: pointer;
+	background-color: white;
+}
+
+.antUpgradeBtnAvailable {
+	cursor: pointer;
+	background-color: silver;
+}
+
 #cubes{
 	position: relative;
 	padding: 0;
@@ -2398,79 +2467,59 @@ img.small {
 }
 
 header {
-	display: grid;
-	grid-template-columns: 5% [leftspace] 1fr repeat(4, [stat-image] 32px [stat] 2fr) [buttons] 8fr [rightspace] 1fr 5%;
-	grid-template-rows: [asc-stats] 40px 10px [row1] 32px [row1space] 23px [row2] 32px [row2space] 7px [nav] 22px;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
 }
-header .img.coin {
-	grid-column: stat-image 1;
-	grid-row: row1;
+
+header .img {
+	height: 32px;
+	width: 32px;
 }
-header .img.diamond {
-	grid-column: stat-image 2;
-	grid-row: row1;
+
+.subHeader {
+	display: flex;
 }
-header .img.offering {
-	grid-column: stat-image 3;
-	grid-row: row1;
+
+.currenciesContainer {
+	display: flex;
+	flex-direction: column;
+	width: 50%;
 }
-header .img.quark {
-	grid-column: stat-image 4;
-	grid-row: row1;
+
+.currencyRow {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+	margin-bottom: 15px;
 }
-header .img.mythos {
-	grid-column: stat-image 1;
-	grid-row: row2;
+
+.currencyContainer {
+    display: flex;
+    justify-content: flex-start;
+    align-items: center;
+    width: 140px;
 }
-header .img.mythosshard {
-	grid-column: stat-image 2;
-	grid-row: row2;
-}
-header .img.particle {
-	grid-column: stat-image 3;
-	grid-row: row2;
-}
-header .img.obtanium {
-	grid-column: stat-image 4;
-	grid-row: row2;
-}
+
 header #coinDisplay {
-	grid-column: stat 1;
-	grid-row: row1;	
 	color: gold;
 }
 header #diamondDisplay {
-	grid-column: stat 2;
-	grid-row: row1;	
 	color: cyan;
 }
 header #offeringDisplay {
-	grid-column: stat 3;
-	grid-row: row1;	
 	color: gold;
 }
-header #quarkDisplay {
-	grid-column: stat 4;
-	grid-row: row1;	
-}
 header #mythosDisplay {
-	grid-column: stat 1;
-	grid-row: row2;	
 	color: plum;
 }
 header #mythosshardDisplay {
-	grid-column: stat 2;
-	grid-row: row2;	
 	color: plum;
 }
 header #particlesDisplay {
-	grid-column: stat 3;
-	grid-row: row2;
 	color: limegreen;
 }
 header #obtainiumDisplay {
-	grid-column: stat 4;
-	grid-row: row2;	
 	color: pink;
 }
 .statDisplay {
@@ -2485,6 +2534,7 @@ header #obtainiumDisplay {
 	flex-direction: row;
 	justify-content: center;
 	padding-top: 10px;
+	margin-bottom: 15px;
 	height: 20px;
 	line-height: 20px;
 }

--- a/index.html
+++ b/index.html
@@ -49,46 +49,72 @@
                 <span id="ascTimeAccel">x</span>
             </span>
         </div>
-        <img class="img coin" src="Pictures/Coin.png" title='Coin' alt="">
-        <div class="statDisplay" id="coinDisplay">1</div>
-        <img  class="prestigeunlock img diamond" src="Pictures/Diamond.png" title='Diamond'  alt="">
-        <div class="prestigeunlock statDisplay" id="diamondDisplay">1</div>
-        <img  class="prestigeunlock img offering" src="Pictures/Offering.png" title='Offering'  alt="">
-        <div class="prestigeunlock statDisplay" id="offeringDisplay" >1</div>
-        <img class="transcendunlock img quark" src="Pictures/Quark.png" title='Quark' alt="">
-        <div class="transcendunlock statDisplay" id="quarkDisplay">1</div>
-        <img class="transcendunlock img mythos" src="Pictures/Mythos.png" title='Mythos' alt="">
-        <div class="transcendunlock statDisplay" id="mythosDisplay">1</div>
-        <img class="transcendunlock img mythosshard" src="Pictures/MythosShard.png" title='Mythos Shard' alt="">
-        <div class="transcendunlock statDisplay" id="mythosshardDisplay">1</div>
-        <img class="reincarnationunlock img particle" src="Pictures/Particle.png" title='Particle'  alt="">
-        <div class="reincarnationunlock statDisplay" id="particlesDisplay">1</div>
-        <img class="reincarnationunlock img obtanium" src="Pictures/Obtainium.png" title='Obtainium' alt="">
-        <div class="reincarnationunlock statDisplay" id="obtainiumDisplay">1</div>
-        <div id="resetrow">
-        
-            <img class="coinunlock4" id="prestigebtn" src="Pictures/Transparent Pics/Prestige.png" alt="">
-            <img class="prestigeunlock" id="transcendbtn" src="Pictures/Transparent Pics/Transcend.png" alt="">
-            <img class="transcendunlock" id="reincarnatebtn" src="Pictures/Transparent Pics/Reincarnate.png" alt="">
-            <img class="transcendunlock" id="acceleratorboostbtn" src="Pictures/Transparent Pics/AcceleratorBoost.png" alt="">
-            <img class="transcendunlock" id="challengebtn" src="Pictures/Transparent Pics/Challenge.png" alt="">
-            <img class="reincarnationunlock" id="reincarnatechallengebtn" src="Pictures/Transparent Pics/ChallengeReincarnation.png" alt="">
-            <img class="ascendunlock" id="ascendChallengeBtn" src="Pictures/Transparent Pics/ChallengeAscension.png" alt="">
-            <img class="chal10" id="ascendbtn" src="Pictures/questionable.png" alt="">
-            
-            <div id="resetrewards" style="display: block;">
-                <div>
-                    <img id="resetofferings1" src="" style="font-size: 0;" alt="">
-                    <div id="resetofferings2" style="color: gold"></div>
-                    <img id="resetcurrency1" src="" style="font-size: 0;" alt="">
-                    <div id="resetcurrency2" style="color:gold"></div>
-                    <img id="resetobtainium" src="" alt="">
-                    <div id="resetobtainium2" style="color:pink;"></div>
+        <div class="subHeader">
+            <div class="currenciesContainer">
+                <div class="currencyRow">
+                    <div class="currencyContainer">
+                        <img class="img coin" src="Pictures/Coin.png" title='Coin' alt="">
+                        <div class="statDisplay" id="coinDisplay">1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="prestigeunlock img diamond" src="Pictures/Diamond.png" title='Diamond'  alt="">
+                        <div class="prestigeunlock statDisplay" id="diamondDisplay">1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="prestigeunlock img offering" src="Pictures/Offering.png" title='Offering'  alt="">
+                        <div class="prestigeunlock statDisplay" id="offeringDisplay" >1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="transcendunlock img quark" src="Pictures/Quark.png" title='Quark' alt="">
+                        <div class="transcendunlock statDisplay" id="quarkDisplay">1</div>
+                    </div>
+                </div>
+                <div class="currencyRow">
+                    <div class="currencyContainer">
+                        <img class="transcendunlock img mythos" src="Pictures/Mythos.png" title='Mythos' alt="">
+                        <div class="transcendunlock statDisplay" id="mythosDisplay">1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="transcendunlock img mythosshard" src="Pictures/MythosShard.png" title='Mythos Shard' alt="">
+                        <div class="transcendunlock statDisplay" id="mythosshardDisplay">1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="reincarnationunlock img particle" src="Pictures/Particle.png" title='Particle'  alt="">
+                        <div class="reincarnationunlock statDisplay" id="particlesDisplay">1</div>
+                    </div>
+                    <div class="currencyContainer">
+                        <img class="reincarnationunlock img obtanium" src="Pictures/Obtainium.png" title='Obtainium' alt="">
+                        <div class="reincarnationunlock statDisplay" id="obtainiumDisplay">1</div>
+                    </div>
                 </div>
             </div>
+            <div class="resetInformationContainer">
+                <div class="resetsContainer">
+                    <img class="resetbtn coinunlock4" id="prestigebtn" src="Pictures/Transparent Pics/Prestige.png" alt="">
+                    <img class="resetbtn prestigeunlock" id="transcendbtn" src="Pictures/Transparent Pics/Transcend.png" alt="">
+                    <img class="resetbtn transcendunlock" id="reincarnatebtn" src="Pictures/Transparent Pics/Reincarnate.png" alt="">
+                    <img class="resetbtn transcendunlock" id="acceleratorboostbtn" src="Pictures/Transparent Pics/AcceleratorBoost.png" alt="">
+                    <img class="resetbtn transcendunlock" id="challengebtn" src="Pictures/Transparent Pics/Challenge.png" alt="">
+                    <img class="resetbtn reincarnationunlock" id="reincarnatechallengebtn" src="Pictures/Transparent Pics/ChallengeReincarnation.png" alt="">
+                    <img class="resetbtn ascendunlock" id="ascendChallengeBtn" src="Pictures/Transparent Pics/ChallengeAscension.png" alt="">
+                    <img class="resetbtn chal10" id="ascendbtn" src="Pictures/questionable.png" alt="">
+                    <div id="resetrow">
+                        <div id="resetrewards" style="display: block;">
+                            <div>
+                                <img id="resetofferings1" src="Pictures/Offering.png" style="display: none;" alt="">
+                                <div id="resetofferings2" style="color: gold"></div>
+                                <img id="resetcurrency1" src="" style="display: none;" alt="">
+                                <div id="resetcurrency2" style="color:gold"></div>
+                                <img id="resetobtainium" src="Pictures/Obtainium.png" style="display: none;" alt="">
+                                <div id="resetobtainium2" style="color:pink;"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id="resetinfo" style="color:white"></div>
+            </div>
         </div>
-        <div id="resetinfo" style="color:white"></div>
-        <nav id="navbar">
+        <nav class="navbar">
         
             
             <ul id="tabrow">
@@ -109,7 +135,7 @@
     <div id="tabBorder"></div>
     <div id="buildings">
         <div class="subTabWrapper"> 
-            <button id="switchToCoinBuilding" style="border: 2px solid yellow">Coin Buildings</button>
+            <button id="switchToCoinBuilding" style="border: 2px solid yellow; background-color: crimson;">Coin Buildings</button>
             <button class="prestigeunlock" id="switchToDiamondBuilding" style="border: 2px solid cyan">Diamond Buildings</button>
             <button class="transcendunlock" id="switchToMythosBuilding" style="border: 2px solid plum">Mythos Buildings</button>
             <button class="reincarnationunlock" id="switchToParticleBuilding" style="border: 2px solid greenyellow">Particle Buildings</button>
@@ -136,62 +162,62 @@
         <div class="buttonRow">
             <div>
                 <img class="image" id="coin1" src="Pictures/Tier1.png" alt="">
-                <p class="desc" id="buildtext1" style="color: gold">Workers: 321495 [+1.49e+391945]</p>
-                <button id="buycoin1" class="buy" style="background-color: #070707;">Cost: 100 Coins.</button>
+                <span class="desc" id="buildtext1" style="color: gold">Workers: 321495 [+1.49e+391945]</span>
+                <button class="buildingPurchaseBtn" id="buycoin1">Cost: 100 Coins.</button>
                 <button class="auto" id="toggle1" toggleid="1" style="background-color: #171717;">Auto: On</button>
-                <p class="stats" id="buildtext2" style="color: gold">100 Coins/second [100%]</p>
+                <span class="stats" id="buildtext2" style="color: gold">100 Coins/second [100%]</span>
             </div>
             <div>
                 <img class="coinunlock1 image" id="coin2" src="Pictures/Tier2.png" alt="">
-                <p class="coinunlock1 desc" id="buildtext3" style="color: gold">Investments: 0 [+0]</p>
-                <button class="coinunlock1 buy" id="buycoin2" style="background-color: #070707;">Cost: 2e3 Coins.</button>
+                <span class="coinunlock1 desc" id="buildtext3" style="color: gold">Investments: 0 [+0]</span>
+                <button class="coinunlock1 buildingPurchaseBtn" id="buycoin2">Cost: 2e3 Coins.</button>
                 <button class="auto" id="toggle2" toggleid="2" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock1 stats" id="buildtext4" style="color: gold">0 Coins/second [0%]</p>
+                <span class="coinunlock1 stats" id="buildtext4" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock2 image" id="coin3" src="Pictures/Tier3.png" alt="">
-                <p class="coinunlock2 desc" id="buildtext5" style="color: gold">Printers: 0 [+0]</p>
-                <button class="coinunlock2 buy" id="buycoin3" style="background-color: #070707;">Cost: 4e4 Coins.</button>
+                <span class="coinunlock2 desc" id="buildtext5" style="color: gold">Printers: 0 [+0]</span>
+                <button class="coinunlock2 buildingPurchaseBtn" id="buycoin3">Cost: 4e4 Coins.</button>
                 <button class="auto" id="toggle3" toggleid="3" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock2 stats" id="buildtext6" style="color: gold">0 Coins/second [0%]</p>
+                <span class="coinunlock2 stats" id="buildtext6" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock3 image" id="coin4" src="Pictures/Tier4.png" alt="">
-                <p class="coinunlock3 desc" id="buildtext7" style="color: gold">Coin Mints: 0 [+0]</p>
-                <button class="coinunlock3 buy" id="buycoin4" style="background-color: #070707;">Cost: 8e5 Coins.</button>
+                <span class="coinunlock3 desc" id="buildtext7" style="color: gold">Coin Mints: 0 [+0]</span>
+                <button class="coinunlock3 buildingPurchaseBtn" id="buycoin4">Cost: 8e5 Coins.</button>
                 <button class="auto" id="toggle4" toggleid="4" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock3 stats" id="buildtext8" style="color: gold">0 Coins/second [0%]</p>
+                <span class="coinunlock3 stats" id="buildtext8" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock4 image" id="coin5" src="Pictures/Tier5.png" alt="">
-                <p class="coinunlock4 desc" id="buildtext9" style="color: gold">Alchemies: 0 [+0]</p>
-                <button class="coinunlock4 buy" id="buycoin5" style="background-color: #070707;">Cost: 1.6e7 Coins.</button>
+                <span class="coinunlock4 desc" id="buildtext9" style="color: gold">Alchemies: 0 [+0]</span>
+                <button class="coinunlock4 buildingPurchaseBtn" id="buycoin5">Cost: 1.6e7 Coins.</button>
                 <button class="auto" id="toggle5" toggleid="5" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock4 stats" id="buildtext10" style="color: gold">0 Coins/second [0%]</p>
+                <span class="coinunlock4 stats" id="buildtext10" style="color: gold">0 Coins/second [0%]</span>
             </div>
         </div>
 
         <div class="buttonRow">
             <div>
                 <img class="coinunlock1 image" id="accelerator" src="Pictures/Accelerator.png" alt="">
-                <p class="coinunlock1 desc" id="buildtext11" style="color: yellow">Accelerators: 0 [+0]</p>
-                <button class="coinunlock1 buy" id="buyaccelerator" style="background-color: #070707;">Cost: 500 Coins.</button>
+                <span class="coinunlock1 desc" id="buildtext11" style="color: yellow">Accelerators: 0 [+0]</span>
+                <button class="coinunlock1 buildingPurchaseBtn" id="buyaccelerator">Cost: 500 Coins.</button>
                 <button class="auto" id="toggle6" toggleid="6" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock1 stats" id="buildtext12" style="color: cyan">Acceleration Factor: 10.0%. Acceleration Multiplier: 1.00x</p>
+                <span class="coinunlock1 stats" id="buildtext12" style="color: cyan">Acceleration Factor: 10.0%. Acceleration Multiplier: 1.00x</span>
             </div>
             <div>
                 <img class="coinunlock3 image" id="multiplier" src="Pictures/Multiplier.png" alt="">
-                <p class="coinunlock3 desc" id="buildtext13" style="color: yellow">Multipliers: 0 [+0]</p>
-                <button class="coinunlock3 buy" id="buymultiplier" style="background-color: #070707;">Cost: 500 Coins.</button>
+                <span class="coinunlock3 desc" id="buildtext13" style="color: yellow">Multipliers: 0 [+0]</span>
+                <button class="coinunlock3 buildingPurchaseBtn" id="buymultiplier">Cost: 500 Coins.</button>
                 <button class="auto" id="toggle7" toggleid="7" style="background-color: #171717;">Auto: On</button>
-                <p class="coinunlock3 stats" id="buildtext14" style="color: pink">Multiplier Power: 2.000%. Multiplier: 1.00x</p>
+                <span class="coinunlock3 stats" id="buildtext14" style="color: pink">Multiplier Power: 2.000%. Multiplier: 1.00x</span>
             </div>
             <div>
                 <img class="prestigeunlock image" id="acceleratorboost" src="Pictures/AcceleratorBoost.png" alt="">
-                <p class="prestigeunlock desc" id="buildtext15" style="color: cyan">Accelerator Boosts: 0 [+0]</p>
-                <button class="prestigeunlock buy" id="buyacceleratorboost" style="background-color: #070707;">Cost: 500 Coins.</button>
+                <span class="prestigeunlock desc" id="buildtext15" style="color: cyan">Accelerator Boosts: 0 [+0]</span>
+                <button class="prestigeunlock buildingPurchaseBtn" id="buyacceleratorboost">Cost: 500 Coins.</button>
                 <button class="auto" id="toggle8" toggleid="8" style="background-color: #171717;">Auto: On</button>
-                <p class="prestigeunlock stats" id="buildtext16" style="color: crimson">Next one adds 1.00% Acceleration Factor.</p>
+                <span class="prestigeunlock stats" id="buildtext16" style="color: crimson">Next one adds 1.00% Acceleration Factor.</span>
             </div>
         </div>
 
@@ -217,38 +243,38 @@
         <div class="buttonRow">
             <div>
                 <img id="diamond1" class="image" src="Pictures/DiamondTier1.png" style="border: 1px solid cyan" alt="">
-                <p id="prestigetext1" class="desc">Refineries: 0 [+0]</p>
-                <button id="buydiamond1" class="buy" style="border: 1px solid white; border-radius: 8px;">434342</button>
+                <span id="prestigetext1" class="desc">Refineries: 0 [+0]</span>
+                <button id="buydiamond1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">434342</button>
                 <button class="auto" id="toggle10" toggleid="10" style="background-color: #171717;">Auto: On</button>
-                <p id="prestigetext2" class="stats">100 Shards/sec</p>
+                <span id="prestigetext2" class="stats">100 Shards/sec</span>
             </div>
             <div>
                 <img id="diamond2" class="image" src="Pictures/DiamondTier2.png" style="border: 1px solid cyan" alt="">
-                <p id="prestigetext3" class="desc">Coal Plants: 0 [+0]</p>
-                <button id="buydiamond2" class="buy" style="border: 1px solid white; border-radius: 8px;">532523</button>
+                <span id="prestigetext3" class="desc">Coal Plants: 0 [+0]</span>
+                <button id="buydiamond2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">532523</button>
                 <button class="auto" id="toggle11" toggleid="11" style="background-color: #171717;">Auto: On</button>
-                <p id="prestigetext4" class="stats">100 Augments/sec</p>
+                <span id="prestigetext4" class="stats">100 Augments/sec</span>
             </div>
             <div>
                 <img id="diamond3" class="image" src="Pictures/DiamondTier3.png" style="border: 1px solid cyan" alt="">
-                <p id="prestigetext5" class="desc">Coal Rigs: 0 [+0]</p>
-                <button id="buydiamond3" class="buy" style="border: 1px solid white; border-radius: 8px;">5454546</button>
+                <span id="prestigetext5" class="desc">Coal Rigs: 0 [+0]</span>
+                <button id="buydiamond3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">5454546</button>
                 <button class="auto" id="toggle12" toggleid="12" style="background-color: #171717;">Auto: On</button>
-                <p id="prestigetext6" class="stats">100 Enhancements/sec</p>
+                <span id="prestigetext6" class="stats">100 Enhancements/sec</span>
             </div>
             <div>
                 <img id="diamond4" class="image" src="Pictures/DiamondTier4.png" style="border: 1px solid cyan" alt="">
-                <p id="prestigetext7" class="desc">Diamond Pickaxes: 0 [+0]</p>
-                <button id="buydiamond4" class="buy" style="border: 1px solid white; border-radius: 8px;">646346</button>
+                <span id="prestigetext7" class="desc">Diamond Pickaxes: 0 [+0]</span>
+                <button id="buydiamond4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">646346</button>
                 <button class="auto" id="toggle13" toggleid="13" style="background-color: #171717;">Auto: On</button>
-                <p id="prestigetext8" class="stats">100 Wizards/sec</p>
+                <span id="prestigetext8" class="stats">100 Wizards/sec</span>
             </div>
             <div>
                 <img id="diamond5" class="image" src="Pictures/DiamondTier5.png" style="border: 1px solid cyan" alt="">
-                <p id="prestigetext9" class="desc">Pandora's Box: 0 [+0]</p>
-                <button id="buydiamond5" class="buy" style="border: 1px solid white; border-radius: 8px;">3464363</button>
+                <span id="prestigetext9" class="desc">Pandora's Box: 0 [+0]</span>
+                <button id="buydiamond5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">3464363</button>
                 <button class="auto" id="toggle14" toggleid="14" style="background-color: #171717;">Auto: On</button>
-                <p id="prestigetext10" class="stats">100 Oracles/sec</p>
+                <span id="prestigetext10" class="stats">100 Oracles/sec</span>
             </div>
         </div>
 
@@ -294,38 +320,38 @@
         <div class="buttonRow">
             <div>
                 <img id="mythos1" class="image" src="Pictures/MythosTier1.png" style="border: 1px solid plum" alt="">
-                <p id="transcendtext1" class="desc">Augments: 0 [+0]</p>
-                <button id="buymythos1" class="buy" style="border: 1px solid white; border-radius: 8px;"></button>
+                <span id="transcendtext1" class="desc">Augments: 0 [+0]</span>
+                <button id="buymythos1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
                 <button class="auto" id="toggle16" toggleid="16" style="background-color: #171717;">Auto: Off</button>
-                <p id="transcendtext2" class="stats">100 Shards/sec</p>
+                <span id="transcendtext2" class="stats">100 Shards/sec</span>
             </div>
             <div>
                 <img id="mythos2" class="image" src="Pictures/MythosTier2.png" style="border: 1px solid plum" alt="">
-                <p id="transcendtext3" class="desc">Enhancements: 0 [+0]</p>
-                <button id="buymythos2" class="buy" style="border: 1px solid white; border-radius: 8px;"></button>
+                <span id="transcendtext3" class="desc">Enhancements: 0 [+0]</span>
+                <button id="buymythos2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
                 <button class="auto" id="toggle17" toggleid="17" style="background-color: #171717;">Auto: Off</button>
-                <p id="transcendtext4" class="stats">100 Augments/sec</p>
+                <span id="transcendtext4" class="stats">100 Augments/sec</span>
             </div>
             <div>
                 <img id="mythos3" class="image" src="Pictures/MythosTier3.png" style="border: 1px solid plum" alt="">
-                <p id="transcendtext5" class="desc">Wizards: 0 [+0]</p>
-                <button id="buymythos3" class="buy" style="border: 1px solid white; border-radius: 8px;"></button>
+                <span id="transcendtext5" class="desc">Wizards: 0 [+0]</span>
+                <button id="buymythos3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
                 <button class="auto" id="toggle18" toggleid="18" style="background-color: #171717;">Auto: Off</button>
-                <p id="transcendtext6" class="stats">100 Enhancements/sec</p>
+                <span id="transcendtext6" class="stats">100 Enhancements/sec</span>
             </div>
             <div>
                 <img id="mythos4" class="image" src="Pictures/MythosTier4.png" style="border: 1px solid plum" alt="">
-                <p id="transcendtext7" class="desc">Oracles: 0 [+0]</p>
-                <button id="buymythos4" class="buy" style="border: 1px solid white; border-radius: 8px;"></button>
+                <span id="transcendtext7" class="desc">Oracles: 0 [+0]</span>
+                <button id="buymythos4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
                 <button class="auto" id="toggle19" toggleid="19" style="background-color: #171717;">Auto: Off</button>
-                <p id="transcendtext8" class="stats">100 Wizards/sec</p>
+                <span id="transcendtext8" class="stats">100 Wizards/sec</span>
             </div>
             <div>
                 <img id="mythos5" class="image" src="Pictures/MythosTier5.png" style="border: 1px solid plum" alt="">
-                <p id="transcendtext9" class="desc">Grandmasters: 0 [+0]</p>
-                <button id="buymythos5" class="buy" style="border: 1px solid white; border-radius: 8px;"></button>
+                <span id="transcendtext9" class="desc">Grandmasters: 0 [+0]</span>
+                <button id="buymythos5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
                 <button class="auto" id="toggle20" toggleid="20" style="background-color: #171717;">Auto: Off</button>
-                <p id="transcendtext10" class="stats">100 Oracles/sec</p>
+                <span id="transcendtext10" class="stats">100 Oracles/sec</span>
             </div>
         </div>
         
@@ -356,38 +382,38 @@
         <div class="buttonRow">
             <div>
                 <img id="particles1" src="Pictures/ParticlesTier1.png" style="border: 1px solid green" alt="">
-                <p id="reincarnationtext1" class="desc">Protons: 0 [+0]</p>
-                <button id="buyparticles1" class="buy" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Particles</button>
+                <span id="reincarnationtext1" class="desc">Protons: 0 [+0]</span>
+                <button id="buyparticles1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Particles</button>
                 <button class="auto" id="toggle22" toggleid="22" style="background-color: #171717;">Auto: Off</button>
-                <p id="reincarnationtext6" class="stats">100 Elements/sec</p>
+                <span id="reincarnationtext6" class="stats">100 Elements/sec</span>
             </div>
             <div>
                 <img id="particles2" class="image" src="Pictures/ParticlesTier2.png" style="border: 1px solid green" alt="">
-                <p id="reincarnationtext2" class="desc">Elements: 0 [+0]</p>
-                <button id="buyparticles2" class="buy" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Particles</button>
+                <span id="reincarnationtext2" class="desc">Elements: 0 [+0]</span>
+                <button id="buyparticles2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Particles</button>
                 <button class="auto" id="toggle23" toggleid="23" style="background-color: #171717;">Auto: Off</button>
-                <p id="reincarnationtext7" class="stats">Black Holes: 0 [+0]</p>
+                <span id="reincarnationtext7" class="stats">Black Holes: 0 [+0]</span>
             </div>
             <div>
                 <img id="particles3" class="image" src="Pictures/ParticlesTier3.png" style="border: 1px solid green" alt="">
-                <p id="reincarnationtext3" class="desc">100 Atoms/sec</p>
-                <button id="buyparticles3" class="buy" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+4 Particles</button>
+                <span id="reincarnationtext3" class="desc">100 Atoms/sec</span>
+                <button id="buyparticles3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+4 Particles</button>
                 <button class="auto" id="toggle24" toggleid="24" style="background-color: #171717;">Auto: Off</button>
-                <p id="reincarnationtext8" class="stats">100 Pulsars/sec</p>
+                <span id="reincarnationtext8" class="stats">100 Pulsars/sec</span>
             </div>
             <div>
                 <img id="particles4" class="image" src="Pictures/ParticlesTier4.png" style="border: 1px solid green" alt="">
-                <p id="reincarnationtext4" class="desc">100 Protons/sec</p>
-                <button id="buyparticles4" class="buy" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+8 Particles</button>
+                <span id="reincarnationtext4" class="desc">100 Protons/sec</span>
+                <button id="buyparticles4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+8 Particles</button>
                 <button class="auto" id="toggle25" toggleid="25" style="background-color: #171717;">Auto: Off</button>
-                <p id="reincarnationtext9" class="stats">Quasars: 0 [+0]</p>
+                <span id="reincarnationtext9" class="stats">Quasars: 0 [+0]</span>
             </div>
             <div>
                 <img id="particles5" class="image" src="Pictures/ParticlesTier5.png" style="border: 1px solid green" alt="">
-                <p id="reincarnationtext5" class="desc">Pulsars: 0 [+0]</p>
-                <button id="buyparticles5" class="buy" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+16 Particles</button>
+                <span id="reincarnationtext5" class="desc">Pulsars: 0 [+0]</span>
+                <button id="buyparticles5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+16 Particles</button>
                 <button class="auto" id="toggle26" toggleid="26" style="background-color: #171717;">Auto: Off</button>
-                <p id="reincarnationtext10" class="stats">100 Black Holes/sec</p>
+                <span id="reincarnationtext10" class="stats">100 Black Holes/sec</span>
             </div>
         </div>
 
@@ -423,38 +449,38 @@
         <div class="buttonRow">
             <div>
                 <img class="image" id="tesseracts1" src="Pictures/TesseractTier1.png" alt="">
-                <p class="desc" id="ascendText1">Dot: 0 [+0]</p>
-                <button class="buy" id="buyTesseracts1" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Tesseracts</button>
+                <span class="desc" id="ascendText1">Dot: 0 [+0]</span>
+                <button class="buildingPurchaseBtn" id="buyTesseracts1" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Tesseracts</button>
                 <button class="auto" id="tesseractAutoToggle1" style="background-color: #171717;">Auto [OFF]</button>
-                <p class="stats" id="ascendText6">+100 Constant/sec</p>
+                <span class="stats" id="ascendText6">+100 Constant/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts2" src="Pictures/TesseractTier2.png" alt="">
-                <p class="desc" id="ascendText2">Vector: 0 [+0]</p>
-                <button class="buy" id="buyTesseracts2" style="border: 1px solid white; border-radius: 8px;">Cost: 10 Tesseracts</button>
+                <span class="desc" id="ascendText2">Vector: 0 [+0]</span>
+                <button class="buildingPurchaseBtn" id="buyTesseracts2" style="border: 1px solid white; border-radius: 8px;">Cost: 10 Tesseracts</button>
                 <button class="auto" id="tesseractAutoToggle2" style="background-color: #171717;">Auto [OFF]</button>
-                <p class="stats" id="ascendText7">100 Dots/sec</p>
+                <span class="stats" id="ascendText7">100 Dots/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts3" src="Pictures/TesseractTier3.png" alt="">
-                <p class="desc" id="ascendText3">Three-Space: 0 [+0]</p>
-                <button class="buy" id="buyTesseracts3" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Tesseracts</button>
+                <span class="desc" id="ascendText3">Three-Space: 0 [+0]</span>
+                <button class="buildingPurchaseBtn" id="buyTesseracts3" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Tesseracts</button>
                 <button class="auto" id="tesseractAutoToggle3" style="background-color: #171717;">Auto [OFF]</button>
-                <p class="stats" id="ascendText8">100 Vectors/sec</p>
+                <span class="stats" id="ascendText8">100 Vectors/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts4" src="Pictures/TesseractTier4.png" alt="">
-                <p class="desc" id="ascendText4">Bent Time: 0 [+0]</p>
-                <button class="buy" id="buyTesseracts4" style="border: 1px solid white; border-radius: 8px;">Cost: 1000 Tesseracts</button>
+                <span class="desc" id="ascendText4">Bent Time: 0 [+0]</span>
+                <button class="buildingPurchaseBtn" id="buyTesseracts4" style="border: 1px solid white; border-radius: 8px;">Cost: 1000 Tesseracts</button>
                 <button class="auto" id="tesseractAutoToggle4" style="background-color: #171717;">Auto [OFF]</button>
-                <p class="stats" id="ascendText9">100 Three-Spaces/sec</p>
+                <span class="stats" id="ascendText9">100 Three-Spaces/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts5" src="Pictures/TesseractTier5.png" alt="">
-                <p class="desc" id="ascendText5">Hilbert Space: 0 [+0]</p>
-                <button class="buy" id="buyTesseracts5" style="border: 1px solid white; border-radius: 8px;">Cost: 10000 Tesseracts</button>
+                <span class="desc" id="ascendText5">Hilbert Space: 0 [+0]</span>
+                <button class="buildingPurchaseBtn" id="buyTesseracts5" style="border: 1px solid white; border-radius: 8px;">Cost: 10000 Tesseracts</button>
                 <button class="auto" id="tesseractAutoToggle5" style="background-color: #171717;">Auto [OFF]</button>
-                <p class="stats" id="ascendText10">100 Bent Time/sec</p>
+                <span class="stats" id="ascendText10">100 Bent Time/sec</span>
             </div>
         </div>
 
@@ -1166,37 +1192,37 @@
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/TalismanShard.png" title='Talisman Shard' style="font-size:0;" alt=""></td>
                         <td style="width: 66px; color: yellow"><p id="talismanShardInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem1" style="border: 2px solid gold">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem1" style="border: 2px solid gold">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/CommonTalisman.png" title='Common Fragment' style="font-size:0;" alt=""></td>
                         <td style="width: 68px; color: white"><p id="commonFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem2" style="border:2px solid white">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem2" style="border:2px solid white">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/UncommonTalisman.png" title='Uncommon Fragment' style="font-size:0;" alt=""></td>
                         <td style="width: 68px; color: limegreen"><p id="uncommonFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem3" style="border:2px solid lime">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem3" style="border:2px solid lime">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/RareTalisman.png" title='Rare Fragment' style="font-size:0;"  alt=""></td>
                         <td style="width: 68px; color: darkcyan"><p id="rareFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem4" style="border:2px solid aqua">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem4" style="border:2px solid aqua">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/EpicTalisman.png" title='Epic Fragment' style="font-size:0;"  alt=""></td>
                         <td style="width: 68px; color: plum"><p id="epicFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem5" style="border:2px solid purple">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem5" style="border:2px solid purple">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/LegendaryTalisman.png" title='Legendary Fragment' style="font-size:0;"  alt=""></td>
                         <td style="width: 68px; color: orange"><p id="legendaryFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem6" style="border:2px solid orange">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem6" style="border:2px solid orange">BUY</button></td>
                     </tr>
                     <tr>
                         <td style="font-size: 0; width: 32px"><img src="Pictures/MythicalTalisman.png" title='Mythical Fragment' style="font-size:0;" alt=""></td>
                         <td style="width: 68px; color: crimson"><p id="mythicalFragmentInventory">0</p></td>
-                        <td><button class="talismanbtn" id="buyTalismanItem7" style="border:2px solid red">BUY</button></td>
+                        <td><button class="talismanBtn" id="buyTalismanItem7" style="border:2px solid red">BUY</button></td>
                     </tr>
                 </table>
                 <table id="buyfragments">
@@ -1687,14 +1713,14 @@
                 </div>
 
                 <div id="antrow1">
-                    <img id="anttier1" src="Pictures/Transparent Pics/AntTierOne.png" style="cursor: pointer;" alt="">
-                    <img id="anttier2" src="Pictures/Transparent Pics/AntTierTwo.png" style="cursor: pointer;" alt="">
-                    <img id="anttier3" src="Pictures/Transparent Pics/AntTierThree.png" style="cursor: pointer;" alt="">
-                    <img id="anttier4" src="Pictures/Transparent Pics/AntTierFour.png" style="cursor: pointer;" alt="">
-                    <img id="anttier5" src="Pictures/Transparent Pics/AntTierFive.png" style="cursor: pointer;" alt="">
-                    <img id="anttier6" src="Pictures/Transparent Pics/AntTierSix.png" style="cursor: pointer;" alt="">
-                    <img id="anttier7" src="Pictures/Transparent Pics/AntTierSeven.png" style="cursor: pointer;" alt="">
-                    <img id="anttier8" src="Pictures/Transparent Pics/AntTierEight.png" style="cursor: pointer;" alt="">
+                    <img id="anttier1" class="antBtn" src="Pictures/Transparent Pics/AntTierOne.png" alt="">
+                    <img id="anttier2" class="antBtn" src="Pictures/Transparent Pics/AntTierTwo.png" alt="">
+                    <img id="anttier3" class="antBtn" src="Pictures/Transparent Pics/AntTierThree.png" alt="">
+                    <img id="anttier4" class="antBtn" src="Pictures/Transparent Pics/AntTierFour.png" alt="">
+                    <img id="anttier5" class="antBtn" src="Pictures/Transparent Pics/AntTierFive.png" alt="">
+                    <img id="anttier6" class="antBtn" src="Pictures/Transparent Pics/AntTierSix.png" alt="">
+                    <img id="anttier7" class="antBtn" src="Pictures/Transparent Pics/AntTierSeven.png" alt="">
+                    <img id="anttier8" class="antBtn" src="Pictures/Transparent Pics/AntTierEight.png" alt="">
                 </div>
 
                 <div id="antrow2" style="color: white">
@@ -1715,18 +1741,18 @@
                 </div>
 
                 <div id="antrow4">
-                    <img id="antUpgrade1" src="Pictures/Transparent Pics/AntUpgrade1.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade2" src="Pictures/Transparent Pics/AntUpgrade2.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade3" src="Pictures/Transparent Pics/AntUpgrade3.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade4" src="Pictures/Transparent Pics/AntUpgrade4.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade5" src="Pictures/Transparent Pics/AntUpgrade5.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade6" src="Pictures/Transparent Pics/AntUpgrade6.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade7" src="Pictures/Transparent Pics/AntUpgrade7.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade8" src="Pictures/Transparent Pics/AntUpgrade8.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade9" src="Pictures/Transparent Pics/AntUpgrade9.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade10" src="Pictures/Transparent Pics/AntUpgrade10.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade11" src="Pictures/Transparent Pics/AntUpgrade11.png" style="cursor: pointer;" alt="">
-                    <img id="antUpgrade12" src="Pictures/Transparent Pics/AntUpgrade12.png" style="cursor: pointer;" alt="">
+                    <img id="antUpgrade1" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade1.png" alt="">
+                    <img id="antUpgrade2" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade2.png" alt="">
+                    <img id="antUpgrade3" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade3.png" alt="">
+                    <img id="antUpgrade4" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade4.png" alt="">
+                    <img id="antUpgrade5" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade5.png" alt="">
+                    <img id="antUpgrade6" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade6.png" alt="">
+                    <img id="antUpgrade7" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade7.png" alt="">
+                    <img id="antUpgrade8" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade8.png" alt="">
+                    <img id="antUpgrade9" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade9.png" alt="">
+                    <img id="antUpgrade10" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade10.png" alt="">
+                    <img id="antUpgrade11" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade11.png" alt="">
+                    <img id="antUpgrade12" class="antBtn" src="Pictures/Transparent Pics/AntUpgrade12.png" alt="">
                 </div>
 
                 <div id="antToggleFeatures">
@@ -2384,7 +2410,7 @@
         </div>
 <div id="settings">
     <div class="subtabSwitcher subTabWrapper">
-        <button id="switchSettingSubTab1" style="border: 2px solid white">Settings</button>
+        <button id="switchSettingSubTab1" class="buttonActive" style="border: 2px solid white">Settings</button>
         <button id="switchSettingSubTab2" style="border: 2px solid gold">Credits</button>
         <button id="switchSettingSubTab3" style="border: 2px solid orange">Stats for Nerds</button>
         <button id="switchSettingSubTab4" class="prestigeunlockib" style="border: 2px solid brown">Reset History</button>

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -29,7 +29,7 @@ export const resetrepeat = (input: resetNames) => {
 }
 
 export const resetdetails = (input: resetNames) => {
-    getElementById<HTMLImageElement>('resetofferings1').src = "Pictures/Offering.png"
+    document.getElementById('resetofferings1').style.display = "block"
 
     const transcensionChallenge = player.currentChallenge.transcension;
     const reincarnationChallenge = player.currentChallenge.reincarnation;
@@ -38,14 +38,14 @@ export const resetdetails = (input: resetNames) => {
     const offeringImage = getElementById<HTMLImageElement>("resetofferings1");
     const offeringText = document.getElementById("resetofferings2");
     const currencyImage1 = getElementById<HTMLImageElement>("resetcurrency1");
-    const resetObtainiumImage = getElementById<HTMLImageElement>("resetobtainium");
-    const resetobtainiumText = document.getElementById("resetobtainium2");
+    const resetObtainiumImage = document.getElementById("resetobtainium");
+    const resetObtainiumText = document.getElementById("resetobtainium2");
     const resetInfo = document.getElementById('resetinfo');
     const resetCurrencyGain = document.getElementById("resetcurrency2");
 
     (input == "reincarnation") ? 
-        (resetObtainiumImage.src = "Pictures/Obtainium.png", resetobtainiumText.textContent = format(Math.floor(G['obtainiumGain']))):
-        (resetObtainiumImage.src = "", resetobtainiumText.textContent = "");
+        (resetObtainiumImage.style.display = "block", resetObtainiumText.textContent = format(Math.floor(G['obtainiumGain']))):
+        (resetObtainiumImage.style.display = "none", resetObtainiumText.textContent = "");
 
     (input == "ascensionChallenge" || input == "ascension")?
         offeringImage.style.display = offeringText.style.display = "none":
@@ -56,6 +56,7 @@ export const resetdetails = (input: resetNames) => {
             if(currencyImage1.src !== "Pictures/Diamond.png"){
                 currencyImage1.src = "Pictures/Diamond.png"
             }
+            currencyImage1.style.display = "block"
             resetCurrencyGain.textContent = "+" + format(G['prestigePointGain']);
             resetInfo.textContent = "Coins, Coin Producers, Coin Upgrades, and Crystals are reset, but in return you gain diamonds and a few offerings. Required: " + format(player.coinsThisPrestige) + "/1e16 Coins || TIME SPENT: " + format(player.prestigecounter) + " seconds.";
             resetInfo.style.color = "turquoise";
@@ -64,6 +65,7 @@ export const resetdetails = (input: resetNames) => {
             if(currencyImage1.src !== "Pictures/Mythos.png"){
                 currencyImage1.src = "Pictures/Mythos.png"
             }
+            currencyImage1.style.display = "block"
             resetCurrencyGain.textContent = "+" + format(G['transcendPointGain']);
             resetInfo.textContent = "Reset all Coin and Diamond Upgrades/Features, Crystal Upgrades & Producers, for Mythos/Offerings. Required: " + format(player.coinsThisTranscension) + "/1e100 Coins || TIME SPENT: " + format(player.transcendcounter) + " seconds.";
             resetInfo.style.color = "orchid";
@@ -72,6 +74,7 @@ export const resetdetails = (input: resetNames) => {
             if(currencyImage1.src !== "Pictures/Particle.png"){
                 currencyImage1.src = "Pictures/Particle.png"
             }
+            currencyImage1.style.display = "block"
             resetCurrencyGain.textContent = "+" + format(G['reincarnationPointGain']);
             resetInfo.textContent = "Reset ALL previous reset tiers, but gain Particles, Obtainium and Offerings! Required: " + format(player.transcendShards) + "/1e300 Mythos Shards || TIME SPENT: " + format(player.reincarnationcounter) + " seconds.";
             resetInfo.style.color = "limegreen";
@@ -80,12 +83,13 @@ export const resetdetails = (input: resetNames) => {
             if(currencyImage1.src !== "Pictures/Diamond.png") {
                 currencyImage1.src = "Pictures/Diamond.png"
             }
+            currencyImage1.style.display = "block"
             resetCurrencyGain.textContent = "-" + format(player.acceleratorBoostCost);
             resetInfo.textContent = "Reset Coin Producers/Upgrades, Crystals and Diamonds in order to increase the power of your Accelerators. Required: " + format(player.prestigePoints) + "/" + format(player.acceleratorBoostCost) + " Diamonds.";
             resetInfo.style.color = "cyan";
             break;
         case "transcensionChallenge":
-            currencyImage1.src = "";
+            currencyImage1.style.display = "none"
             resetCurrencyGain.textContent = "";
 
             (transcensionChallenge !== 0)?
@@ -93,7 +97,7 @@ export const resetdetails = (input: resetNames) => {
             (resetInfo.style.color = "crimson", resetInfo.textContent = "You're not in a Transcension Challenge right now. Get in one before you can leave it, duh!");
             break;
         case "reincarnationChallenge":
-            currencyImage1.src = "";
+            currencyImage1.style.display = "none"
             resetCurrencyGain.textContent = "";
 
             if (reincarnationChallenge !== 0) {
@@ -108,13 +112,13 @@ export const resetdetails = (input: resetNames) => {
             }
             break;
         case "ascensionChallenge":
-            currencyImage1.src = "";
+            currencyImage1.style.display = "none"
             resetCurrencyGain.textContent = "";
             resetInfo.textContent = "Click this if you're in an Ascension Challenge and want to leave. You get it already!";
             resetInfo.style.color = "gold";
             break;
         case "ascension":
-            currencyImage1.src = "";
+            currencyImage1.style.display = "none"
             resetCurrencyGain.textContent = "";
             resetInfo.textContent = "Ascend. 10x1 is required! +" + format(CalcCorruptionStuff()[4], 0, true) + " Wow! Cubes for doing it! Time: " + format(player.ascensionCounter, 0, false) + " Seconds.";
             resetInfo.style.color = "gold";

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -489,7 +489,7 @@ export const toggleBuildingScreen = (input: string) => {
     }
     for (const key in screen) {
         document.getElementById(screen[key].screen).style.display = "none";
-        document.getElementById(screen[key].button).style.backgroundColor = "#171717";
+        document.getElementById(screen[key].button).style.backgroundColor = "";
     }
     document.getElementById(screen[G['buildingSubTab']].screen).style.display = "block"
     document.getElementById(screen[G['buildingSubTab']].button).style.backgroundColor = "crimson"
@@ -509,7 +509,7 @@ export const toggleRuneScreen = (index: number) => {
             b.style.display = "block";
         } else {
             a.style.border = "2px solid silver"
-            a.style.backgroundColor = "#171717"
+            a.style.backgroundColor = ""
             b.style.display = "none";
         }
     }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -343,33 +343,33 @@ export const revealStuff = () => {
 export const hideStuff = () => {
 
     document.getElementById("buildings").style.display = "none"
-    document.getElementById("buildingstab").style.backgroundColor = "#171717";
+    document.getElementById("buildingstab").style.backgroundColor = "";
     document.getElementById("upgrades").style.display = "none"
-    document.getElementById("upgradestab").style.backgroundColor = "#171717"
+    document.getElementById("upgradestab").style.backgroundColor = ""
     document.getElementById("settings").style.display = "none"
 
     const settingsTab = document.getElementById("settingstab");
     if (settingsTab.getAttribute('full') === '0') {
-        settingsTab.style.backgroundColor = "#171717"
+        settingsTab.style.backgroundColor = ""
         settingsTab.style.color = "white"
         settingsTab.style.border = '1px solid white';
     }
 
     document.getElementById("statistics").style.display = "none"
-    document.getElementById("achievementstab").style.backgroundColor = "#171717"
+    document.getElementById("achievementstab").style.backgroundColor = ""
     document.getElementById("achievementstab").style.color = "white"
     document.getElementById("runes").style.display = "none"
-    document.getElementById("runestab").style.backgroundColor = "#171717"
+    document.getElementById("runestab").style.backgroundColor = ""
     document.getElementById("challenges").style.display = "none"
-    document.getElementById("challengetab").style.backgroundColor = "#171717"
+    document.getElementById("challengetab").style.backgroundColor = ""
     document.getElementById("research").style.display = "none"
-    document.getElementById("researchtab").style.backgroundColor = "#171717"
+    document.getElementById("researchtab").style.backgroundColor = ""
     document.getElementById("shop").style.display = "none"
-    document.getElementById("shoptab").style.backgroundColor = "purple"
+    document.getElementById("shoptab").style.backgroundColor = ""
     document.getElementById("ants").style.display = "none"
-    document.getElementById("anttab").style.backgroundColor = "#171717"
-    document.getElementById("cubetab").style.backgroundColor = "#171717"
-    document.getElementById("traitstab").style.backgroundColor = "#171717"
+    document.getElementById("anttab").style.backgroundColor = ""
+    document.getElementById("cubetab").style.backgroundColor = ""
+    document.getElementById("traitstab").style.backgroundColor = ""
     document.getElementById("cubes").style.display = "none"
     document.getElementById("traits").style.display = "none"
 
@@ -516,30 +516,30 @@ export const buttoncolorchange = () => {
         const f = document.getElementById("buyaccelerator");
         const g = document.getElementById("buymultiplier");
         const h = document.getElementById("buyacceleratorboost");
-        ((!player.toggles[1] || player.upgrades[81] === 0) && player.coins.gte(player.firstCostCoin)) ?
-            a.style.backgroundColor = "#555555" :
-            a.style.backgroundColor = "#171717";
-        ((!player.toggles[2] || player.upgrades[82] === 0) && player.coins.gte(player.secondCostCoin)) ?
-            b.style.backgroundColor = "#555555" :
-            b.style.backgroundColor = "#171717";
-        ((!player.toggles[3] || player.upgrades[83] === 0) && player.coins.gte(player.thirdCostCoin)) ?
-            c.style.backgroundColor = "#555555" :
-            c.style.backgroundColor = "#171717";
-        ((!player.toggles[4] || player.upgrades[84] === 0) && player.coins.gte(player.fourthCostCoin)) ?
-            d.style.backgroundColor = "#555555" :
-            d.style.backgroundColor = "#171717";
-        ((!player.toggles[5] || player.upgrades[85] === 0) && player.coins.gte(player.fifthCostCoin)) ?
-            e.style.backgroundColor = "#555555" :
-            e.style.backgroundColor = "#171717";
-        ((!player.toggles[6] || player.upgrades[86] === 0) && player.coins.gte(player.acceleratorCost)) ?
-            f.style.backgroundColor = "#555555" :
-            f.style.backgroundColor = "#171717";
-        ((!player.toggles[7] || player.upgrades[87] === 0) && player.coins.gte(player.multiplierCost)) ?
-            g.style.backgroundColor = "#555555" :
-            g.style.backgroundColor = "#171717";
-        ((!player.toggles[8] || player.upgrades[88] === 0) && player.prestigePoints.gte(player.acceleratorBoostCost)) ?
-            h.style.backgroundColor = "#555555" :
-            h.style.backgroundColor = "#171717";
+        ((!player.toggles[1] || player.upgrades[81] === 0) && player.coins.gte(player.firstCostCoin))
+            ? a.classList.add("buildingPurchaseBtnAvailable")
+            : a.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[2] || player.upgrades[82] === 0) && player.coins.gte(player.secondCostCoin))
+            ? b.classList.add("buildingPurchaseBtnAvailable")
+            : b.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[3] || player.upgrades[83] === 0) && player.coins.gte(player.thirdCostCoin))
+            ? c.classList.add("buildingPurchaseBtnAvailable")
+            : c.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[4] || player.upgrades[84] === 0) && player.coins.gte(player.fourthCostCoin))
+            ? d.classList.add("buildingPurchaseBtnAvailable")
+            : d.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[5] || player.upgrades[85] === 0) && player.coins.gte(player.fifthCostCoin))
+            ? e.classList.add("buildingPurchaseBtnAvailable")
+            : e.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[6] || player.upgrades[86] === 0) && player.coins.gte(player.acceleratorCost))
+            ? f.classList.add("buildingPurchaseBtnAvailable")
+            : f.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[7] || player.upgrades[87] === 0) && player.coins.gte(player.multiplierCost))
+            ? g.classList.add("buildingPurchaseBtnAvailable")
+            : g.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[8] || player.upgrades[88] === 0) && player.prestigePoints.gte(player.acceleratorBoostCost))
+            ? h.classList.add("buildingPurchaseBtnAvailable")
+            : h.classList.remove("buildingPurchaseBtnAvailable");
     }
 
     if (G['currentTab'] === "buildings" && G['buildingSubTab'] === "diamond") {
@@ -553,11 +553,21 @@ export const buttoncolorchange = () => {
         const h = document.getElementById("buycrystalupgrade3");
         const i = document.getElementById("buycrystalupgrade4");
         const j = document.getElementById("buycrystalupgrade5");
-        ((!player.toggles[10] || player.achievements[78] === 0) && player.prestigePoints.gte(player.firstCostDiamonds)) ? a.style.backgroundColor = "#555555" : a.style.backgroundColor = "#171717";
-        ((!player.toggles[11] || player.achievements[85] === 0) && player.prestigePoints.gte(player.secondCostDiamonds)) ? b.style.backgroundColor = "#555555" : b.style.backgroundColor = "#171717";
-        ((!player.toggles[12] || player.achievements[92] === 0) && player.prestigePoints.gte(player.thirdCostDiamonds)) ? c.style.backgroundColor = "#555555" : c.style.backgroundColor = "#171717";
-        ((!player.toggles[13] || player.achievements[99] === 0) && player.prestigePoints.gte(player.fourthCostDiamonds)) ? d.style.backgroundColor = "#555555" : d.style.backgroundColor = "#171717";
-        ((!player.toggles[14] || player.achievements[106] === 0) && player.prestigePoints.gte(player.fifthCostDiamonds)) ? e.style.backgroundColor = "#555555" : e.style.backgroundColor = "#171717";
+        ((!player.toggles[10] || player.achievements[78] === 0) && player.prestigePoints.gte(player.firstCostDiamonds))
+            ? a.classList.add("buildingPurchaseBtnAvailable")
+            : a.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[11] || player.achievements[85] === 0) && player.prestigePoints.gte(player.secondCostDiamonds))
+            ? b.classList.add("buildingPurchaseBtnAvailable")
+            : b.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[12] || player.achievements[92] === 0) && player.prestigePoints.gte(player.thirdCostDiamonds))
+            ? c.classList.add("buildingPurchaseBtnAvailable")
+            : c.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[13] || player.achievements[99] === 0) && player.prestigePoints.gte(player.fourthCostDiamonds))
+            ? d.classList.add("buildingPurchaseBtnAvailable")
+            : d.classList.remove("buildingPurchaseBtnAvailable");
+        ((!player.toggles[14] || player.achievements[106] === 0) && player.prestigePoints.gte(player.fifthCostDiamonds))
+            ? e.classList.add("buildingPurchaseBtnAvailable")
+            : e.classList.remove("buildingPurchaseBtnAvailable");
         let k = 0;
         k += Math.floor(G['rune3level'] / 16 * G['effectiveLevelMult']) * 100 / 100
         if (player.upgrades[73] === 1 && player.currentChallenge.reincarnation !== 0) {
@@ -587,8 +597,9 @@ export const buttoncolorchange = () => {
             const g = document.getElementById("buyTalismanItem7");
             const arr = [a, b, c, d, e, f, g];
             for (let i = 0; i < arr.length; i++) {
-                arr[i].style.backgroundColor = (player.researchPoints > G['talismanResourceObtainiumCosts'][i]
-                    && player.runeshards > G['talismanResourceOfferingCosts'][i]) ? "purple" : "#171717"
+                (player.researchPoints > G['talismanResourceObtainiumCosts'][i] && player.runeshards > G['talismanResourceOfferingCosts'][i])
+                    ? arr[i].classList.add("talisminBtnAvailable")
+                    : arr[i].classList.remove("talisminBtnAvailable")
             }
         }
     }
@@ -598,8 +609,8 @@ export const buttoncolorchange = () => {
             const toggle = player.toggles[i + 15];
             const mythos = player[`${G['ordinals'][i - 1]}CostMythos`];
             (!toggle || !player.upgrades[93 + i]) && player.transcendPoints.gte(mythos) 
-                ? document.getElementById('buymythos' + i).style.backgroundColor = "#555555" 
-                : document.getElementById('buymythos' + i).style.backgroundColor = "#171717"
+                ? document.getElementById(`buymythos${i}`).classList.add("buildingPurchaseBtnAvailable")
+                : document.getElementById(`buymythos${i}`).classList.remove("buildingPurchaseBtnAvailable");
         }
     }
 
@@ -607,17 +618,17 @@ export const buttoncolorchange = () => {
         for (let i = 1; i <= 5; i++) {
             const costParticles = player[G['ordinals'][i - 1] + 'CostParticles'] as Decimal;
             player.reincarnationPoints.gte(costParticles) 
-                ? document.getElementById("buyparticles" + i).style.backgroundColor = "#555555" 
-                : document.getElementById("buyparticles" + i).style.backgroundColor = "#171717";
+                ? document.getElementById(`buyparticles${i}`).classList.add("buildingPurchaseBtnAvailable")
+                : document.getElementById(`buyparticles${i}`).classList.remove("buildingPurchaseBtnAvailable");
         }
     }
 
     if (G['currentTab'] === "buildings" && G['buildingSubTab'] === "tesseract") {
         for (let i = 1; i <= 5; i++) {
             const ascendBuilding = player['ascendBuilding' + i]['cost'] as number;
-            player.wowTesseracts >= ascendBuilding ?
-                document.getElementById('buyTesseracts' + i).style.backgroundColor = "#555555" :
-                document.getElementById('buyTesseracts' + i).style.backgroundColor = "#171717";
+            player.wowTesseracts >= ascendBuilding
+                ? document.getElementById(`buyTesseracts${i}`).classList.add("buildingPurchaseBtnAvailable")
+                : document.getElementById(`buyTesseracts${i}`).classList.remove("buildingPurchaseBtnAvailable");
         }
         for (let i = 1; i <= 8; i++) {
             (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]).times(G['constUpgradeCosts'][i]))) ?
@@ -635,16 +646,14 @@ export const buttoncolorchange = () => {
         (player.reincarnationPoints.gte(player.firstCostAnts)) ? document.getElementById("anttier1").style.backgroundColor = "white" : document.getElementById("anttier1").style.backgroundColor = "#171717";
         for (let i = 2; i <= 8; i++) {
             const costAnts = player[G['ordinals'][i - 1] + 'CostAnts'] as Decimal | number;
-            player.antPoints.gte(costAnts) 
-                ? document.getElementById("anttier" + i).style.backgroundColor = "white" 
-                : document.getElementById("anttier" + i).style.backgroundColor = "#171717";
+            player.antPoints.gte(costAnts)
+                ? document.getElementById(`anttier${i}`).classList.add("antTierBtnAvailable")
+                : document.getElementById(`anttier${i}`).classList.remove("antTierBtnAvailable")
         }
         for (let i = 1; i <= 12; i++) {
-            if (player.antPoints.gte(Decimal.pow(G['antUpgradeCostIncreases'][i-1], player.antUpgrades[i-1] * G['extinctionMultiplier'][player.usedCorruptions[10]]).times(G['antUpgradeBaseCost'][i-1]))) {
-                document.getElementById("antUpgrade" + i).style.backgroundColor = "silver"
-            } else {
-                document.getElementById("antUpgrade" + i).style.backgroundColor = "#171717";
-            }
+            player.antPoints.gte(Decimal.pow(G['antUpgradeCostIncreases'][i-1], player.antUpgrades[i-1] * G['extinctionMultiplier'][player.usedCorruptions[10]]).times(G['antUpgradeBaseCost'][i-1]))
+                ? document.getElementById(`antUpgrade${i}`).classList.add("antUpgradeBtnAvailable")
+                : document.getElementById(`antUpgrade${i}`).classList.remove("antUpgradeBtnAvailable")
         }
     }
 }
@@ -781,7 +790,7 @@ export const CSSRuneBlessings = () => {
         a.style.left = b.style.left = "10%"
 
         c.style.top = d.style.top = (23 + 75 * i) + "px"
-        c.style.left = d.style.left = "15%"
+        c.style.left = d.style.left = "16%"
 
         e.style.top = f.style.top = (36 + 75 * i) + "px"
         e.style.left = f.style.left = "32%"


### PR DESCRIPTION
- removed global scale transform
- centered general user interface on wide screens
- centered subtab buttons
- centered building rows
- added a hover effect to tabs and subtabs
- made your cursor only be a pointer on ant tiers and upgrades, building purchase buttons, and talisman shard purchase buttons if they're affordable
- added a hover effect to building purchase buttons and talisman shard purchase buttons when they're purchasable
- highlight the coin building and settings subtabs by default as they are the default subtabs on load
- cleaned up background css related to all these things (tried to use flexbox and classes rather than grids and html style decs)