### PR TITLE
more hover effects and alignment/centering fixes

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -566,7 +566,7 @@ nav li:hover {
 
 .buttonRow > div {
     display: flex;
-    justify-content: center;
+    justify-content: flex-start;
     align-items: center;
     height: 35px;
 }
@@ -610,6 +610,15 @@ nav li:hover {
     width: 80px;
     height: 30px;
     margin-left: 15px;
+}
+
+.autobuyerToggleButton {
+	background-color: #171717;
+	transition: background-color 0.15s;
+}
+
+.autobuyerToggleButton:hover {
+	background-color: #333333;
 }
 
 .buttonRow > div > .stats {
@@ -765,14 +774,19 @@ nav li:hover {
 }
 
 #coinBuildings {
+	display: flex;
     position: relative;
 	padding: 0;
+	flex-direction: column;
+    align-items: center;
 }
 
 #prestige {
     position: relative;
 	padding: 0;
 	color: cyan;
+	flex-direction: column;
+    align-items: center;
 }
 
 #crystalupgradestable { margin: 0 auto; }
@@ -860,6 +874,7 @@ nav li:hover {
 	width: 100px;
 	text-align: center;
 	border: 2px solid gold;
+	cursor: default;
 }
 
 .runeTypeElement {
@@ -867,6 +882,16 @@ nav li:hover {
 	text-align: center;
 	align-items: center;
 	align-content: center;
+}
+
+.runeType > .runeButtonAvailable {
+	background-color: purple;
+	cursor: pointer;
+	transition-duration: 0.15s;
+}
+
+.runeType > .runeButtonAvailable:hover {
+	background-color: #b300b2;
 }
 
 #runeEffectDisplays {
@@ -1435,6 +1460,8 @@ nav li:hover {
 #transcension {
 	position: relative;
 	padding: 0;
+	flex-direction: column;
+    align-items: center;
 }
 
 #transcension > .buttonRow {
@@ -1614,6 +1641,8 @@ nav li:hover {
     position: relative;
 	padding: 0;
 	color: limegreen;
+	flex-direction: column;
+    align-items: center;
 }
 
 #reincarnationTexts {
@@ -1703,6 +1732,36 @@ nav li:hover {
 
 #researchinfo2 {
 	height: 40px;
+}
+
+.researchAvailable {
+	cursor: pointer;
+	transition-duration: 0.15s;
+}
+
+.researchAvailable:hover {
+	background-color: #333333
+}
+
+.researchPurchased {
+	background-color: purple;
+}
+
+.researchPurchasedAvailable {
+	cursor: pointer;
+	transition-duration: 0.15s;
+}
+
+.researchPurchasedAvailable:hover {
+	background-color: #b300b2
+}
+
+.researchMaxed {
+	background-color: green;
+}
+
+.researchRoomba {
+	background-color: orange;
 }
 
 #shop {
@@ -2137,6 +2196,8 @@ p[id$="BlessingsTotal"] {
 	position: relative;
 	padding: 0;
 	color: orange;
+	flex-direction: column;
+    align-items: center;
 }
 
 #tesseractTexts { margin-top: 20px; }
@@ -2150,12 +2211,13 @@ p[id$="BlessingsTotal"] {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	width: 450px;
 }
 
 #ascendConstantUpgrades > p {
 	margin: 0;
 	text-align: left;
-	width: 25%;
+	width: 100%;
 }
 
 #ascendautomation {
@@ -2268,6 +2330,7 @@ p[id$="BlessingsTotal"] {
 }
 .subtabContent.subtabActive.subtabDisplayFlex {
 	display: flex;
+	justify-content: center;
 }
 
 .historySubTab {
@@ -2359,8 +2422,17 @@ p[id$="BlessingsTotal"] {
 	position: absolute;
 	height: 30px;
 	width: 325px;
-	border: 1px solid yellow;
+	border: 1px solid yellow !important;
 	color: gold;
+	transition-duration: 0.15s;
+	cursor: default;
+}
+.runeButtonsAvailable{
+	background-color: #222222;
+	cursor: pointer;
+}
+.runeButtonsAvailable:hover{
+	background-color: #444444;
 }
 .runeInputSettings{
 	top: 45px;

--- a/index.html
+++ b/index.html
@@ -186,35 +186,35 @@
                 <img class="image" id="coin1" src="Pictures/Tier1.png" alt="">
                 <span class="desc" id="buildtext1" style="color: gold">Workers: 321495 [+1.49e+391945]</span>
                 <button class="buildingPurchaseBtn" id="buycoin1">Cost: 100 Coins.</button>
-                <button class="auto" id="toggle1" toggleid="1" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle1" toggleid="1">Auto: On</button>
                 <span class="stats" id="buildtext2" style="color: gold">100 Coins/second [100%]</span>
             </div>
             <div>
                 <img class="coinunlock1 image" id="coin2" src="Pictures/Tier2.png" alt="">
                 <span class="coinunlock1 desc" id="buildtext3" style="color: gold">Investments: 0 [+0]</span>
                 <button class="coinunlock1 buildingPurchaseBtn" id="buycoin2">Cost: 2e3 Coins.</button>
-                <button class="auto" id="toggle2" toggleid="2" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle2" toggleid="2">Auto: On</button>
                 <span class="coinunlock1 stats" id="buildtext4" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock2 image" id="coin3" src="Pictures/Tier3.png" alt="">
                 <span class="coinunlock2 desc" id="buildtext5" style="color: gold">Printers: 0 [+0]</span>
                 <button class="coinunlock2 buildingPurchaseBtn" id="buycoin3">Cost: 4e4 Coins.</button>
-                <button class="auto" id="toggle3" toggleid="3" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle3" toggleid="3">Auto: On</button>
                 <span class="coinunlock2 stats" id="buildtext6" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock3 image" id="coin4" src="Pictures/Tier4.png" alt="">
                 <span class="coinunlock3 desc" id="buildtext7" style="color: gold">Coin Mints: 0 [+0]</span>
                 <button class="coinunlock3 buildingPurchaseBtn" id="buycoin4">Cost: 8e5 Coins.</button>
-                <button class="auto" id="toggle4" toggleid="4" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle4" toggleid="4">Auto: On</button>
                 <span class="coinunlock3 stats" id="buildtext8" style="color: gold">0 Coins/second [0%]</span>
             </div>
             <div>
                 <img class="coinunlock4 image" id="coin5" src="Pictures/Tier5.png" alt="">
                 <span class="coinunlock4 desc" id="buildtext9" style="color: gold">Alchemies: 0 [+0]</span>
                 <button class="coinunlock4 buildingPurchaseBtn" id="buycoin5">Cost: 1.6e7 Coins.</button>
-                <button class="auto" id="toggle5" toggleid="5" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle5" toggleid="5">Auto: On</button>
                 <span class="coinunlock4 stats" id="buildtext10" style="color: gold">0 Coins/second [0%]</span>
             </div>
         </div>
@@ -224,21 +224,21 @@
                 <img class="coinunlock1 image" id="accelerator" src="Pictures/Accelerator.png" alt="">
                 <span class="coinunlock1 desc" id="buildtext11" style="color: yellow">Accelerators: 0 [+0]</span>
                 <button class="coinunlock1 buildingPurchaseBtn" id="buyaccelerator">Cost: 500 Coins.</button>
-                <button class="auto" id="toggle6" toggleid="6" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle6" toggleid="6">Auto: On</button>
                 <span class="coinunlock1 stats" id="buildtext12" style="color: cyan">Acceleration Factor: 10.0%. Acceleration Multiplier: 1.00x</span>
             </div>
             <div>
                 <img class="coinunlock3 image" id="multiplier" src="Pictures/Multiplier.png" alt="">
                 <span class="coinunlock3 desc" id="buildtext13" style="color: yellow">Multipliers: 0 [+0]</span>
                 <button class="coinunlock3 buildingPurchaseBtn" id="buymultiplier">Cost: 500 Coins.</button>
-                <button class="auto" id="toggle7" toggleid="7" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle7" toggleid="7">Auto: On</button>
                 <span class="coinunlock3 stats" id="buildtext14" style="color: pink">Multiplier Power: 2.000%. Multiplier: 1.00x</span>
             </div>
             <div>
                 <img class="prestigeunlock image" id="acceleratorboost" src="Pictures/AcceleratorBoost.png" alt="">
                 <span class="prestigeunlock desc" id="buildtext15" style="color: cyan">Accelerator Boosts: 0 [+0]</span>
                 <button class="prestigeunlock buildingPurchaseBtn" id="buyacceleratorboost">Cost: 500 Coins.</button>
-                <button class="auto" id="toggle8" toggleid="8" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle8" toggleid="8">Auto: On</button>
                 <span class="prestigeunlock stats" id="buildtext16" style="color: crimson">Next one adds 1.00% Acceleration Factor.</span>
             </div>
         </div>
@@ -267,35 +267,35 @@
                 <img id="diamond1" class="image" src="Pictures/DiamondTier1.png" style="border: 1px solid cyan" alt="">
                 <span id="prestigetext1" class="desc">Refineries: 0 [+0]</span>
                 <button id="buydiamond1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">434342</button>
-                <button class="auto" id="toggle10" toggleid="10" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle10" toggleid="10">Auto: On</button>
                 <span id="prestigetext2" class="stats">100 Shards/sec</span>
             </div>
             <div>
                 <img id="diamond2" class="image" src="Pictures/DiamondTier2.png" style="border: 1px solid cyan" alt="">
                 <span id="prestigetext3" class="desc">Coal Plants: 0 [+0]</span>
                 <button id="buydiamond2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">532523</button>
-                <button class="auto" id="toggle11" toggleid="11" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle11" toggleid="11">Auto: On</button>
                 <span id="prestigetext4" class="stats">100 Augments/sec</span>
             </div>
             <div>
                 <img id="diamond3" class="image" src="Pictures/DiamondTier3.png" style="border: 1px solid cyan" alt="">
                 <span id="prestigetext5" class="desc">Coal Rigs: 0 [+0]</span>
                 <button id="buydiamond3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">5454546</button>
-                <button class="auto" id="toggle12" toggleid="12" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle12" toggleid="12">Auto: On</button>
                 <span id="prestigetext6" class="stats">100 Enhancements/sec</span>
             </div>
             <div>
                 <img id="diamond4" class="image" src="Pictures/DiamondTier4.png" style="border: 1px solid cyan" alt="">
                 <span id="prestigetext7" class="desc">Diamond Pickaxes: 0 [+0]</span>
                 <button id="buydiamond4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">646346</button>
-                <button class="auto" id="toggle13" toggleid="13" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle13" toggleid="13">Auto: On</button>
                 <span id="prestigetext8" class="stats">100 Wizards/sec</span>
             </div>
             <div>
                 <img id="diamond5" class="image" src="Pictures/DiamondTier5.png" style="border: 1px solid cyan" alt="">
                 <span id="prestigetext9" class="desc">Pandora's Box: 0 [+0]</span>
                 <button id="buydiamond5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">3464363</button>
-                <button class="auto" id="toggle14" toggleid="14" style="background-color: #171717;">Auto: On</button>
+                <button class="auto autobuyerToggleButton" id="toggle14" toggleid="14">Auto: On</button>
                 <span id="prestigetext10" class="stats">100 Oracles/sec</span>
             </div>
         </div>
@@ -344,35 +344,35 @@
                 <img id="mythos1" class="image" src="Pictures/MythosTier1.png" style="border: 1px solid plum" alt="">
                 <span id="transcendtext1" class="desc">Augments: 0 [+0]</span>
                 <button id="buymythos1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
-                <button class="auto" id="toggle16" toggleid="16" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle16" toggleid="16">Auto: Off</button>
                 <span id="transcendtext2" class="stats">100 Shards/sec</span>
             </div>
             <div>
                 <img id="mythos2" class="image" src="Pictures/MythosTier2.png" style="border: 1px solid plum" alt="">
                 <span id="transcendtext3" class="desc">Enhancements: 0 [+0]</span>
                 <button id="buymythos2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
-                <button class="auto" id="toggle17" toggleid="17" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle17" toggleid="17">Auto: Off</button>
                 <span id="transcendtext4" class="stats">100 Augments/sec</span>
             </div>
             <div>
                 <img id="mythos3" class="image" src="Pictures/MythosTier3.png" style="border: 1px solid plum" alt="">
                 <span id="transcendtext5" class="desc">Wizards: 0 [+0]</span>
                 <button id="buymythos3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
-                <button class="auto" id="toggle18" toggleid="18" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle18" toggleid="18">Auto: Off</button>
                 <span id="transcendtext6" class="stats">100 Enhancements/sec</span>
             </div>
             <div>
                 <img id="mythos4" class="image" src="Pictures/MythosTier4.png" style="border: 1px solid plum" alt="">
                 <span id="transcendtext7" class="desc">Oracles: 0 [+0]</span>
                 <button id="buymythos4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
-                <button class="auto" id="toggle19" toggleid="19" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle19" toggleid="19">Auto: Off</button>
                 <span id="transcendtext8" class="stats">100 Wizards/sec</span>
             </div>
             <div>
                 <img id="mythos5" class="image" src="Pictures/MythosTier5.png" style="border: 1px solid plum" alt="">
                 <span id="transcendtext9" class="desc">Grandmasters: 0 [+0]</span>
                 <button id="buymythos5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;"></button>
-                <button class="auto" id="toggle20" toggleid="20" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle20" toggleid="20">Auto: Off</button>
                 <span id="transcendtext10" class="stats">100 Oracles/sec</span>
             </div>
         </div>
@@ -406,35 +406,35 @@
                 <img id="particles1" src="Pictures/ParticlesTier1.png" style="border: 1px solid green" alt="">
                 <span id="reincarnationtext1" class="desc">Protons: 0 [+0]</span>
                 <button id="buyparticles1" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Particles</button>
-                <button class="auto" id="toggle22" toggleid="22" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle22" toggleid="22">Auto: Off</button>
                 <span id="reincarnationtext6" class="stats">100 Elements/sec</span>
             </div>
             <div>
                 <img id="particles2" class="image" src="Pictures/ParticlesTier2.png" style="border: 1px solid green" alt="">
                 <span id="reincarnationtext2" class="desc">Elements: 0 [+0]</span>
                 <button id="buyparticles2" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Particles</button>
-                <button class="auto" id="toggle23" toggleid="23" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle23" toggleid="23">Auto: Off</button>
                 <span id="reincarnationtext7" class="stats">Black Holes: 0 [+0]</span>
             </div>
             <div>
                 <img id="particles3" class="image" src="Pictures/ParticlesTier3.png" style="border: 1px solid green" alt="">
                 <span id="reincarnationtext3" class="desc">100 Atoms/sec</span>
                 <button id="buyparticles3" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+4 Particles</button>
-                <button class="auto" id="toggle24" toggleid="24" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle24" toggleid="24">Auto: Off</button>
                 <span id="reincarnationtext8" class="stats">100 Pulsars/sec</span>
             </div>
             <div>
                 <img id="particles4" class="image" src="Pictures/ParticlesTier4.png" style="border: 1px solid green" alt="">
                 <span id="reincarnationtext4" class="desc">100 Protons/sec</span>
                 <button id="buyparticles4" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+8 Particles</button>
-                <button class="auto" id="toggle25" toggleid="25" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle25" toggleid="25">Auto: Off</button>
                 <span id="reincarnationtext9" class="stats">Quasars: 0 [+0]</span>
             </div>
             <div>
                 <img id="particles5" class="image" src="Pictures/ParticlesTier5.png" style="border: 1px solid green" alt="">
                 <span id="reincarnationtext5" class="desc">Pulsars: 0 [+0]</span>
                 <button id="buyparticles5" class="buildingPurchaseBtn" style="border: 1px solid white; border-radius: 8px;">Cost: 1e+16 Particles</button>
-                <button class="auto" id="toggle26" toggleid="26" style="background-color: #171717;">Auto: Off</button>
+                <button class="auto autobuyerToggleButton" id="toggle26" toggleid="26">Auto: Off</button>
                 <span id="reincarnationtext10" class="stats">100 Black Holes/sec</span>
             </div>
         </div>
@@ -473,35 +473,35 @@
                 <img class="image" id="tesseracts1" src="Pictures/TesseractTier1.png" alt="">
                 <span class="desc" id="ascendText1">Dot: 0 [+0]</span>
                 <button class="buildingPurchaseBtn" id="buyTesseracts1" style="border: 1px solid white; border-radius: 8px;">Cost: 1 Tesseracts</button>
-                <button class="auto" id="tesseractAutoToggle1" style="background-color: #171717;">Auto [OFF]</button>
+                <button class="auto autobuyerToggleButton" id="tesseractAutoToggle1">Auto [OFF]</button>
                 <span class="stats" id="ascendText6">+100 Constant/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts2" src="Pictures/TesseractTier2.png" alt="">
                 <span class="desc" id="ascendText2">Vector: 0 [+0]</span>
                 <button class="buildingPurchaseBtn" id="buyTesseracts2" style="border: 1px solid white; border-radius: 8px;">Cost: 10 Tesseracts</button>
-                <button class="auto" id="tesseractAutoToggle2" style="background-color: #171717;">Auto [OFF]</button>
+                <button class="auto autobuyerToggleButton" id="tesseractAutoToggle2">Auto [OFF]</button>
                 <span class="stats" id="ascendText7">100 Dots/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts3" src="Pictures/TesseractTier3.png" alt="">
                 <span class="desc" id="ascendText3">Three-Space: 0 [+0]</span>
                 <button class="buildingPurchaseBtn" id="buyTesseracts3" style="border: 1px solid white; border-radius: 8px;">Cost: 100 Tesseracts</button>
-                <button class="auto" id="tesseractAutoToggle3" style="background-color: #171717;">Auto [OFF]</button>
+                <button class="auto autobuyerToggleButton" id="tesseractAutoToggle3">Auto [OFF]</button>
                 <span class="stats" id="ascendText8">100 Vectors/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts4" src="Pictures/TesseractTier4.png" alt="">
                 <span class="desc" id="ascendText4">Bent Time: 0 [+0]</span>
                 <button class="buildingPurchaseBtn" id="buyTesseracts4" style="border: 1px solid white; border-radius: 8px;">Cost: 1000 Tesseracts</button>
-                <button class="auto" id="tesseractAutoToggle4" style="background-color: #171717;">Auto [OFF]</button>
+                <button class="auto autobuyerToggleButton" id="tesseractAutoToggle4">Auto [OFF]</button>
                 <span class="stats" id="ascendText9">100 Three-Spaces/sec</span>
             </div>
             <div>
                 <img class="image" id="tesseracts5" src="Pictures/TesseractTier5.png" alt="">
                 <span class="desc" id="ascendText5">Hilbert Space: 0 [+0]</span>
                 <button class="buildingPurchaseBtn" id="buyTesseracts5" style="border: 1px solid white; border-radius: 8px;">Cost: 10000 Tesseracts</button>
-                <button class="auto" id="tesseractAutoToggle5" style="background-color: #171717;">Auto [OFF]</button>
+                <button class="auto autobuyerToggleButton" id="tesseractAutoToggle5">Auto [OFF]</button>
                 <span class="stats" id="ascendText10">100 Bent Time/sec</span>
             </div>
         </div>
@@ -603,7 +603,7 @@
                         <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/ConstantUpgrade1.png" id="upg125" alt=""></td>
                     </tr>
                 </table>
-                <button class="auto" id="shoptogglecoin" style="border:2px solid green">Auto: ON</button>
+                <button class="autobuyerToggleButton" id="shoptogglecoin" style="border:2px solid green">Auto: ON</button>
             </div>
             <div>
                 <img class="prestigeunlock" src="Pictures/Diamond.png" alt="">
@@ -639,7 +639,7 @@
                     </tr>
 
                 </table>
-                <button class="auto" id="shoptoggleprestige" style="border:2px solid green">Auto: ON</button>
+                <button class="autobuyerToggleButton" id="shoptoggleprestige" style="border:2px solid green">Auto: ON</button>
             </div>
             <div>
                 <img class="transcendunlock" src="Pictures/Mythos.png" alt="">
@@ -674,7 +674,7 @@
                         <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos20.png" id="upg60" alt=""></td>
                     </tr>
                 </table>
-                <button class="auto" id="shoptoggletranscend" style="border:2px solid green">Auto: ON</button>
+                <button class="autobuyerToggleButton" id="shoptoggletranscend" style="border:2px solid green">Auto: ON</button>
             </div>
             <div>
                 <img class="prestigeunlock" src="Pictures/Generators.png" alt="">
@@ -709,7 +709,7 @@
                         <td><img id="upg120" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTwenty.png" alt=""></td>
                     </tr>
                 </table>
-                <button class="auto" id="shoptogglegenerator" style="border:2px solid green">Auto: ON</button>
+                <button class="autobuyerToggleButton" id="shoptogglegenerator" style="border:2px solid green">Auto: ON</button>
             </div>
             <div>
                 <img class="prestigeunlock" src="Pictures/Automation.png" alt="">
@@ -778,7 +778,7 @@
                         <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle20.png" id="upg80" alt=""></td>
                     </tr>
                 </table>
-                <button id="particleAutoUpgrade" style="border: 2px solid green">Auto: ON</button>
+                <button class="autobuyerToggleButton" id="particleAutoUpgrade" style="border: 2px solid green">Auto: ON</button>
             </div>
         </div>
 
@@ -786,7 +786,7 @@
             <p id="upgradedescription" style="color: beige">Hover over an upgrade icon to see details!</p>
             <p id="upgradecost"></p>
             <p id="upgradeeffect"></p>
-            <button class="auto" id="toggle9" toggleid="9" format="Hover-to-Buy [$]" style="border:2px solid green">Hover-To-Buy: Off</button>
+            <button class="auto autobuyerToggleButton" id="toggle9" toggleid="9" format="Hover-to-Buy [$]" style="border:2px solid green">Hover-To-Buy: Off</button>
         </div>
     </div>
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -20,6 +20,7 @@ import type {
 import { challengeRequirement } from './Challenges';
 import { Synergism } from './Events';
 import { resetNames } from './types/Synergism';
+import { updateClassList } from './Utility';
 
 let repeatreset: ReturnType<typeof setTimeout>;
 
@@ -539,17 +540,18 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
         player.challengecompletions[7] = player.highestchallengecompletions[7] = player.cubeUpgrades[49]
         player.challengecompletions[8] = player.highestchallengecompletions[8] = player.cubeUpgrades[49]
 
+        document.getElementById(`res${player.autoResearch || 1}`).classList.remove("researchRoomba");
         player.roombaResearchIndex = 0;
         player.autoResearch = 1;
 
         for (let j = 1; j <= (200); j++) {
-            const k = "res" + j;
+            const k = `res${j}`;
             if (player.researches[j] > 0.5 && player.researches[j] < G['researchMaxLevels'][j]) {
-                document.getElementById(k).style.backgroundColor = "purple"
+                updateClassList(k, ["researchPurchased"], ["researchAvailable", "researchMaxed", "researchPurchasedAvailable", "researchUnpurchased"])
             } else if (player.researches[j] > 0.5 && player.researches[j] >= G['researchMaxLevels'][j]) {
-                document.getElementById(k).style.backgroundColor = "green"
+                updateClassList(k, ["researchMaxed"], ["researchAvailable", "researchPurchased", "researchPurchasedAvailable", "researchUnpurchased"])
             } else {
-                document.getElementById(k).style.backgroundColor = "black"
+                updateClassList(k, ["researchUnpurchased"], ["researchAvailable", "researchPurchased", "researchPurchasedAvailable", "researchMaxed"])
             }
         }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1285,9 +1285,6 @@ if (player.achievements[102] == 1)document.getElementById("runeshowpower4").text
             document.getElementById('automaticobtainium').textContent = "[LOCKED - Buy Research 3x11]"
         }
 
-        if (player.autoResearchToggle && player.autoResearch > 0.5) {
-            document.getElementById("res" + player.autoResearch).style.backgroundColor = "orange"
-        }
         if (player.autoSacrificeToggle && player.autoSacrifice > 0.5) {
             document.getElementById("rune" + player.autoSacrifice).style.backgroundColor = "orange"
         }

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -7,7 +7,6 @@ import { calculateRuneLevels } from './Calculate';
 import { reset } from './Reset';
 import { achievementaward } from './Achievements';
 import { getChallengeConditions } from './Challenges';
-import { maxRoombaResearchIndex } from './Research';
 import { loadStatisticsCubeMultipliers, loadStatisticsOfferingMultipliers, loadStatisticsAccelerator, loadStatisticsMultiplier } from './Statistics';
 import { corruptionDisplay, corruptionLoadoutTableUpdate } from './Corruptions';
 
@@ -404,35 +403,16 @@ export const toggleAutoResearch = () => {
     if (player.autoResearchToggle) {
         player.autoResearchToggle = false;
         el.textContent = "Automatic: OFF";
+        document.getElementById(`res${player.autoResearch || 1}`).classList.remove("researchRoomba");
         player.autoResearch = 0;
     } else {
         player.autoResearchToggle = true;
         el.textContent = "Automatic: ON"
     }
 
-
-    if (!player.autoResearchToggle) {
-        for (let i = 1; i <= maxRoombaResearchIndex(player); i++) {
-            const l = document.getElementById("res" + i)
-            if (player.researches[i] === 0) {
-                l.style.backgroundColor = "black"
-            }
-            if (0 < player.researches[i] && player.researches[i] < G['researchMaxLevels'][i]) {
-                l.style.backgroundColor = "purple"
-            }
-            if (player.researches[i] === G['researchMaxLevels'][i]) {
-                l.style.backgroundColor = "green"
-            }
-        }
-    }
-
     if (player.autoResearchToggle && player.cubeUpgrades[9] === 1) {
         player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex]
-        const doc = document.getElementById("res" + player.autoResearch)
-        if (doc)
-            doc.style.backgroundColor = "orange"
     }
-
 
 }
 
@@ -491,7 +471,7 @@ export const toggleBuildingScreen = (input: string) => {
         document.getElementById(screen[key].screen).style.display = "none";
         document.getElementById(screen[key].button).style.backgroundColor = "";
     }
-    document.getElementById(screen[G['buildingSubTab']].screen).style.display = "block"
+    document.getElementById(screen[G['buildingSubTab']].screen).style.display = "flex"
     document.getElementById(screen[G['buildingSubTab']].button).style.backgroundColor = "crimson"
     player.subtabNumber = screen[G['buildingSubTab']].subtabNumber
 }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -584,7 +584,9 @@ export const buttoncolorchange = () => {
     if (G['currentTab'] === "runes") {
         if (G['runescreen'] === "runes") {
             for (let i = 1; i <= 5; i++) {
-                player.runeshards > 0.5 ? document.getElementById("activaterune" + i).style.backgroundColor = "purple" : document.getElementById("activaterune" + i).style.backgroundColor = "#171717";
+                player.runeshards > 0.5
+                    ? document.getElementById(`activaterune${i}`).classList.add("runeButtonAvailable")
+                    : document.getElementById(`activaterune${i}`).classList.remove("runeButtonAvailable")
             }
         }
         if (G['runescreen'] === "talismans") {
@@ -643,7 +645,7 @@ export const buttoncolorchange = () => {
     }
 
     if (G['currentTab'] === "ants") {
-        (player.reincarnationPoints.gte(player.firstCostAnts)) ? document.getElementById("anttier1").style.backgroundColor = "white" : document.getElementById("anttier1").style.backgroundColor = "#171717";
+        (player.reincarnationPoints.gte(player.firstCostAnts)) ? document.getElementById(`anttier1`).classList.add("antTierBtnAvailable") : document.getElementById(`anttier1`).classList.remove("antTierBtnAvailable");
         for (let i = 2; i <= 8; i++) {
             const costAnts = player[G['ordinals'][i - 1] + 'CostAnts'] as Decimal | number;
             player.antPoints.gte(costAnts)

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -201,14 +201,18 @@ export const visualUpdateRunes = () => {
         const blessingMultiplierArray = [0, 8, 10, 6.66, 2, 1]
         let t = 0;
         for (let i = 1; i <= 5; i++) {
-            document.getElementById('runeBlessingLevel' + i + 'Value').textContent = format(player.runeBlessingLevels[i], 0, true)
-            document.getElementById('runeBlessingPower' + i + 'Value1').textContent = format(G['runeBlessings'][i])
-            document.getElementById('runeBlessingPurchaseAmount' + i).textContent = format(Math.max(1, calculateSummationLinear(player.runeBlessingLevels[i], G['blessingBaseCost'], player.runeshards, player.runeBlessingBuyAmount)[0] - player.runeBlessingLevels[i]))
-            document.getElementById('runeBlessingPurchaseCost' + i).textContent = format(Math.max(G['blessingBaseCost'] * (1 + player.runeBlessingLevels[i]), calculateSummationLinear(player.runeBlessingLevels[i], G['blessingBaseCost'], player.runeshards, player.runeBlessingBuyAmount)[1]))
+            document.getElementById(`runeBlessingLevel${i}Value`).textContent = format(player.runeBlessingLevels[i], 0, true)
+            document.getElementById(`runeBlessingPower${i}Value1`).textContent = format(G['runeBlessings'][i])
+            const levelsPurchasable = calculateSummationLinear(player.runeBlessingLevels[i], G['blessingBaseCost'], player.runeshards, player.runeBlessingBuyAmount)[0] - player.runeBlessingLevels[i]
+            levelsPurchasable > 0
+                ? document.getElementById(`runeBlessingPurchase${i}`).classList.add("runeButtonsAvailable")
+                : document.getElementById(`runeBlessingPurchase${i}`).classList.remove("runeButtonsAvailable")
+            document.getElementById(`runeBlessingPurchaseAmount${i}`).textContent = format(Math.max(1, levelsPurchasable))
+            document.getElementById(`runeBlessingPurchaseCost${i}`).textContent = format(Math.max(G['blessingBaseCost'] * (1 + player.runeBlessingLevels[i]), calculateSummationLinear(player.runeBlessingLevels[i], G['blessingBaseCost'], player.runeshards, player.runeBlessingBuyAmount)[1]))
             if (i === 5) {
                 t = 1
             }
-            document.getElementById('runeBlessingPower' + i + 'Value2').textContent = format(1 - t + blessingMultiplierArray[i] * G['effectiveRuneBlessingPower'][i], 4, true)
+            document.getElementById(`runeBlessingPower${i}Value2`).textContent = format(1 - t + blessingMultiplierArray[i] * G['effectiveRuneBlessingPower'][i], 4, true)
         }
     }
 
@@ -217,11 +221,15 @@ export const visualUpdateRunes = () => {
         const subtract = [0, 0, 0, 1, 0, 0]
         for (let i = 1; i <= 5; i++) {
             spiritMultiplierArray[i] *= (calculateCorruptionPoints() / 400)
-            document.getElementById('runeSpiritLevel' + i + 'Value').textContent = format(player.runeSpiritLevels[i], 0, true)
-            document.getElementById('runeSpiritPower' + i + 'Value1').textContent = format(G['runeSpirits'][i])
-            document.getElementById('runeSpiritPurchaseAmount' + i).textContent = format(Math.max(1, calculateSummationLinear(player.runeSpiritLevels[i], G['spiritBaseCost'], player.runeshards, player.runeSpiritBuyAmount)[0] - player.runeSpiritLevels[i]))
-            document.getElementById('runeSpiritPurchaseCost' + i).textContent = format(Math.max(G['spiritBaseCost'] * (1 + player.runeSpiritLevels[i]), calculateSummationLinear(player.runeSpiritLevels[i], G['spiritBaseCost'], player.runeshards, player.runeSpiritBuyAmount)[1]))
-            document.getElementById('runeSpiritPower' + i + 'Value2').textContent = format(1 - subtract[i] + spiritMultiplierArray[i] * G['effectiveRuneSpiritPower'][i], 4, true)
+            document.getElementById(`runeSpiritLevel${i}Value`).textContent = format(player.runeSpiritLevels[i], 0, true)
+            document.getElementById(`runeSpiritPower${i}Value1`).textContent = format(G['runeSpirits'][i])
+            const levelsPurchasable = calculateSummationLinear(player.runeSpiritLevels[i], G['spiritBaseCost'], player.runeshards, player.runeSpiritBuyAmount)[0] - player.runeSpiritLevels[i]
+            levelsPurchasable > 0
+                ? document.getElementById(`runeSpiritPurchase${i}`).classList.add("runeButtonsAvailable")
+                : document.getElementById(`runeSpiritPurchase${i}`).classList.remove("runeButtonsAvailable")
+            document.getElementById(`runeSpiritPurchaseAmount${i}`).textContent = format(Math.max(1, levelsPurchasable))
+            document.getElementById(`runeSpiritPurchaseCost${i}`).textContent = format(Math.max(G['spiritBaseCost'] * (1 + player.runeSpiritLevels[i]), calculateSummationLinear(player.runeSpiritLevels[i], G['spiritBaseCost'], player.runeshards, player.runeSpiritBuyAmount)[1]))
+            document.getElementById(`runeSpiritPower${i}Value2`).textContent = format(1 - subtract[i] + spiritMultiplierArray[i] * G['effectiveRuneSpiritPower'][i], 4, true)
         }
     }
 }

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -83,3 +83,13 @@ export const padArray = <T extends any>(a: T[], b: T, length: number) => {
 
     return a;
 } 
+
+export const updateClassList = (targetElement: string, additions: Array<string>, removals: Array<string>) => {
+    const target = document.getElementById(targetElement);
+    for (const addition of additions) {
+        target.classList.add(addition);
+    }
+    for (const removal of removals) {
+        target.classList.remove(removal);
+    }
+}


### PR DESCRIPTION
- fixed building row alignment in cases where you had some but not all autobuyers
- added hover effects and a pointer cursor to purchasable researches
- added hover effects to building and upgrade autobuyer buttons, the hover-to-buy button, and the rune sacrifice buttons for the first 5 runes (not sure how to handle the last 2 as they seem not to be fully implemented?)
- centered the reset history subtab
- added hover effects and a purchasable state to rune blessing/spirit buttons