### PR TITLE
more css fixes and hover effects

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -138,6 +138,13 @@ a {color: white;}
 	border: 1px solid gold;
 	margin: 0 auto;
 	height: 50%;
+	transition-duration: 0.15s;
+}
+
+#confirm > button:hover,
+#alert > button:hover,
+#prompt > button:hover {
+	background-color: #333333;
 }
 
 #confirm {
@@ -1900,6 +1907,11 @@ nav li:hover {
 	width: 150px;
 	height: 40px;
 	margin-left: 5px;
+	transition-duration: 0.15s;
+}
+
+#shopButtons > button:hover {
+	background-color: #333333;
 }
 
 #shopHovers {
@@ -1912,11 +1924,21 @@ nav li:hover {
 .consumablebutton {
 	width: 128px;
 	height: 40px;
+	transition-duration: 0.15s;
+}
+
+.consumablebutton:hover {
+	background-color: #333333;
 }
 
 .permshopbutton {
 	width: 100px;
 	height: 40px;
+	transition-duration: 0.15s;
+}
+
+.permshopbutton:hover {
+	background-color: #333333;
 }
 
 #ants {

--- a/Synergism.css
+++ b/Synergism.css
@@ -728,17 +728,22 @@ nav li:hover {
 }
 #buyamountoffering {
 	position: absolute;
-	padding: 0;
-	font-size: 0;
+	font-size: 11px;
+	width: 220px;
 	left: 80%;
-	top: 20px;
+	top: 30px;
+	margin-left: -173px;
+}
+.talismanBuyAmountContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    width: 30%;
 }
 #buyamounttalisman {
-	position: absolute;
-	padding: 0;
-	font-size: 0;
-	left: 80%;
-	top: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 }
 #buyamountmythos {
 	position: absolute;
@@ -773,14 +778,9 @@ nav li:hover {
 	top: 30px;
 	margin-left: -120px;
 }
-#toggletalismanbuy{
-	color: white;
-	position: absolute;
+#toggletalismanbuy {
 	font-size: 11px;
-	width: 220px;
-	left: 80%;
-	top: 30px;
-	margin-left: -118.5px;
+	margin: -4px 0px 5px;
 }
 #togglemythosbuy{
 	color: white;
@@ -855,6 +855,14 @@ nav li:hover {
 #runes {
 	position: relative;
 	padding: 0;
+}
+
+#runeContainer1 {
+	flex-direction: column;
+}
+
+#runeContainer2 {
+	margin-top: 20px;
 }
 
 #runesToggle {
@@ -944,454 +952,107 @@ nav li:hover {
 	margin: auto;
 }
 
-#toggleautofortify {
-	position: absolute;
-	top: 65px;
-	margin-left: 10px;
+#toggleautofortify, #toggleautoenhance {
 	width: 125px;
 	height: 30px;
-	text-align: center;
+	color: white;
+	border: 2px solid red;
+	transition-duration: 0.15s;
 }
-#toggleautoenhance {
-	position: absolute;
-	top: 100px;
-	margin-left: 10px;
-	width: 125px;
-	height: 30px;
-	text-align: center;
+
+#toggleautofortify:hover, #toggleautoenhance:hover {
+	background-color: #333333;
 }
-#talismancounter {
-	position: absolute;
-	top: 45px;
-	width: 800px;
-	left: 30%;
-	margin-left: -370px;
-	text-align: left;
-	font-size: 0.9em;
-}
-#buyfragments {
-	position: absolute;
-	top: 95px;
-	width: 800px;
-	left: 50%;
-	margin-left: -370px;
-	text-align: left;
-	font-size: 0.9em;
-}
+
 #talismanFragmentCost {
-	position: absolute;
-	top: 390px;
-	width: 250px;
-	left: 10.75%;
-	margin-left: -125px;
+    width: 250px;
 	text-align: center;
 	font-size: 1.1em;
-	color: white
+	margin-right: -30px;
+}
+
+.talismanShardsContainer {
+	display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    width: 30%;
+    margin-top: 25px;
+}
+
+.talismanShardContainer {
+	display: flex;
+	align-items: center;
+	margin-bottom: 12px;
+}
+
+.talismanShardIcon {
+	width: 32px;
+}
+
+.talismanShardAmount {
+	min-width: 70px;
+	margin-left: 4px;
+	font-size: 0.9em;
 }
 
 .talismanBtn {
 	height: 30px;
-	width: 108px;
-	text-align: center;
+    width: 80px;
+	min-width: 80px;
 	color: orange;
-	background-color: #171717;
-	cursor: default;
+	cursor: pointer;
 	transition-duration: 0.15s;
 }
+
+.talismanBtn:hover {
+	background-color: #333333;
+}
+
 .talisminBtnAvailable {
 	background-color: purple;
 	cursor: pointer;
 }
+
 .talisminBtnAvailable:hover {
     background-color: #b300b2;
 }
-#TaxTalisman{
-	position: absolute;
-	left: 28%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
+
+.talismansContainer {
+	display: flex;
+	width: 70%;
+    justify-content: space-around;
+    padding: 0 10px;
+}
+
+.talismanContainer {
+	flex-direction: column;
+	width: 11%;
+	min-width: 102px;
+    align-items: center;
+}
+
+.talismanName {
 	font-size: 1.2em;
-}
-#MultiplierAcceleratorTalisman{
-	position: absolute;
-	left: 36%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
 	text-align: center;
-	font-size: 1.2em;
 }
-#CostTalisman{
-	position: absolute;
-	left: 44%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
-	font-size: 1.2em;
-}
-#RunesTalisman{
-	position: absolute;
-	left: 52%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
-	font-size: 1.2em;
-}
-#UnknownTalisman{
-	position: absolute;
-	left: 60%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
-	font-size: 1.2em;
-}
-#AntTalisman{
-	position: absolute;
-	left: 68%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
-	font-size: 1.2em;
-}
-#MoneyTalisman{
-	position: absolute;
-	left: 76%;
-	width: 200px;
-	margin-left: -100px;
-	top: 45px;
-	text-align: center;
-	font-size: 1.2em;
-}
-#talisman1{
-	position: absolute;
-	left: 28%;
+
+.talismanIcon {
 	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
+	border: 4px solid white;
+	cursor: pointer;
 }
 
-#talisman1level{
-	position: absolute;
-	left: 28%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
+.talismanLevel {
+    margin-top: 1px;
+    margin-bottom: 3px;
 }
 
-#leveluptalisman1 {
-	position: absolute;
-	height: 30px;
-	left: 28%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman1{
-	position: absolute;
-	height: 30px;
-	left: 28%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman1{
-	position: absolute;
-	height: 30px;
-	left: 28%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-
-#talisman2{
-	position: absolute;
-	left: 36%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman2level{
-	position: absolute;
-	left: 36%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman2 {
-	position: absolute;
-	height: 30px;
-	left: 36%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman2{
-	position: absolute;
-	height: 30px;
-	left: 36%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman2{
-	position: absolute;
-	height: 30px;
-	left: 36%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-#talisman3{
-	position: absolute;
-	left: 44%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman3level{
-	position: absolute;
-	left: 44%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman3 {
-	position: absolute;
-	height: 30px;
-	left: 44%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman3{
-	position: absolute;
-	height: 30px;
-	left: 44%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman3{
-	position: absolute;
-	height: 30px;
-	left: 44%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-#talisman4{
-	position: absolute;
-	left: 52%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman4level{
-	position: absolute;
-	left: 52%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman4 {
-	position: absolute;
-	height: 30px;
-	left: 52%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman4{
-	position: absolute;
-	height: 30px;
-	left: 52%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman4{
-	position: absolute;
-	height: 30px;
-	left: 52%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-#talisman5{
-	position: absolute;
-	left: 60%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman5level{
-	position: absolute;
-	left: 60%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman5 {
-	position: absolute;
-	height: 30px;
-	left: 60%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman5{
-	position: absolute;
-	height: 30px;
-	left: 60%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman5{
-	position: absolute;
-	height: 30px;
-	left: 60%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-#talisman6{
-	position: absolute;
-	left: 68%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman6level{
-	position: absolute;
-	left: 68%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman6 {
-	position: absolute;
-	height: 30px;
-	left: 68%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman6{
-	position: absolute;
-	height: 30px;
-	left: 68%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman6{
-	position: absolute;
-	height: 30px;
-	left: 68%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
-#talisman7{
-	position: absolute;
-	left: 76%;
-	width: 72px;
-	margin-left: -41px;
-	top: 90px;
-	text-align: center;
-}
-
-#talisman7level{
-	position: absolute;
-	left: 76%;
-	width: 128px;
-	margin-left: -66px;
-	top: 155px;
-	text-align: center;
-}
-
-#leveluptalisman7 {
-	position: absolute;
-	height: 30px;
-	left: 76%;
-	width: 80px;
-	margin-left: -41px;
-	top: 195px;
-	text-align: center;
-}
-#enhancetalisman7{
-	position: absolute;
-	height: 30px;
-	left: 76%;
-	width: 80px;
-	margin-left: -41px;
-	top: 225px;
-	text-align: center;
-}
-#respectalisman7{
-	position: absolute;
-	height: 30px;
-	left: 76%;
-	width: 80px;
-	margin-left: -41px;
-	top: 255px;
-	text-align: center;
-}
 #respecAllTalismans{
-	position: absolute;
 	height: 30px;
-	left: 28%;
 	width: 80px;
-	margin-left: -41px;
-	top: 355px;
-	text-align: center;
+	color: plum;
+	border: 2px solid white;
+	margin-top: 50px;
 }
 #talismanEffect {
 	position: absolute;
@@ -1461,6 +1122,10 @@ nav li:hover {
 	height: 30px;
 	width: 200px;
 	text-align: center;
+	transition-duration: 0.15s;
+}
+.talismanRespecBtn:hover {
+	background-color: #333333;
 }
 #talismanRespecButton1{
 	position: absolute;

--- a/Synergism.css
+++ b/Synergism.css
@@ -503,20 +503,37 @@ nav li:hover {
 #exportButtons > * { margin: .15em 0; }
 
 #importFileButton {
-	border: 1px solid white;
-	width: 100px;
-	margin: 2px auto;
+    border: 2px solid white;
+    width: 176px;
+    margin: 2px auto;
+	padding: 0 0 2px;
+    cursor: pointer;
+    transition-duration: 0.15s;
+}
+
+#importFileButton:hover {
+	background-color: #333333;
 }
 
 #savegame, #deleteGame {
 	width: 180px;
 	margin: 2px auto;
+	transition-duration: 0.15s;
+}
+
+#savegame:hover, #deleteGame:hover {
+	background-color: #333333;
 }
 
 #exportgame {
 	width: 150px;
 	height: 40px;
 	margin: 5px auto;
+	transition-duration: 0.15s;
+}
+
+#exportgame:hover {
+	background-color: #333333;
 }
 
 /* Third party URLs (Discord, Patreon, patch notes) */
@@ -537,6 +554,15 @@ nav li:hover {
 	margin-right: 5px;
 }
 
+#promocodes {
+	transition-duration: 0.15s;
+	padding: 5px;
+}
+
+#promocodes:hover {
+	background-color: #333333;
+}
+
 #promocodeinfo {
 	word-break: break-all;
 	width: 75%;
@@ -554,6 +580,10 @@ nav li:hover {
 .auto.square {
 	width: 40px;
 	height: 40px;
+	transition-duration: 0.15s;
+}
+.auto.square:hover {
+	background-color: #333333;
 }
 
 .buttonRow {
@@ -1526,6 +1556,11 @@ nav li:hover {
 	height: 30px;
 	width: 200px;
 	margin: 7px;
+	transition-duration: 0.15s;
+}
+
+#challengesAutoToggles > button:hover {
+	background-color: #333333
 }
 
 #toggleAutoChallengeStart { border: 2px solid gold; }
@@ -1566,7 +1601,11 @@ nav li:hover {
 	height: 75px;
 	border: 6px solid gold;
 	background-color: black;
-	color: white
+	color: white;
+	transition-duration: 0.15s;
+}
+#startChallenge:hover {
+	background-color: #333333;
 }
 #oneChallengeDetails {
 	display: flex;
@@ -1636,6 +1675,17 @@ nav li:hover {
 #challengehotkeys { color: gray; }
 #challengewarning { color: crimson; }
 #challengewarningreincarnation { color: limegreen; }
+
+.challenge {
+	background-color: #171717;
+	transition-duration: 0.15s;
+}
+.challenge:hover {
+	background-color: #333333;
+}
+.challengeActive {
+	background-color: plum;
+}
 
 #reincarnation {
     position: relative;
@@ -1728,6 +1778,11 @@ nav li:hover {
 	height: 30px;
 	margin: 0 7px;
 	text-align: center;
+	transition-duration: 0.15s;
+}
+
+#researchToggles > button:hover {
+	background-color: #333333;
 }
 
 #researchinfo2 {
@@ -1756,12 +1811,12 @@ nav li:hover {
 	background-color: #b300b2
 }
 
-.researchMaxed {
-	background-color: green;
-}
-
 .researchRoomba {
 	background-color: orange;
+}
+
+.researchMaxed {
+	background-color: green;
 }
 
 #shop {
@@ -1901,20 +1956,28 @@ nav li:hover {
 	margin-left: 200px;
 }
 
-#toggleAntMax{
+#toggleAntMax {
 	position: absolute;
 	height: 30px;
 	width: 100px;
 	right: 51%;
 	border: 1px solid gold;
+	transition-duration: 0.15s;
 }
-#toggleAutoSacrificeAnt{
+#toggleAntMax:hover {
+	background-color: #333333;
+}
+#toggleAutoSacrificeAnt {
 	position: absolute;
 	height: 30px;
 	width: 150px;
 	top: 0;
 	left: 51%;
-	border: 1px solid crimson
+	border: 1px solid crimson;
+	transition-duration: 0.15s;
+}
+#toggleAutoSacrificeAnt:hover {
+	background-color: #333333;
 }
 #autoSacrificeAntMode {
 	position: absolute;
@@ -1924,6 +1987,10 @@ nav li:hover {
 	margin-left: 155px;
 	top: 0;
 	border: 1px solid green;
+	transition-duration: 0.15s;
+}
+#autoSacrificeAntMode:hover {
+	background-color: #333333;
 }
 #autoAntSacrificeAmount {
 	position: absolute;
@@ -2032,6 +2099,11 @@ nav li:hover {
 	width: 250px;
 	height: 30px;
 	margin: 3px;
+	transition-duration: 0.15s;
+}
+
+.cubeSwitchTabBtn:hover {
+	background-color: #333333;
 }
 
 #wowCubeSidebar > p { margin: 0; }
@@ -2059,8 +2131,15 @@ nav li:hover {
 	margin-left: -96px;
 }
 .cubeBtn {
+	width: 100px;
+	height: 30px;
 	color: white;
 	background-color: black;
+	border: 1px solid gold;
+	transition-duration: 0.15s;
+}
+.cubeBtn:hover {
+	background-color: #333333;
 }
 
 p[id$="BlessingsTotal"] {
@@ -2108,12 +2187,6 @@ p[id$="BlessingsTotal"] {
 	grid-row: 2;
 	grid-column: 2;
 	margin-left: 10px;
-}
-
-.openBtn > button {
-	width: 100px;
-	height: 30px;
-	border: 1px solid gold;
 }
 
 .cubeBonus{
@@ -2533,18 +2606,17 @@ p[id$="BlessingsTotal"] {
 	padding: 10px;
 	border: 1px solid orange;
 }
-#corrStatsBtn {
+#corrStatsBtn, #corrLoadoutsBtn {
 	width: 120px;
 	height: 25px;
 	border: 2px solid;
+	transition-duration: 0.15s;
+}
+#corrStatsBtn:hover, #corrLoadoutsBtn:hover {
+	background-color: #333333;
 }
 #corrButtonRow {
 	min-width: 300px;
-}
-#corrLoadoutsBtn {
-	width: 120px;
-	height: 25px;
-	border: 2px solid;
 }
 .corruptionStatRow {
 	display: flex;
@@ -2568,18 +2640,22 @@ p[id$="BlessingsTotal"] {
 	height: 30px;
 	margin: 5px;
 	padding: 3px;
+	transition-duration: 0.15s;
+}
+.corrBtn:hover {
+	background-color: #333333;
 }
 .corruptionMax {
-	border: 2px solid green;
+	border: 2px solid green !important;
 }
 .corruptionUp {
-	border: 1px solid green;
+	border: 1px solid green !important;
 }
 .corruptionDown {
-	border: 1px solid red;
+	border: 1px solid red !important;
 }
 .corruptionReset {
-	border: 2px solid red;
+	border: 2px solid red !important;
 }
 
 #corruptionLoadouts {
@@ -2594,20 +2670,27 @@ img.small {
 	height: 32px;
 }
 .corrSave {
-	padding: 3px 4px;
 	border: 1px solid dodgerblue;
 	margin-left: 10px;
+	padding: 3px 4px;
+	transition-duration: 0.15s;
 }
 .corrLoad {
-	padding: 3px 4px;
 	border: 1px solid #5b5ddc;
+	padding: 3px 4px;
+	transition-duration: 0.15s;
+}
+
+.corrSave:hover, .corrLoad:hover {
+	background-color: #333333;
 }
 
 #corruptionCleanse {
 	height: 30px;
 	width: 150px;
 	margin: auto 20px auto;
-	border: 2px solid darkmagenta
+	border: 2px solid darkmagenta;
+	transition-duration: 0.15s;
 }
 #corruptionCleanseConfirm {
 	height: 30px;
@@ -2615,6 +2698,11 @@ img.small {
 	margin: auto;
 	border: 2px solid green;
 	visibility: hidden;
+	transition-duration: 0.15s;
+}
+
+#corruptionCleanse:hover, #corruptionCleanseConfirm:hover {
+	background-color: #333333;
 }
 
 header {

--- a/index.html
+++ b/index.html
@@ -1417,21 +1417,21 @@
                 </div>
                 <table id="challengeIcons">
                     <tr>
-                        <td><img id="challenge1" src="Pictures/Transparent Pics/ChallengeOne.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge2" src="Pictures/Transparent Pics/ChallengeTwo.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge3" src="Pictures/Transparent Pics/ChallengeThree.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge4" src="Pictures/Transparent Pics/ChallengeFour.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge5" src="Pictures/Transparent Pics/ChallengeFive.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge6" class="reincarnationunlock" src="Pictures/Transparent Pics/ChallengeSix.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge7" class="chal6" src="Pictures/Transparent Pics/ChallengeSeven.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge8" class="chal7" src="Pictures/Transparent Pics/ChallengeEight.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge9" class="chal8" src="Pictures/Transparent Pics/ChallengeNine.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge10" class="chal9" src="Pictures/Transparent Pics/ChallengeTen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge11" class="ascendunlock" src="Pictures/Transparent Pics/ChallengeEleven.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge12" class="chal11" src="Pictures/Transparent Pics/ChallengeTwelve.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge13" class="chal12" src="Pictures/Transparent Pics/ChallengeThirteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge14" class="chal13" src="Pictures/Transparent Pics/ChallengeFourteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
-                        <td><img id="challenge15" class="chal14" src="Pictures/Transparent Pics/ChallengeFifteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge1" class="challenge" src="Pictures/Transparent Pics/ChallengeOne.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge2" class="challenge" src="Pictures/Transparent Pics/ChallengeTwo.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge3" class="challenge" src="Pictures/Transparent Pics/ChallengeThree.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge4" class="challenge" src="Pictures/Transparent Pics/ChallengeFour.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge5" class="challenge" src="Pictures/Transparent Pics/ChallengeFive.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge6" class="challenge reincarnationunlock" src="Pictures/Transparent Pics/ChallengeSix.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge7" class="challenge chal6" src="Pictures/Transparent Pics/ChallengeSeven.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge8" class="challenge chal7" src="Pictures/Transparent Pics/ChallengeEight.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge9" class="challenge chal8" src="Pictures/Transparent Pics/ChallengeNine.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge10" class="challenge chal9" src="Pictures/Transparent Pics/ChallengeTen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge11" class="challenge ascendunlock" src="Pictures/Transparent Pics/ChallengeEleven.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge12" class="challenge chal11" src="Pictures/Transparent Pics/ChallengeTwelve.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge13" class="challenge chal12" src="Pictures/Transparent Pics/ChallengeThirteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge14" class="challenge chal13" src="Pictures/Transparent Pics/ChallengeFourteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
+                        <td><img id="challenge15" class="challenge chal14" src="Pictures/Transparent Pics/ChallengeFifteen.png" style="cursor: pointer; font-size: 0;" alt=""></td>
                     </tr>
                     <tr>
                         <td ><div class="challengeLevels" class="challengeLevels" id="challenge1level">0 / 25</div></td>
@@ -1873,10 +1873,10 @@
                         <img class="openImage" src="Pictures/WowCube.png" alt="">
                         <p class="inventory" style="color: white">You possess <span id="cubeQuantity" style="color: yellow">13</span> Wow! Cubes. Get more from harder Ascensions and other stuff.</p>
                         <div class="openBtn"> 
-                            <button id="open1Cube">Open x1</button>
-                            <button id="open20Cube">Open x20</button>
-                            <button id="open1000Cube">Open x1,000</button>
-                            <button id="openMostCube">Open All</button>
+                            <button class="cubeBtn" id="open1Cube">Open x1</button>
+                            <button class="cubeBtn" id="open20Cube">Open x20</button>
+                            <button class="cubeBtn" id="open1000Cube">Open x1,000</button>
+                            <button class="cubeBtn" id="openMostCube">Open All</button>
                         </div>
                     </div>
 
@@ -2477,17 +2477,17 @@
                 <input type="checkbox" id="saveType" name="saveType">
                 <label style="display: inline;" for="saveType">Copy to Clipboard</label>
             </div>
-            <button id="exportgame" style="border:2px solid green">Export the game here.</button>
+            <button id="exportgame" style="border:2px solid green">Export the game here</button>
             <p id="exportinfo" class="tightText" style="color: white"></p>
             <label title="Use $VERSION$ for version, $TIME$ for 24h time, $TIME12$ for 12h">
                 <input id="saveStringInput">
             </label>
             <p id="saveString" class="tightText" title="Use $VERSION$ for version, $TIME$ for 24h time, $TIME12$ for 12h"></p>
             <p id="importgame" class="tightText" style="color: limegreen">Load game below!</p>
-            <label id="importFileButton" for="importfile">Choose File</label>
+            <label id="importFileButton" for="importfile">Load from file</label>
             <input type="file" id="importfile" accept=".txt" style="display: none">
-            <button id="savegame" style="border: 2px solid plum">Save the game manually.</button>
-            <button id="deleteGame" style="border: 2px solid red">Delete Savefile</button>
+            <button id="savegame" style="border: 2px solid plum">Save the game manually</button>
+            <button id="deleteGame" style="border: 2px solid red">Delete savefile</button>
             <p id="saveinfo" style="color: limegreen"></p>
         </div>
         <div id="thirdParty">

--- a/index.html
+++ b/index.html
@@ -1197,118 +1197,119 @@
             </div>
 
             <div id="runeContainer2" style="display: none;">
-                <div id="buyamounttalisman">
-                <table id="talismanbuyamount">
-                    <tr>
-                        <td><img id="talismanTen" src="Pictures/Transparent Pics/TalismanTen.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                        <td><img id="talismanTwentyFive" src="Pictures/Transparent Pics/TalismanTwentyFive.png"  style="cursor:pointer;" alt=""></td>
-                        <td><img id="talismanFifty" src="Pictures/Transparent Pics/TalismanFifty.png"  style="cursor:pointer;" alt=""></td>
-                        <td><img id="talismanHundred" src="Pictures/Transparent Pics/TalismanHundred.png"  style="cursor:pointer;" alt=""></td>
-                    </tr>
-                </table>
-                <button id="toggleautoenhance" style="border: 2px solid red; color: white">Auto Enhance: OFF</button>
-                <button id="toggleautofortify" style="border: 2px solid red; color: white">Auto Enhance: OFF</button>
-                <p id="toggletalismanbuy">Toggle percent resources used</p>
+                <div class="talismanShardsContainer">
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/TalismanShard.png" title='Talisman Shard' alt=""></img>
+                        <span class="talismanShardAmount" id="talismanShardInventory" style="color: yellow">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem1" style="border: 2px solid gold">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/CommonTalisman.png" title='Common Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="commonFragmentInventory" style="color: white">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem2" style="border:2px solid white">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/UncommonTalisman.png" title='Uncommon Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="uncommonFragmentInventory" style="color: limegreen">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem3" style="border:2px solid lime">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/RareTalisman.png" title='Rare Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="rareFragmentInventory" style="color: darkcyan">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem4" style="border:2px solid aqua">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/EpicTalisman.png" title='Epic Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="epicFragmentInventory" style="color: plum">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem5" style="border:2px solid purple">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/LegendaryTalisman.png" title='Legendary Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="legendaryFragmentInventory" style="color: orange">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem6" style="border:2px solid orange">BUY</button>
+                    </div>
+                    <div class="talismanShardContainer">
+                        <img class="talismanShardIcon" src="Pictures/MythicalTalisman.png" title='Mythical Fragment' alt=""></img>
+                        <span class="talismanShardAmount" id="mythicalFragmentInventory" style="color: crimson">0</span>
+                        <button class="talismanBtn" id="buyTalismanItem7" style="border:2px solid red">BUY</button>
+                    </div>
+                    <span id="talismanFragmentCost">Cost for 1: 1e6 Obtainium</span>
                 </div>
-                <table id="talismancounter" style="table-layout: fixed;">
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/TalismanShard.png" title='Talisman Shard' style="font-size:0;" alt=""></td>
-                        <td style="width: 66px; color: yellow"><p id="talismanShardInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem1" style="border: 2px solid gold">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/CommonTalisman.png" title='Common Fragment' style="font-size:0;" alt=""></td>
-                        <td style="width: 68px; color: white"><p id="commonFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem2" style="border:2px solid white">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/UncommonTalisman.png" title='Uncommon Fragment' style="font-size:0;" alt=""></td>
-                        <td style="width: 68px; color: limegreen"><p id="uncommonFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem3" style="border:2px solid lime">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/RareTalisman.png" title='Rare Fragment' style="font-size:0;"  alt=""></td>
-                        <td style="width: 68px; color: darkcyan"><p id="rareFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem4" style="border:2px solid aqua">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/EpicTalisman.png" title='Epic Fragment' style="font-size:0;"  alt=""></td>
-                        <td style="width: 68px; color: plum"><p id="epicFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem5" style="border:2px solid purple">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/LegendaryTalisman.png" title='Legendary Fragment' style="font-size:0;"  alt=""></td>
-                        <td style="width: 68px; color: orange"><p id="legendaryFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem6" style="border:2px solid orange">BUY</button></td>
-                    </tr>
-                    <tr>
-                        <td style="font-size: 0; width: 32px"><img src="Pictures/MythicalTalisman.png" title='Mythical Fragment' style="font-size:0;" alt=""></td>
-                        <td style="width: 68px; color: crimson"><p id="mythicalFragmentInventory">0</p></td>
-                        <td><button class="talismanBtn" id="buyTalismanItem7" style="border:2px solid red">BUY</button></td>
-                    </tr>
-                </table>
-                <table id="buyfragments">
-
-                </table>
-                <p id="talismanFragmentCost">Cost for 1: 1e6 Obtainium</p>
-                <div id="talisman1area">
-                    <p id="TaxTalisman" style="color: limegreen;">Exemption</p>
-                    <img id="talisman1" src="Pictures/taxtalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman1level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman1" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman1" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman1" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman2area">
-                    <p id="MultiplierAcceleratorTalisman" style="color: cyan">Chronos</p>
-                    <img id="talisman2" src="Pictures/noMA.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman2level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman2" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman2" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman2" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman3area">
-                    <p id="CostTalisman" style="color: orange">Midas</p>
-                    <img id="talisman3" src="Pictures/CostTalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman3level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman3" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman3" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman3" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman4area">
-                    <p id="RunesTalisman" style="color: salmon">Metaphysics</p>
-                    <img id="talisman4" src="Pictures/RunesTalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman4level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman4" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman4" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman4" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman5area">
-                    <p id="UnknownTalisman" style="color: crimson">Polymath</p>
-                    <img id="talisman5" src="Pictures/PolymathTalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman5level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman5" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman5" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman5" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman6area">
-                    <p id="AntTalisman" style="color: burlywood">Mortuus Est</p>
-                    <img id="talisman6" src="Pictures/AntTalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman6level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman6" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman6" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman6" style="color: plum; border: 2px solid white">RESPEC</button>
-                </div>
-                <div id="talisman7area">
-                    <p id="MoneyTalisman" style="color: chartreuse">Plastic</p>
-                    <img id="talisman7" src="Pictures/P2WTalisman.png" style="border: 4px solid white; cursor: pointer;" alt="">
-                    <p id="talisman7level" style="color: white">Level 0/30</p>
-                    <button id="leveluptalisman7" style="color: silver; border: 2px solid white;">FORTIFY</button>
-                    <button id="enhancetalisman7" style="color: gold; border: 2px solid orangered">ENHANCE</button>
-                    <button id="respectalisman7" style="color: plum; border: 2px solid white">RESPEC</button>
+                <div class="talismansContainer">
+                    <div class="talismanContainer" id="talisman1area">
+                        <span class="talismanName" style="color: limegreen;">Exemption</span>
+                        <img class="talismanIcon" id="talisman1" src="Pictures/taxtalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman1level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman1" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman1" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman1" style="color: plum; border: 2px solid white">RESPEC</button>
+                        <button class="talismanBtn" id="respecAllTalismans">RESPEC ALL</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman2area">
+                        <span class="talismanName" style="color: cyan">Chronos</span>
+                        <img class="talismanIcon" id="talisman2" src="Pictures/noMA.png" alt="">
+                        <span class="talismanLevel" id="talisman2level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman2" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman2" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman2" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman3area">
+                        <span class="talismanName" style="color: orange">Midas</span>
+                        <img class="talismanIcon" id="talisman3" src="Pictures/CostTalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman3level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman3" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman3" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman3" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman4area">
+                        <span class="talismanName" style="color: salmon">Metaphysics</span>
+                        <img class="talismanIcon" id="talisman4" src="Pictures/RunesTalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman4level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman4" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman4" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman4" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman5area">
+                        <span class="talismanName" style="color: crimson">Polymath</span>
+                        <img class="talismanIcon" id="talisman5" src="Pictures/PolymathTalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman5level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman5" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman5" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman5" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman6area">
+                        <span class="talismanName" style="color: burlywood">Mortuus Est</span>
+                        <img class="talismanIcon" id="talisman6" src="Pictures/AntTalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman6level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman6" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman6" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman6" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
+                    <div class="talismanContainer" id="talisman7area">
+                        <span class="talismanName" style="color: chartreuse">Plastic</span>
+                        <img class="talismanIcon" id="talisman7" src="Pictures/P2WTalisman.png" alt="">
+                        <span class="talismanLevel" id="talisman7level" style="color: white">Level 0/30</span>
+                        <button class="talismanBtn" id="leveluptalisman7" style="color: silver; border: 2px solid white;">FORTIFY</button>
+                        <button class="talismanBtn" id="enhancetalisman7" style="color: gold; border: 2px solid orangered">ENHANCE</button>
+                        <button class="talismanBtn" id="respectalisman7" style="color: plum; border: 2px solid white">RESPEC</button>
+                    </div>
                 </div>
 
-                <button id="respecAllTalismans" style="color: plum; border: 2px solid white">RESPEC ALL</button>
+                <div class="talismanBuyAmountContainer">
+                    <div id="buyamounttalisman">
+                        <table>
+                            <tr>
+                                <td><img id="talismanTen" src="Pictures/Transparent Pics/TalismanTen.png" style="cursor:pointer; background-color: green;" alt=""></td>
+                                <td><img id="talismanTwentyFive" src="Pictures/Transparent Pics/TalismanTwentyFive.png"  style="cursor:pointer;" alt=""></td>
+                                <td><img id="talismanFifty" src="Pictures/Transparent Pics/TalismanFifty.png"  style="cursor:pointer;" alt=""></td>
+                                <td><img id="talismanHundred" src="Pictures/Transparent Pics/TalismanHundred.png"  style="cursor:pointer;" alt=""></td>
+                            </tr>
+                        </table>
+                        <span id="toggletalismanbuy">Toggle percent resources used</span>
+                        <button id="toggleautoenhance">Auto Enhance: OFF</button>
+                        <button id="toggleautofortify">Auto Enhance: OFF</button>
+                    </div>
+                </div>
 
                 <div id="talismanEffect">
                     <p id="talismanSummary" style="color: silver"></p>

--- a/src/Research.ts
+++ b/src/Research.ts
@@ -37,8 +37,9 @@ export const buyResearch = (index: number, auto = false, linGrowth = 0): boolean
 
     // Handles toggling auto research focus, for when cube Upgrade 1x9 is NOT BOUGHT
     if (!auto && player.autoResearchToggle && player.shopUpgrades.obtainiumAuto >= 1 && player.cubeUpgrades[9] < 1) {
-        player.autoResearch = index;
+        document.getElementById(`res${player.autoResearch}`).classList.remove("researchRoomba");
         document.getElementById(`res${index}`).classList.add("researchRoomba");
+        player.autoResearch = index;
     }
 
     // Buys Research. metaData returns amount of levels to buy and cost, array
@@ -49,6 +50,9 @@ export const buyResearch = (index: number, auto = false, linGrowth = 0): boolean
     if ((auto || !player.autoResearchToggle) && isResearchUnlocked(index) && !isResearchMaxed(index) && canAfford) {
         player.researchPoints -= metaData[1]
         player.researches[index] = metaData[0];
+        if (isResearchMaxed(player.autoResearch)) {
+            document.getElementById(`res${player.autoResearch || 1}`).classList.remove("researchRoomba");
+        }
 
         //Updates Progress Description
         G['researchfiller2'] = "Level: " + player.researches[index] + "/" + (G['researchMaxLevels'][index])

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -486,7 +486,7 @@ export const toggleRuneScreen = (index: number) => {
         if (i === index) {
             a.style.border = "2px solid gold"
             a.style.backgroundColor = "crimson"
-            b.style.display = "block";
+            b.style.display = "flex";
         } else {
             a.style.border = "2px solid silver"
             a.style.backgroundColor = ""

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -670,7 +670,7 @@ export const toggleCubeSubTab = (i: number) => {
             cubeTab.style.display = "block"
             player.subtabNumber = j - 1
         }
-        document.getElementById("switchCubeSubTab" + j).style.backgroundColor = i === j ? "crimson" : "#171717"
+        document.getElementById("switchCubeSubTab" + j).style.backgroundColor = i === j ? "crimson" : ""
     }
 
     visualUpdateCubes();

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -196,15 +196,15 @@ export const revealStuff = () => {
     (document.getElementById("rune4area").style.display = "none", document.getElementById("runeshowpower4").style.display = "none");
 
     player.achievements[119] === 1 ? //Tax+ Challenge Achievement 7
-        document.getElementById("talisman1area").style.display = "block" :
+        document.getElementById("talisman1area").style.display = "flex" :
         document.getElementById("talisman1area").style.display = "none";
 
     player.achievements[126] === 1 ? //No MA Challenge Achievement 7
-        document.getElementById("talisman2area").style.display = "block" :
+        document.getElementById("talisman2area").style.display = "flex" :
         document.getElementById("talisman2area").style.display = "none";
 
     player.achievements[133] === 1 ? //Cost++ Challenge Achievement 7
-        document.getElementById("talisman3area").style.display = "block" :
+        document.getElementById("talisman3area").style.display = "flex" :
         document.getElementById("talisman3area").style.display = "none";
 
     player.achievements[134] === 1 ? //No Runes Challenge Achievement 1
@@ -212,11 +212,11 @@ export const revealStuff = () => {
         (document.getElementById("toggleRuneSubTab2").style.display = "none", document.getElementById("toggleRuneSubTab3").style.display = "none");
 
     player.achievements[140] === 1 ? //No Runes Challenge Achievement 7
-        document.getElementById("talisman4area").style.display = "block" :
+        document.getElementById("talisman4area").style.display = "flex" :
         document.getElementById("talisman4area").style.display = "none";
 
     player.achievements[147] === 1 ? //Sadistic Challenge Achievement 7
-        document.getElementById("talisman5area").style.display = "block" :
+        document.getElementById("talisman5area").style.display = "flex" :
         document.getElementById("talisman5area").style.display = "none";
 
     player.achievements[173] === 1 ? //Galactic Crumb Achievement 5
@@ -262,7 +262,7 @@ export const revealStuff = () => {
         document.getElementById("autotessbuyeramount").style.display = "block" :
         document.getElementById("autotessbuyeramount").style.display = "none";
     (player.antUpgrades[12-1] > 0 || player.ascensionCount > 0) ? //Ant Talisman Unlock, Mortuus
-        document.getElementById("talisman6area").style.display = "block" :
+        document.getElementById("talisman6area").style.display = "flex" :
         document.getElementById("talisman6area").style.display = "none";
 
     player.shopUpgrades.offeringAuto > 0 ? //Auto Offering Shop Purchase
@@ -274,7 +274,7 @@ export const revealStuff = () => {
         document.getElementById("toggleautoresearch").style.display = "none";
 
     player.shopUpgrades.shopTalisman > 0 ? //Plastic Talisman Shop Purchase
-        document.getElementById("talisman7area").style.display = "block" :
+        document.getElementById("talisman7area").style.display = "flex" :
         document.getElementById("talisman7area").style.display = "none";
 
     player.cubeUpgrades[8] > 0 ?

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -663,21 +663,17 @@ export const buttoncolorchange = () => {
 
 export const updateChallengeDisplay = () => {
     //Sets background colors on load/challenge initiation
-    for (let k = 1; k <= 10; k++) {
-        const el = document.getElementById("challenge" + k)
-        el.style.backgroundColor = "#171717"
+    for (let k = 1; k <= 15; k++) {
+        const el = document.getElementById(`challenge${k}`)
+        el.classList.remove("challengeActive")
         if (player.currentChallenge.transcension === k) {
-            el.style.backgroundColor = "plum"
+            el.classList.add("challengeActive")
         }
         if (player.currentChallenge.reincarnation === k) {
-            el.style.backgroundColor = "plum"
+            el.classList.add("challengeActive")
         }
-    }
-    for (let k = 11; k <= 15; k++) {
-        const el = document.getElementById("challenge" + k)
-        el.style.backgroundColor = "#171717"
         if (player.currentChallenge.ascension === k) {
-            el.style.backgroundColor = "plum"
+            el.classList.add("challengeActive")
         }
     }
     //Corrects HTML on retry challenges button


### PR DESCRIPTION
- fixed auto research classes sticking on researches before unlocking the roomba
- added hover effects to the confirmation toggles, save/delete save buttons, choose file button, export game button, promo code button, research level and auto buttons, ant max/auto sac/auto sac mode buttons, challenges, challenge enter/sweep/retry/auto buttons, corruption stat/loadout/cleanse/cleanse confirm/save and load/add and subtract buttons, talisman fortify/enhance/respec/respec all/respec settings/auto buttons, shop buttons, modal buttons, cube tab subtab buttons, and all cube tier open buttons
- made the corruption up/down buttons border color not change on select
- added a pointer cursor to and changed look and wording on the choose file button
- made the promo code button larger
- standardized the lack of punctuation and first capital letter only on all save related buttons
- made wow cube open buttons black to match all other cube tiers
- remade most of the talisman tab in flexbox to scale better on wider screens and fit entirely into the smallest screen size