### PR TITLE
css fixes/changes and even more hover effects

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -760,6 +760,17 @@ nav li:hover {
 	top: 0;
 	left: 80%;
 }
+
+.buyAmountBtn {
+	background-color: black;
+	cursor: pointer;
+	transition-duration: 0.15s;
+}
+
+.buyAmountBtn:hover {
+	background-color: #333;
+}
+
 #togglecrystalbuy{
 	color: white;
 	position: absolute;
@@ -842,7 +853,15 @@ nav li:hover {
 	margin-top: 35px;
 }
 
-#toggle15, #prestigeautotoggle { width: 150px; }
+#toggle15, #prestigeautotoggle, #prestigeamount { width: 150px; }
+
+#toggle15, #prestigeautotoggle {
+	transition-duration: 0.15s;
+}
+
+#toggle15:hover, #prestigeautotoggle:hover {
+	background-color: #333333;
+}
 
 #prestigehotkeys{
 	width: 1200px;
@@ -1195,6 +1214,14 @@ nav li:hover {
 	margin: 0 auto; 
 }
 
+#toggle21, #transcendautotoggle {
+	transition-duration: 0.15s;
+}
+
+#toggle21:hover, #transcendautotoggle:hover {
+	background-color: #333333;
+}
+
 #transcendhotkeys{
 	color: gray;
 	text-align: center;
@@ -1363,6 +1390,14 @@ nav li:hover {
 #toggle27 { margin-top: 55px; }
 
 #toggle27, #reincarnationamount, #reincarnateautotoggle { width: 150px; }
+
+#toggle27, #reincarnateautotoggle {
+	transition-duration: 0.15s;
+}
+
+#toggle27:hover, #reincarnateautotoggle:hover {
+	background-color: #333333;
+}
 
 #reincarnateautomation > div {
 	display: flex;
@@ -1977,11 +2012,20 @@ p[id$="BlessingsTotal"] {
 	width: 150px;
 }
 
+#tesseractautobuytoggle {
+	transition-duration: 0.15s;
+}
+
+#tesseractautobuytoggle:hover {
+	background-color: #333333;
+}
+
 #tesseractAmount{
 	border: 1px solid green;
 	color: white;
 	background-color: black
 }
+
 
 #autotessbuyeramount{
 	color: white;
@@ -2131,6 +2175,11 @@ p[id$="BlessingsTotal"] {
 
 #historyTogglePerSecondButton {
 	float: right;
+	transition-duration: 0.15s;
+}
+
+#historyTogglePerSecondButton:hover {
+	background-color: #333333;
 }
 
 .onOffToggle {
@@ -2266,11 +2315,14 @@ p[id$="BlessingsTotal"] {
 #autoAscend {
 	color: white
 }
-#ascensionAutoEnable {
+
+#ascensionAutoEnable, #ascensionAutoToggle {
 	width: 150px;
+	transition-duration: 0.15s;
 }
-#ascensionAutoToggle {
-	width: 150px;
+
+#ascensionAutoEnable:hover, #ascensionAutoToggle:hover {
+	background-color: #333333;
 }
 
 #corruptionStatsLoadouts {

--- a/Synergism.css
+++ b/Synergism.css
@@ -1029,6 +1029,7 @@ nav li:hover {
 	width: 11%;
 	min-width: 102px;
     align-items: center;
+	white-space: nowrap;
 }
 
 .talismanName {
@@ -1254,18 +1255,13 @@ nav li:hover {
 }
 
 #challengeDetails {
-	display: grid;
-	margin-left: 200px;
-	grid-template-columns: 400px 10px 600px;
-	grid-template-rows: 200px 200px ;
-	grid-template-areas: 
-	"main . sidebar"
-	"main . sidebar";
+	display: flex;
+	justify-content: center;
+	margin-top: 20px;
 }
 
 #challengeTimers {
-	grid-area: main;
-	margin: auto;
+	margin-right: 20px;
 }
 #startChallenge {
 	font-size: 1.1em;
@@ -1281,28 +1277,15 @@ nav li:hover {
 }
 #oneChallengeDetails {
 	display: flex;
-	grid-area: sidebar;
-	margin: 0;
+    flex-direction: column;
+    justify-content: flex-start;
+	width: 600px;
 }
 #oneChallengeDetails > p {
 	margin: auto;
 	height: auto;
 }
 
-/*
-#challengeDetails {
-	display: flex;
-	flex-direction: row;
-	text-align: left;
-	justify-content: center;
-	margin-top: 10px;
-}
-
-#oneChallengeDetails > p { 
-	margin: 0; 
-	margin-left: 30px;
-}
-*/
 #challengeName { color: white; }
 #challengeFlavor { color:plum; }
 #challengeRestrictions { color:crimson; }
@@ -1633,21 +1616,25 @@ nav li:hover {
 
 #antrow3 > p { margin: 5px }
 
-#antToggleFeatures{
-	position: absolute;
-	padding: 0;
-	top: 474px;
-	width: 1000px;
-	height: 100px;
-	text-align: center;
-	margin-left: 200px;
+#antToggleFeatures {
+    display: flex;
+    justify-content: center;
+}
+
+#antSacrificeButtons {
+	display: flex;
+	flex-direction: column;
+}
+
+.antSacrificeButtonsContainer {
+	display: flex;
+	justify-content: center;
 }
 
 #toggleAntMax {
-	position: absolute;
 	height: 30px;
 	width: 100px;
-	right: 51%;
+    margin-right: -110px;
 	border: 1px solid gold;
 	transition-duration: 0.15s;
 }
@@ -1655,11 +1642,9 @@ nav li:hover {
 	background-color: #333333;
 }
 #toggleAutoSacrificeAnt {
-	position: absolute;
 	height: 30px;
 	width: 150px;
-	top: 0;
-	left: 51%;
+	margin-right: 10px;
 	border: 1px solid crimson;
 	transition-duration: 0.15s;
 }
@@ -1667,12 +1652,8 @@ nav li:hover {
 	background-color: #333333;
 }
 #autoSacrificeAntMode {
-	position: absolute;
 	height: 20px;
 	width: 150px;
-	left: 51%;
-	margin-left: 155px;
-	top: 0;
 	border: 1px solid green;
 	transition-duration: 0.15s;
 }
@@ -1680,15 +1661,9 @@ nav li:hover {
 	background-color: #333333;
 }
 #autoAntSacrificeAmount {
-	position: absolute;
 	width: 150px;
-	left: 51%;
-	margin-left: 155px;
-	top: 21px;
 }
 #autoAntSacrifice {
-	position: absolute;
-	top: 25px;
 	text-align: center;
 	width: 100%;
 }
@@ -1708,6 +1683,11 @@ nav li:hover {
 	top: 70px;
 	text-align: center;
 	left: 70%;
+}
+
+.antSacrificeSettingsContainer {
+	display: flex;
+	flex-direction: column;
 }
 
 

--- a/Synergism.css
+++ b/Synergism.css
@@ -1749,10 +1749,8 @@ nav li:hover {
 #wowCubeSidebar {
 	display: flex;
 	flex-direction: column;
-	margin-left: 4.5%;
-	margin-top: 25%;
+	margin-right: 2%;
 	text-align: center;
-	grid-area: sidebar;
 }
 
 #wowCubeSidebarButtons {
@@ -1819,35 +1817,25 @@ p[id$="BlessingsTotal"] {
 #platonicBlessingsTotal { color: orange; }
 
 #cubesWrapper {
-	display: grid;
-	grid-template-columns: 4% [sidebar] 20% 4% [tab] 50%;
-}
-
-#cubesWrapper > div[id^="cubeTab"] {
-	grid-area: tab;
-	margin-top: 15px;
-}
-
-#cubesWrapper > div[id^="cubeTab"] > p {
-	text-align: center;
-	margin: 2px;
+	display: flex;
+	justify-content: center;
+	margin-top: 40px;
+	margin-left: -185px;
 }
 
 .openGrid {
-	display: grid;
-	grid-template-columns: 64px 700px;
-	grid-template-rows: 32px auto;
+	display: flex;
+	align-self: flex-start;
 }
 
 .openImage {
-	grid-row: 1/3;
-	grid-column: 1;
+	height: 64px;
+	width: 64px;
 }
 
 .inventory {
-	grid-row: 1;
-	grid-column: 2;
-	margin: .5% 10px;
+	white-space: nowrap;
+    margin: 6px 10px;
 }
 
 .openBtn {
@@ -1856,23 +1844,41 @@ p[id$="BlessingsTotal"] {
 	margin-left: 10px;
 }
 
+.openButtons {
+	display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
 .cubeBonus{
-	margin-left: 2.5%;
+	margin-left: -2px;
 	margin-top: 5px;
+	width: 100%;
 }
 .cubeIcon {
 	border-spacing: 0;
+}
+
+.cubeTab {
+	flex-direction: column;
+	align-items: center;
+	width: 700px;
 }
 
 #cubeTab5Wrapper {
 	display: flex;
 	flex-direction: column;
 	align-items: center;
-	width: 85%;
+	width: 700px;
 	margin-top: 15px;
 }
 
 #cubeTab5Wrapper > p { margin: 2px; }
+
+#cubeTab6 {
+	flex-direction: row;
+    align-items: flex-start;
+}
 
 #cube1Bonus{
 	width: 1500px;
@@ -2494,9 +2500,7 @@ header #obtainiumDisplay {
 }
 
 #c15Rewards{
-	position: absolute;
-	top: 65px;
-	left: 25%
+
 }
 .challengeContainer {
 	width: 410px;
@@ -2524,18 +2528,18 @@ header #obtainiumDisplay {
 	font-size: 1em;
 }
 
-#platonicUpgrades{
-	position: absolute;
-	left: 60%;
-	top: 65px;
+.platonicUpgradesContainer {
+	display: flex;
+	flex-direction: column;
+	margin-left: 50px;
 }
+
+#platonicUpgrades {
+	margin-bottom: 50px;
+}
+
 .platonicUpgradeImage{
 	cursor: pointer;
-}
-#platonicUpgradeDescriptions{
-	position: absolute;
-	left: 60%;
-	top: 210px;
 }
 .platonicContainer {
 	width: 400px;

--- a/index.html
+++ b/index.html
@@ -1467,20 +1467,20 @@
                         </div>
                     </div>
                     <div id="oneChallengeDetails" style="display:none">
-                        <p id="challengeName">No Multiplier || Completions: 0/25</p>
-                        <p id="challengeFlavor">Multipliers make the game a little fast, let's take them out!</p>
-                        <p id="challengeRestrictions">Restriction: No Multipliers</p>
+                        <span id="challengeName">No Multiplier || Completions: 0/25</span>
+                        <span id="challengeFlavor">Multipliers make the game a little fast, let's take them out!</span>
+                        <span id="challengeRestrictions">Restriction: No Multipliers</span>
                         <br>
-                        <p id="challengeGoal">Gain 1e10 Coins</p>
-                        <p id="challengePerCompletionRewards">Per Completion Bonuses <span id="completionSoftcap" style="color: orchid"></span></p>
-                        <p id="challengePer1">+10% Multiplier Boosts <span id="challengeCurrent1" style="color:orchid">Current: 0</span></p>
-                        <p id="challengePer2">+10 base Multiplier Boosts <span id="challengeCurrent2" style="color:orchid">Current: 0</span></p>
-                        <p id="challengePer3">--- <span id="challengeCurrent3" style="color:orchid">Current: 0</span></p>
+                        <span id="challengeGoal">Gain 1e10 Coins</span>
+                        <span id="challengePerCompletionRewards">Per Completion Bonuses <span id="completionSoftcap" style="color: orchid"></span></span>
+                        <span id="challengePer1">+10% Multiplier Boosts <span id="challengeCurrent1" style="color:orchid">Current: 0</span></span>
+                        <span id="challengePer2">+10 base Multiplier Boosts <span id="challengeCurrent2" style="color:orchid">Current: 0</span></span>
+                        <span id="challengePer3">--- <span id="challengeCurrent3" style="color:orchid">Current: 0</span></span>
                         <br>
-                        <p id="challengeFirstCompletionRewards">Bonus/Unlock for First Completion</p>
-                        <p id="challengeFirst1">+1 Free Multiplier!</p>
+                        <span id="challengeFirstCompletionRewards">Bonus/Unlock for First Completion</span>
+                        <span id="challengeFirst1">+1 Free Multiplier!</span>
                         <br>
-                        <p id="challengeQuarkBonus">+1 Quarks</p>
+                        <span id="challengeQuarkBonus">+1 Quarks</span>
                     </div>
                 </div>
 
@@ -1781,10 +1781,14 @@
                 <div id="antToggleFeatures">
                     <button id="toggleAntMax">Buy Max: ON</button>
                     <div id="antSacrificeButtons">
-                        <button id="toggleAutoSacrificeAnt">Auto Sacrifice: OFF</button>
-                        <button id="autoSacrificeAntMode">Mode: In-game time</button>
-                        <input id="autoAntSacrificeAmount" type="number">
-                        <p id="autoAntSacrifice"></p>
+                        <div class="antSacrificeButtonsContainer">
+                            <button id="toggleAutoSacrificeAnt">Auto Sacrifice: OFF</button>
+                            <div class="antSacrificeSettingsContainer">
+                                <button id="autoSacrificeAntMode">Mode: In-game time</button>
+                                <input id="autoAntSacrificeAmount" type="number">
+                            </div>
+                        </div>
+                        <span id="autoAntSacrifice"></span>
                     </div>
                 </div>
 

--- a/index.html
+++ b/index.html
@@ -167,10 +167,10 @@
         <div id="buyamountcoin">
             <table class="coinunlock3" id="coinbuyamount">
                 <tr>
-                <td><img  id="coinone" src="Pictures/Transparent Pics/CoinOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                <td><img  id="cointen" src="Pictures/Transparent Pics/CoinTen.png"  style="cursor:pointer;" alt=""></td>
-                <td><img  id="coinhundred" src="Pictures/Transparent Pics/CoinHundred.png"  style="cursor:pointer;" alt=""></td>
-                <td><img  id="cointhousand" src="Pictures/Transparent Pics/CoinThousand.png"  style="cursor:pointer;" alt=""></td>
+                <td><img id="coinone" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinOne.png" style="background-color: green;" alt=""></td>
+                <td><img id="cointen" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinTen.png" alt=""></td>
+                <td><img id="coinhundred" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinHundred.png" alt=""></td>
+                <td><img id="cointhousand" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinThousand.png" alt=""></td>
                 </tr>
             </table>
             <p class="coinunlock3" id="togglecoinbuy">Toggle amount to buy</p>
@@ -252,10 +252,10 @@
         <div id="buyamountcrystal">
             <table id="crystalbuyamount">
                 <tr>
-                <td><img  id="crystalone" src="Pictures/Transparent Pics/CrystalOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                <td><img  id="crystalten" src="Pictures/Transparent Pics/CrystalTen.png"  style="cursor:pointer;" alt=""></td>
-                <td><img  id="crystalhundred" src="Pictures/Transparent Pics/CrystalHundred.png"  style="cursor:pointer;" alt=""></td>
-                <td><img  id="crystalthousand" src="Pictures/Transparent Pics/CrystalThousand.png"  style="cursor:pointer;" alt=""></td>
+                <td><img id="crystalone" class="buyAmountBtn" src="Pictures/Transparent Pics/CrystalOne.png" style="background-color: green;" alt=""></td>
+                <td><img id="crystalten" class="buyAmountBtn" src="Pictures/Transparent Pics/CrystalTen.png" alt=""></td>
+                <td><img id="crystalhundred" class="buyAmountBtn" src="Pictures/Transparent Pics/CrystalHundred.png" alt=""></td>
+                <td><img id="crystalthousand" class="buyAmountBtn" src="Pictures/Transparent Pics/CrystalThousand.png" alt=""></td>
 
                 </tr>
             </table>
@@ -319,8 +319,8 @@
         </div>
 
         <div id="autocrystalbuild">
-            <button class="auto" id="toggle15" toggleid="15" format="Auto Prestige [$]" style="background-color: #171717;">Automatic Prestige & Customization Being Developed!</button>
-            <button id="prestigeautotoggle" style="border:2px solid green; background-color: #171717;"></button>
+            <button class="auto" id="toggle15" toggleid="15" format="Auto Prestige [$]">Automatic Prestige & Customization Being Developed!</button>
+            <button id="prestigeautotoggle" style="border:2px solid green;"></button>
             <input class="transcendunlock" type="number" id="prestigeamount" min="1" max="999999999" defaultValue="1">
             <p class="transcendunlock" id="autoprestige"></p>
             <p id="prestigehotkeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer. Press [6], [7], [8], [9] or [0] to buy the corresponding Crystal upgrade starting on the left.</p>
@@ -330,10 +330,10 @@
         <div id="buyamountmythos">
             <table id="mythosbuyamount">
                 <tr>
-                <td><img id="mythosone" src="Pictures/Transparent Pics/MythosOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                <td><img id="mythosten" src="Pictures/Transparent Pics/MythosTen.png"  style="cursor:pointer;" alt=""></td>
-                <td><img id="mythoshundred" src="Pictures/Transparent Pics/MythosHundred.png"  style="cursor:pointer;" alt=""></td>
-                <td><img id="mythosthousand" src="Pictures/Transparent Pics/MythosThousand.png"  style="cursor:pointer;" alt=""></td>
+                <td><img id="mythosone" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosOne.png" style="background-color: green;" alt=""></td>
+                <td><img id="mythosten" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosTen.png" alt=""></td>
+                <td><img id="mythoshundred" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosHundred.png" alt=""></td>
+                <td><img id="mythosthousand" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosThousand.png" alt=""></td>
                 </tr>
             </table>
             <p id="togglemythosbuy">Toggle amount to buy</p>
@@ -380,9 +380,9 @@
         <p id="transcendshardinfo" style="color:pink; text-align: center">You have 1.39e+100394 Transcend Shards, providing 1,214,593 multiplier power boosts.</p>
         <p id="transcendshardbonus" style="color: limegreen; text-align: center;">Each Multiplier Boost increases the base effect of Multipliers by 0.005!</p>
 
-        <button class="auto" id="toggle21" toggleid="21" format="Auto Transcend [$]" style="background-color: #171717;">Auto: Off</button>
+        <button class="auto" id="toggle21" toggleid="21" format="Auto Transcend [$]">Auto: Off</button>
 
-        <button id="transcendautotoggle" style="border:2px solid green; background-color: #171717;"></button>
+        <button id="transcendautotoggle" style="border:2px solid green;"></button>
         <input class="transcendunlock" type="number" id="transcendamount" min="1" max="999999999" defaultValue="1">
         <p class="transcendunlock" id="autotranscend"></p>
 
@@ -392,10 +392,10 @@
         <div id="buyamountparticle">
             <table id="particlebuyamount">
                 <tr>
-                <td><img id="particleone" src="Pictures/Transparent Pics/ParticleOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                <td><img id="particleten" src="Pictures/Transparent Pics/ParticleTen.png"  style="cursor:pointer;" alt=""></td>
-                <td><img id="particlehundred" src="Pictures/Transparent Pics/ParticleHundred.png"  style="cursor:pointer;" alt=""></td>
-                <td><img id="particlethousand" src="Pictures/Transparent Pics/ParticleThousand.png"  style="cursor:pointer;" alt=""></td>
+                <td><img id="particleone" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleOne.png" style="background-color: green;" alt=""></td>
+                <td><img id="particleten" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleTen.png" alt=""></td>
+                <td><img id="particlehundred" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleHundred.png" alt=""></td>
+                <td><img id="particlethousand" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleThousand.png" alt=""></td>
                 </tr>
             </table>
             <p id="toggleparticlebuy">Toggle amount to buy</p>
@@ -443,12 +443,12 @@
             <p id="reincarnationshardinfo" style="color:lime; text-align: center">You have 1.39e+100394 Atoms, providing a building power of 3.02.</p>
             <p id="reincarnationCrystalInfo" style="color: cyan; text-align: center; display: none;">Thanks to research 3x9, you also multiply Crystal producion by 1.</p>
             <p id="reincarnationMythosInfo" style="color:plum; text-align: center; display: none;">Thanks to research 3x10, you also multiply Mythos Shard production by 1.</p>
-            <button class="auto" id="toggle27" toggleid="27" format="Auto Reincarnate [$]" style="background-color: #171717;">Auto: Off</button>
+            <button class="auto" id="toggle27" toggleid="27" format="Auto Reincarnate [$]">Auto: Off</button>
         </div>
 
         <div id="reincarnateautomation">
             <div>
-                <button id="reincarnateautotoggle" style="border:2px solid green; background-color: #171717;"></button>
+                <button id="reincarnateautotoggle" style="border:2px solid green;"></button>
                 <input class="reincarnationunlock" type="number" id="reincarnationamount" min="1" max="999999999" defaultValue="1">
                 <p class="reincarnationunlock" id="autoreincarnate"></p>
             </div>
@@ -459,10 +459,10 @@
         <div id="buyAmountTesseract">
             <table id="buyTesseractToggles">
                 <tr>
-                    <td><img id="tesseractone" src="Pictures/Transparent Pics/TesseractOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                    <td><img id="tesseractten" src="Pictures/Transparent Pics/TesseractTen.png"  style="cursor:pointer;" alt=""></td>
-                    <td><img id="tesseracthundred" src="Pictures/Transparent Pics/TesseractHundred.png"  style="cursor:pointer;" alt=""></td>
-                    <td><img id="tesseractthousand" src="Pictures/Transparent Pics/TesseractThousand.png"  style="cursor:pointer;" alt=""></td>
+                    <td><img id="tesseractone" class="buyAmountBtn" src="Pictures/Transparent Pics/TesseractOne.png" style="background-color: green;" alt=""></td>
+                    <td><img id="tesseractten" class="buyAmountBtn" src="Pictures/Transparent Pics/TesseractTen.png" alt=""></td>
+                    <td><img id="tesseracthundred" class="buyAmountBtn" src="Pictures/Transparent Pics/TesseractHundred.png" alt=""></td>
+                    <td><img id="tesseractthousand" class="buyAmountBtn"src="Pictures/Transparent Pics/TesseractThousand.png" alt=""></td>
                 </tr>
             </table>
             <p id="toggleTesseractBuy">Toggle amount to buy</p>
@@ -552,7 +552,7 @@
             <p id="constUpgradeEffect1" style="color: white">Current Effect: <span id="constUpgradeEffect2" style="color: orchid">---</span></p>
         </div>
         <div id="ascendautomation">
-            <button id="tesseractautobuytoggle" style="border:2px solid red; background-color: #171717;">Auto Buy: OFF</button>
+            <button id="tesseractautobuytoggle" style="border:2px solid red;">Auto Buy: OFF</button>
         <input class="tesseractautobuyamount" type="number" id="tesseractAmount" min="1" max="999999999" defaultValue="1">
         <p class="tesseractautobuyamount" id="autotessbuyeramount"></p>
         </div>
@@ -1100,10 +1100,10 @@
                 <div id="buyamountoffering">
                     <table id="offeringbuyamount">
                         <tr>
-                        <td><img id="offeringone" src="Pictures/Transparent Pics/OfferingOne.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                        <td><img id="offeringten" src="Pictures/Transparent Pics/OfferingTen.png"  style="cursor:pointer;" alt=""></td>
-                        <td><img id="offeringhundred" src="Pictures/Transparent Pics/OfferingHundred.png"  style="cursor:pointer;" alt=""></td>
-                        <td><img id="offeringthousand" src="Pictures/Transparent Pics/OfferingThousand.png"  style="cursor:pointer;" alt=""></td>
+                        <td><img id="offeringone" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingOne.png" style="background-color: green;" alt=""></td>
+                        <td><img id="offeringten" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingTen.png" alt=""></td>
+                        <td><img id="offeringhundred" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingHundred.png" alt=""></td>
+                        <td><img id="offeringthousand" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingThousand.png" alt=""></td>
                         </tr>
                     </table>
                     <p id="toggleofferingbuy">Toggle the number of levels to buy per sacrifice</p>
@@ -1299,10 +1299,10 @@
                     <div id="buyamounttalisman">
                         <table>
                             <tr>
-                                <td><img id="talismanTen" src="Pictures/Transparent Pics/TalismanTen.png" style="cursor:pointer; background-color: green;" alt=""></td>
-                                <td><img id="talismanTwentyFive" src="Pictures/Transparent Pics/TalismanTwentyFive.png"  style="cursor:pointer;" alt=""></td>
-                                <td><img id="talismanFifty" src="Pictures/Transparent Pics/TalismanFifty.png"  style="cursor:pointer;" alt=""></td>
-                                <td><img id="talismanHundred" src="Pictures/Transparent Pics/TalismanHundred.png"  style="cursor:pointer;" alt=""></td>
+                                <td><img id="talismanTen" class="buyAmountBtn" src="Pictures/Transparent Pics/TalismanTen.png" style="background-color: green;" alt=""></td>
+                                <td><img id="talismanTwentyFive" class="buyAmountBtn" src="Pictures/Transparent Pics/TalismanTwentyFive.png" alt=""></td>
+                                <td><img id="talismanFifty" class="buyAmountBtn" src="Pictures/Transparent Pics/TalismanFifty.png" alt=""></td>
+                                <td><img id="talismanHundred" class="buyAmountBtn" src="Pictures/Transparent Pics/TalismanHundred.png" alt=""></td>
                             </tr>
                         </table>
                         <span id="toggletalismanbuy">Toggle percent resources used</span>
@@ -2441,7 +2441,7 @@
                     <input id="ascensionAmount" class="ascendunlock hCenter tight" type="number" min="1" max="999999999" defaultValue="1">
                     <p id="autoAscend" class="ascendunlock tightText">Ascend when you've completed Sadistic Challenge I a total of <span id="autoAscendMetric" style="color: orchid">1</span> times.</p>
                     <button id="ascensionAutoEnable" class="ascendunlock hCenter tight" style="border: 2px solid green">Auto Ascend [ON]</button>
-                    <button id="ascensionAutoToggle" class="hCenter tight" style="border:2px solid orchid; background-color: #171717;">Mode: C10 Completions</button>
+                    <button id="ascensionAutoToggle" class="hCenter tight" style="border:2px solid orchid;">Mode: C10 Completions</button>
                 </div>
             </div>
         </div>

--- a/index.html
+++ b/index.html
@@ -1849,7 +1849,7 @@
             <div id="cubesWrapper">
                 <div id="wowCubeSidebar"> 
                     <div id="wowCubeSidebarButtons">
-                        <button id="switchCubeSubTab1" class="cubeSwitchTabBtn" style="border: 2px solid gold;">Cube Tributes</button>
+                        <button id="switchCubeSubTab1" class="cubeSwitchTabBtn" style="border: 2px solid gold; background-color: crimson;">Cube Tributes</button>
                         <button id="switchCubeSubTab2" class="cubeSwitchTabBtn chal11" style="border: 2px solid purple;">Tesseract Gifts</button>
                         <button id="switchCubeSubTab3" class="cubeSwitchTabBtn chal13" style="border: 2px solid red;">Hypercube Benedictions</button>
                         <button id="switchCubeSubTab4" class="cubeSwitchTabBtn chal14" style="border: 2px solid orange;">Platonic Statues</button>
@@ -1869,19 +1869,21 @@
                     <p id="hypercubeQuarksOpenRequirement" class="chal13">Open <span id="hypercubeQuarksOpenRequirementValue" style="color: yellow">1</span> hypercubes for next quark.</p>
                     <p id="hypercubeQuarksOpenToday" class="chal13">Hypercubes opened today: <span id="hypercubeQuarksOpenTodayValue" style="color: orchid;">0</span></p>
                 </div>
-                <div id="cubeTab1" style="display: block">
-                    <p id="cubeWelcome" class="cubePlacement1" style="color: orange">You feel a sense of Pride and Accomplishment... and a hunger for power.</p>
-                    <p id="cubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Cubes, to get one of ten permanent bonuses.</p>
-                    <p id="cubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</p>
+                <div id="cubeTab1" class="cubeTab" style="display: flex">
+                    <span id="cubeWelcome" class="cubePlacement1" style="color: orange">You feel a sense of Pride and Accomplishment... and a hunger for power.</span>
+                    <span id="cubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Cubes, to get one of ten permanent bonuses.</span>
+                    <span id="cubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</span>
                     
                     <div class="openGrid"> 
                         <img class="openImage" src="Pictures/WowCube.png" alt="">
-                        <p class="inventory" style="color: white">You possess <span id="cubeQuantity" style="color: yellow">13</span> Wow! Cubes. Get more from harder Ascensions and other stuff.</p>
-                        <div class="openBtn"> 
-                            <button class="cubeBtn" id="open1Cube">Open x1</button>
-                            <button class="cubeBtn" id="open20Cube">Open x20</button>
-                            <button class="cubeBtn" id="open1000Cube">Open x1,000</button>
-                            <button class="cubeBtn" id="openMostCube">Open All</button>
+                        <div class="openButtons">
+                            <span class="inventory" style="color: white">You possess <span id="cubeQuantity" style="color: yellow">13</span> Wow! Cubes. Get more from harder Ascensions and other stuff.</span>
+                            <div class="openBtn"> 
+                                <button class="cubeBtn" id="open1Cube">Open x1</button>
+                                <button class="cubeBtn" id="open20Cube">Open x20</button>
+                                <button class="cubeBtn" id="open1000Cube">Open x1,000</button>
+                                <button class="cubeBtn" id="openMostCube">Open All</button>
+                            </div>
                         </div>
                     </div>
 
@@ -1951,19 +1953,21 @@
                     </div>
                     <p id="cubeBlessingsTotal">You have a total of <span id="cubeBlessingTotalAmount">0</span> Cube tributes!</p>
                 </div>
-                <div id="cubeTab2" style="display: none">
-                    <p id="tesseractWelcome" class="cubePlacement1" style="color: orchid">You obtain guidance from beings in another dimension!</p>
-                    <p id="tesseractExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Tesseracts, to boost tributes from the previous tier.</p>
-                    <p id="tesseractExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</p>
+                <div id="cubeTab2" class="cubeTab" style="display: none">
+                    <span id="tesseractWelcome" class="cubePlacement1" style="color: orchid">You obtain guidance from beings in another dimension!</span>
+                    <span id="tesseractExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Tesseracts, to boost tributes from the previous tier.</span>
+                    <span id="tesseractExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</span>
                     
                     <div class="openGrid"> 
                         <img class="openImage" src="Pictures/WowTessaract.png" alt="">
-                        <p id="tesseractInventory" class="inventory" style="color: orchid">You possess <span id="tesseractQuantity" style="color: yellow">13</span> Wow! TESSERACTS. Get more from harder Ascensions and other stuff.</p>
-                        <div class="openBtn"> 
-                            <button id="open1Tesseract" class="cubeBtn">Open x1</button>
-                            <button id="open20Tesseract" class="cubeBtn">Open x20</button>
-                            <button id="open1000Tesseract" class="cubeBtn">Open x1,000</button>
-                            <button id="openMostTesseract" class="cubeBtn">Open All</button>
+                        <div class="openButtons">
+                            <span id="tesseractInventory" class="inventory" style="color: orchid">You possess <span id="tesseractQuantity" style="color: yellow">13</span> Wow! TESSERACTS. Get more from harder Ascensions and other stuff.</span>
+                            <div class="openBtn"> 
+                                <button id="open1Tesseract" class="cubeBtn">Open x1</button>
+                                <button id="open20Tesseract" class="cubeBtn">Open x20</button>
+                                <button id="open1000Tesseract" class="cubeBtn">Open x1,000</button>
+                                <button id="openMostTesseract" class="cubeBtn">Open All</button>
+                            </div>
                         </div>
                     </div>
 
@@ -2033,19 +2037,21 @@
                     </div>
                     <p id="tesseractBlessingsTotal">You have a total of <span id="tesseractBlessingTotalAmount">0</span> Tesseract gifts!</p>
                 </div>
-                <div id="cubeTab3" style="display: none">
-                    <p id="hypercubeWelcome" class="cubePlacement1" style="color: rgb(255, 0, 76)">I didn't know that Wow! enterprises made 5-Dimensional Objects.</p>
-                    <p id="hypercubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Hypercubes, to boost blessings from the previous tier.</p>
-                    <p id="hypercubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</p>
+                <div id="cubeTab3" class="cubeTab" style="display: none">
+                    <span id="hypercubeWelcome" class="cubePlacement1" style="color: rgb(255, 0, 76)">I didn't know that Wow! enterprises made 5-Dimensional Objects.</span>
+                    <span id="hypercubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Wow! Hypercubes, to boost blessings from the previous tier.</span>
+                    <span id="hypercubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</span>
 
                     <div class="openGrid"> 
                         <img class="openImage" src="Pictures/WowHypercube.png" alt="">
-                        <p id="hypercubeInventory" class="inventory" style="color: rgb(255, 0, 76)">You possess <span id="hypercubeQuantity" style="color: yellow">13</span> Wow! HYPERCUBES. Get more from harder Ascensions and other stuff.</p>
-                        <div class="openBtn"> 
-                            <button id="open1Hypercube" class="cubeBtn">Open x1</button>
-                            <button id="open20Hypercube" class="cubeBtn">Open x20</button>
-                            <button id="open1000Hypercube" class="cubeBtn">Open x1,000</button>
-                            <button id="openMostHypercube" class="cubeBtn">Open All</button>
+                        <div class="openButtons">
+                            <span id="hypercubeInventory" class="inventory" style="color: rgb(255, 0, 76)">You possess <span id="hypercubeQuantity" style="color: yellow">13</span> Wow! HYPERCUBES. Get more from harder Ascensions and other stuff.</span>
+                            <div class="openBtn"> 
+                                <button id="open1Hypercube" class="cubeBtn">Open x1</button>
+                                <button id="open20Hypercube" class="cubeBtn">Open x20</button>
+                                <button id="open1000Hypercube" class="cubeBtn">Open x1,000</button>
+                                <button id="openMostHypercube" class="cubeBtn">Open All</button>
+                            </div>
                         </div>
                     </div>
 
@@ -2115,19 +2121,21 @@
                     </div>
                     <p id="hypercubeBlessingsTotal">You have a total of <span id="hypercubeBlessingTotalAmount">0</span> Hypercube benedictions!</p>
                 </div>
-                <div id="cubeTab4" style="display: none">
-                    <p id="platonicCubeWelcome" class="cubePlacement1" style="color: orangered">This seems very familiar.</p>
-                    <p id="platonicCubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Platonic! Cubes, for epic perks!.</p>
-                    <p id="platonicCubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</p>
+                <div id="cubeTab4" class="cubeTab" style="display: none">
+                    <span id="platonicCubeWelcome" class="cubePlacement1" style="color: orangered">This seems very familiar.</span>
+                    <span id="platonicCubeExpository1" class="cubePlacement2" style="color: white">Open up some Lootb-- er, Platonic! Cubes, for epic perks!.</span>
+                    <span id="platonicCubeExpository2" class="cubePlacement3" style="color: limegreen">You can also spend them on upgrades that persist through Ascension.</span>
 
                     <div class="openGrid"> 
                         <img class="openImage" src="Pictures/Platonic Cube.png" alt="">
-                        <p id="platonicCubeInventory" class="inventory" style="color:orange">You possess <span id="platonicQuantity" style="color: yellow">13</span> Platonic! Cubes. Get more from really hard ascensions.</p>
-                        <div class="openBtn"> 
-                            <button id="open1PlatonicCube" class="cubeBtn">Open x1</button>
-                            <button id="open40kPlatonicCube" class="cubeBtn">Open x40,000</button>
-                            <button id="open1mPlatonicCube" class="cubeBtn">Open x1 Million</button>
-                            <button id="openMostPlatonicCube" class="cubeBtn">Open All</button>
+                        <div class="openButtons">
+                            <span id="platonicCubeInventory" class="inventory" style="color:orange">You possess <span id="platonicQuantity" style="color: yellow">13</span> Platonic! Cubes. Get more from really hard ascensions.</span>
+                            <div class="openBtn"> 
+                                <button id="open1PlatonicCube" class="cubeBtn">Open x1</button>
+                                <button id="open40kPlatonicCube" class="cubeBtn">Open x40,000</button>
+                                <button id="open1mPlatonicCube" class="cubeBtn">Open x1 Million</button>
+                                <button id="openMostPlatonicCube" class="cubeBtn">Open All</button>
+                            </div>
                         </div>
                     </div>
 
@@ -2257,7 +2265,7 @@
                         <button id="toggleCubeBuy" style="text-align: center;color: white;border: 2px solid pink">Upgrade: 1 Level wow</button>
                     </div>
                 </div>
-                <div id="cubeTab6" style="display: none">
+                <div id="cubeTab6" class="cubeTab" style="display: none">
                     <div id="c15Rewards" class="challengeContainer" style='border: 3px solid plum'>
                         <p id="c15Reward0" class="challengePortion">Best Challenge 15 Exponent: <span id="c15Reward0Num" class="challengeNumber" style='color: gold; font-size: 1.2em;'></span></p>
                         <p id="c15RewardList" class="challengePortion" style="color: orchid;">Next Reward Unlocks at 0 coins.</p>
@@ -2285,44 +2293,46 @@
                         <p id="c15Reward22" class="challengePortion">22. Spirit Effectiveness: +<span id="c15Reward22Num" class="challengeNumber"></span>%</p>
                         <p id="c15Reward23" class="challengePortion">23. Ascension Score: +<span id="c15Reward23Num" class="challengeNumber"></span>%</p>
                     </div>
-                    <div id="platonicUpgrades">
-                        <table id="platonicUpgradePics" style='border: 3px solid plum'>
-                            <tr>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade1.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade2.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade3.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade4.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade5.png" alt="" class="platonicUpgradeImage"></td>
-                            </tr>
-                            <tr>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade6.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade7.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade8.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade9.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade10.png" alt="" class="platonicUpgradeImage"></td>
-                            </tr>
-                            <tr>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade11.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade12.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade13.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade14.png" alt="" class="platonicUpgradeImage"></td>
-                                <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade15.png" alt="" class="platonicUpgradeImage"></td>
-                            </tr>
-                        </table>
-                    </div>
-                    <div id="platonicUpgradeDescriptions" class="platonicContainer" style="border: 3px solid plum">
-                        <p id="platonicUpgradeDescriptionDivisor" class="platonicPortion">===Upgrade Description===</p>
-                        <p id="platonicUpgradeDescription" class="platonicPortion">Click an icon for info!</p>
-                        <p id="platonicUpgradeLevel" class="platonicPortion">---</p>
-                        <p id="platonicUpgradeCostDivisor" class="platonicPortion">===Upgrade Costs===</p>
-                        <p id="platonicOfferingCost" class="platonicPortion">---</p>
-                        <p id="platonicObtainiumCost" class="platonicPortion">---</p>
-                        <p id="platonicCubeCost" class="platonicPortion">---</p>
-                        <p id="platonicTesseractCost" class="platonicPortion">---</p>
-                        <p id="platonicHypercubeCost" class="platonicPortion">---</p>
-                        <p id="platonicPlatonicCost" class="platonicPortion">---</p>
-                        <p id="platonicHepteractCost" class="platonicPortion">---</p>
-                        <p id="platonicCanBuy" class="platonicPortion">---</p>
+                    <div class="platonicUpgradesContainer">
+                        <div id="platonicUpgrades">
+                            <table id="platonicUpgradePics" style='border: 3px solid plum'>
+                                <tr>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade1.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade2.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade3.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade4.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade5.png" alt="" class="platonicUpgradeImage"></td>
+                                </tr>
+                                <tr>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade6.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade7.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade8.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade9.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade10.png" alt="" class="platonicUpgradeImage"></td>
+                                </tr>
+                                <tr>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade11.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade12.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade13.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade14.png" alt="" class="platonicUpgradeImage"></td>
+                                    <td style="font-size: 0;"><img src="Pictures/PlatonicUpgrade15.png" alt="" class="platonicUpgradeImage"></td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div id="platonicUpgradeDescriptions" class="platonicContainer" style="border: 3px solid plum">
+                            <p id="platonicUpgradeDescriptionDivisor" class="platonicPortion">===Upgrade Description===</p>
+                            <p id="platonicUpgradeDescription" class="platonicPortion">Click an icon for info!</p>
+                            <p id="platonicUpgradeLevel" class="platonicPortion">---</p>
+                            <p id="platonicUpgradeCostDivisor" class="platonicPortion">===Upgrade Costs===</p>
+                            <p id="platonicOfferingCost" class="platonicPortion">---</p>
+                            <p id="platonicObtainiumCost" class="platonicPortion">---</p>
+                            <p id="platonicCubeCost" class="platonicPortion">---</p>
+                            <p id="platonicTesseractCost" class="platonicPortion">---</p>
+                            <p id="platonicHypercubeCost" class="platonicPortion">---</p>
+                            <p id="platonicPlatonicCost" class="platonicPortion">---</p>
+                            <p id="platonicHepteractCost" class="platonicPortion">---</p>
+                            <p id="platonicCanBuy" class="platonicPortion">---</p>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -70,7 +70,7 @@ export const challengeDisplay = (i: number, changefocus?: boolean) => {
 
     if (changefocus) {
         G['challengefocus'] = i;
-        document.getElementById("oneChallengeDetails").style.display = "block";
+        document.getElementById("oneChallengeDetails").style.display = "flex";
         document.getElementById('startChallenge').style.display = 'block';
         document.getElementById('retryChallenge').style.display = 'block';
         G['triggerChallenge'] = i

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1100,7 +1100,7 @@ export const loadSynergy = (): void => {
                     d = 'thousand'
                 }
                 const e = q[j] + d;
-                document.getElementById(e).style.backgroundColor = "#000000"
+                document.getElementById(e).style.backgroundColor = ""
             }
             let c;
             if (player[q[j] + 'buyamount'] === 1) {

--- a/src/Talismans.ts
+++ b/src/Talismans.ts
@@ -67,10 +67,10 @@ export const updateTalismanCostDisplay = (type: keyof typeof talismanResourceCos
 }
 
 export const toggleTalismanBuy = (i = player.buyTalismanShardPercent) => {
-    document.getElementById("talismanTen").style.backgroundColor = "#171717"
-    document.getElementById("talismanTwentyFive").style.backgroundColor = "#171717"
-    document.getElementById("talismanFifty").style.backgroundColor = "#171717"
-    document.getElementById("talismanHundred").style.backgroundColor = "#171717"
+    document.getElementById("talismanTen").style.backgroundColor = ""
+    document.getElementById("talismanTwentyFive").style.backgroundColor = ""
+    document.getElementById("talismanFifty").style.backgroundColor = ""
+    document.getElementById("talismanHundred").style.backgroundColor = ""
     player.buyTalismanShardPercent = i
     let x = "Ten";
     if (i === 25) {
@@ -83,7 +83,7 @@ export const toggleTalismanBuy = (i = player.buyTalismanShardPercent) => {
         x = "Hundred"
     }
 
-    document.getElementById("talisman" + x).style.backgroundColor = "green"
+    document.getElementById(`talisman${x}`).style.backgroundColor = "green"
 }
 
 export const updateTalismanInventory = () => {

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -129,16 +129,16 @@ export const toggleBuyAmount = (quantity: 1 | 10 | 100 | 1000, type: ToggleBuy) 
 
     document.getElementById(`${type}${a}`).style.backgroundColor = "Green";
     if (quantity !== 1) {
-        document.getElementById(`${type}one`).style.backgroundColor = "Black"
+        document.getElementById(`${type}one`).style.backgroundColor = ""
     }
     if (quantity !== 10) {
-        document.getElementById(`${type}ten`).style.backgroundColor = "Black"
+        document.getElementById(`${type}ten`).style.backgroundColor = ""
     }
     if (quantity !== 100) {
-        document.getElementById(`${type}hundred`).style.backgroundColor = "Black"
+        document.getElementById(`${type}hundred`).style.backgroundColor = ""
     }
     if (quantity !== 1000) {
-        document.getElementById(`${type}thousand`).style.backgroundColor = "Black"
+        document.getElementById(`${type}thousand`).style.backgroundColor = ""
     }
 }
 

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -663,11 +663,11 @@ export const toggleCubeSubTab = (i: number) => {
     const numSubTabs = subTabsInMainTab(8).subTabList.length
     for (let j = 1; j <= numSubTabs; j++) {
         const cubeTab = document.getElementById(`cubeTab${j}`);
-        if (cubeTab.style.display === "block" && j !== i) {
+        if (cubeTab.style.display === "flex" && j !== i) {
             cubeTab.style.display = "none"
         }
         if (cubeTab.style.display === "none" && j === i) {
-            cubeTab.style.display = "block"
+            cubeTab.style.display = "flex"
             player.subtabNumber = j - 1
         }
         document.getElementById("switchCubeSubTab" + j).style.backgroundColor = i === j ? "crimson" : ""


### PR DESCRIPTION
- fixed talisman container labels text wrapping with certain browsers
- fixed challenge and ant tabs not scaling properly at extreme widths
- improved scaling and centering of the wow cube tab
- initialize cube tribute subtab as highlighted as that's what the game opens to
- added hover effects to the auto ascension settings, the per second ascend history toggle, all buy amount/percent toggles, and auto prestige/transcend/recinc/tess building buy

by the way, if my css or coding breaks anything please feel free to let me know, because I wouldn't want to make you spend your limited coding time fixing something I messed up :)