### PR TITLE
Fix rune subtab being inconsistent on import 

### DIFF
--- a/index.html
+++ b/index.html
@@ -1173,10 +1173,10 @@
 
             <div id="runesToggle">
                 <button id="toggleautosacrifice" style="border: 2px solid orangered; color: white">Auto Rune: OFF</button>
-                <button id="toggleRuneSubTab1" style="border: 2px solid grey; color: white">Runes</button>
-                <button class="chal9" id="toggleRuneSubTab2" style="border: 2px solid grey; color: white">Talismans</button>
-                <button class="chal9" id="toggleRuneSubTab3" style="border: 2px solid grey; color: white">Blessings</button>
-                <button class="chal12" id="toggleRuneSubTab4" style="border: 2px solid grey; color: white">[=-Spirits-=]</button>
+                <button id="toggleRuneSubTab1" style="border: 2px solid gold; color: white; background-color: crimson">Runes</button>
+                <button class="chal9" id="toggleRuneSubTab2" style="border: 2px solid silver; color: white">Talismans</button>
+                <button class="chal9" id="toggleRuneSubTab3" style="border: 2px solid silver; color: white">Blessings</button>
+                <button class="chal12" id="toggleRuneSubTab4" style="border: 2px solid silver; color: white">[=-Spirits-=]</button>
             </div>
 
             <div id="runeContainer1">

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1116,10 +1116,6 @@ const loadSynergy = (reset = false) => {
         }
 
         player.subtabNumber = 0;
-        G['runescreen'] = "runes";
-        document.getElementById("toggleRuneSubTab1").style.backgroundColor = 'crimson'
-        document.getElementById("toggleRuneSubTab1").style.border = '2px solid gold'
-
 
         const q = ['coin', 'crystal', 'mythos', 'particle', 'offering', 'tesseract'] as const;
         if (player.coinbuyamount !== 1 && player.coinbuyamount !== 10 && player.coinbuyamount !== 100 && player.coinbuyamount !== 1000) {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1115,8 +1115,6 @@ const loadSynergy = (reset = false) => {
             updateCubeUpgradeBG(j);
         }
 
-        player.subtabNumber = 0;
-
         const q = ['coin', 'crystal', 'mythos', 'particle', 'offering', 'tesseract'] as const;
         if (player.coinbuyamount !== 1 && player.coinbuyamount !== 10 && player.coinbuyamount !== 100 && player.coinbuyamount !== 1000) {
             player.coinbuyamount = 1;


### PR DESCRIPTION
An example and an image is worth a thousand words:

1. Switch rune subtab to one of Talismans, Blessings, or Spirits.
2. Import a save.
3. Switch back to the rune tab.

![image](https://user-images.githubusercontent.com/6015058/123422007-f2654800-d600-11eb-88f1-6904d7901b57.png)

Pressing number keys in this state pours offerings into runes instead of the expected subtab's behavior.

This PR fixes this by retaining rune subtab on import (which follows other subtabs such as building subtabs and WOW! Cubes subtabs). This additionally fixes a minor styling issue with the subtab buttons when the page is first loaded.