### PR TITLE
Corruption on c11

### DIFF
--- a/index.html
+++ b/index.html
@@ -209,7 +209,7 @@
                 <li class="reincarnationunlock" id="researchtab">Research</li>
                 <li class="chal8" id="anttab">Anthill</li>
                 <li class="chal10" id="cubetab">WOW! Cubes</li>
-                <li class="chal10" id="traitstab">Corruption</li>
+                <li class="chal11" id="traitstab">Corruption</li>
                 <li id="settingstab">Settings</li>
                 <li class="reincarnationunlock" id="shoptab">Shop</li>
             </ul>

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -270,7 +270,7 @@ export const challengeDisplay = (i: number, changefocus?: boolean) => {
         e.textContent = "+12 free Ant Levels! Current: "
         f.textContent = "Ant Speed x(1e5)^completions! Current: "
         g.textContent = "+80 to Rune Caps! Current: "
-        h.textContent = "Unlock 15 Researches, and unlock the ability to open Tesseracts!"
+        h.textContent = "Unlock the Corruption feature! Includes 15 Researches, and the ability to open Tesseracts."
         k.textContent = "Start <[(Reduced Ants)]>"
         l.textContent = "+" + format(12 * CalcECC('ascension', player.challengecompletions[11])) + " free ant levels"
         m.textContent = "Ant Speed x" + format(Decimal.pow(1e5, CalcECC('ascension', player.challengecompletions[11])))

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -109,9 +109,10 @@ export const checkVariablesOnLoad = (data: Player) => {
             globalSpeed: 0
         }
     }
+    let blankCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     if (data.prototypeCorruptions === undefined) {
-        player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        player.usedCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        player.prototypeCorruptions = blankCorruptions
+        player.usedCorruptions = blankCorruptions
     }
     if (data.constantUpgrades === undefined) {
         player.ascendShards = new Decimal("0")
@@ -151,15 +152,15 @@ export const checkVariablesOnLoad = (data: Player) => {
         player.autoTesseracts = [false, false, false, false, false, false]
     }
 
-    if (player.prototypeCorruptions[0] === null || player.prototypeCorruptions[0] === undefined) {
-        player.usedCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    if (player.prototypeCorruptions[0] === null || player.prototypeCorruptions[0] === undefined || player.challengecompletions[11] === 0) {
+        player.usedCorruptions = blankCorruptions
+        player.prototypeCorruptions = blankCorruptions
     }
     if (player.corruptionLoadouts === undefined) {
         player.corruptionLoadouts = {
-            1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+            1: blankCorruptions,
+            2: blankCorruptions,
+            3: blankCorruptions
         };
         player.corruptionShowStats = true
     }

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -109,10 +109,10 @@ export const checkVariablesOnLoad = (data: Player) => {
             globalSpeed: 0
         }
     }
-    let blankCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+
     if (data.prototypeCorruptions === undefined) {
-        player.prototypeCorruptions = blankCorruptions
-        player.usedCorruptions = blankCorruptions
+        player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        player.usedCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     }
     if (data.constantUpgrades === undefined) {
         player.ascendShards = new Decimal("0")
@@ -153,14 +153,14 @@ export const checkVariablesOnLoad = (data: Player) => {
     }
 
     if (player.prototypeCorruptions[0] === null || player.prototypeCorruptions[0] === undefined || player.challengecompletions[11] === 0) {
-        player.usedCorruptions = blankCorruptions
-        player.prototypeCorruptions = blankCorruptions
+        player.usedCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     }
     if (player.corruptionLoadouts === undefined) {
         player.corruptionLoadouts = {
-            1: blankCorruptions,
-            2: blankCorruptions,
-            3: blankCorruptions
+            1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+            3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         };
         player.corruptionShowStats = true
     }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -322,7 +322,8 @@ export const revealStuff = () => {
         (document.getElementById('rune7area').style.display = 'flex', document.getElementById('runeshowpower7').style.display = "flex") :
         (document.getElementById('rune7area').style.display = 'none', document.getElementById('runeshowpower7').style.display = "none") ;
 
-    document.getElementById("ascensionStats").style.visibility = player.achievements[197] > 0 ? "visible" : "hidden";
+    document.getElementById("ascensionStats").style.visibility = player.achievements[183] > 0 ? "visible" : "hidden";
+    document.getElementById("ascTessStats").style.display = player.challengecompletions[197] > 0 ? "" : "none";
     document.getElementById("ascHyperStats").style.display = player.challengecompletions[13] > 0 ? "" : "none";
     document.getElementById("ascPlatonicStats").style.display = player.challengecompletions[14] > 0 ? "" : "none";
 


### PR DESCRIPTION
Many players get confused about corruptions the moment they unlock them by beating c10, even before they've ascended. Corruptions aren't very useful until tesseracts are unlocked and the player is strong enough to ascend with reasonable speed, both of which occur roughly when c11 is completed (or possible to complete). There isn't any other mechanic unlocked by c11, so this also serves to make introduction to new mechanics more gradual. 

The main downside of this change is that some players might have added corruptions but not have completed c11 yet. One way around the problem would be showing the corruption interface to any player with corruptions, another other option is cleansing anyone who hasn't completed c11, which is what's implemented here. 

Another downside is the lack of ability to automate ascends if the tab isn't visible containing the automation isn't visible. There are a few solutions to this: moving the automation to the cubes tab, not allowing automation to be purchased until after corruptions is unlocked, etc. I haven't implemented any of these things, but I can work whichever direction you'd prefer.

Also included is showing the ascension stats bar once the player ascends, rather than waiting until c11 is completed. I don't see why that information shouldn't be available to players who have yet to complete c11. (though, Tess has to be hidden until tess can be earned.) If this should be split into a separate pull request, I'm happy to do that.