### PR TITLE
Fix ascension stats taking up multiple rows

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2753,6 +2753,7 @@ header #obtainiumDisplay {
 
 #ascensionStats {
     display: flex;
+    gap: 10px;
     padding-top: 10px;
     margin-bottom: 15px;
     line-height: 20px;
@@ -2762,6 +2763,7 @@ header #obtainiumDisplay {
 
 #ascensionStats > span {
     display: flex;
+    white-space: pre;
     align-items: center;
 }
 

--- a/index.html
+++ b/index.html
@@ -97,23 +97,23 @@
         <div id="ascensionStats">
             <span id="ascCubeStats">
                 <img src="Pictures/WowCube.png" class="corruptionImg" title="Cube Information" loading="lazy">
-                <span><span id="ascCubes">x</span> C<span id="unit1">/s</span></span>
+                <span id="ascCubes">x</span> C<span id="unit1">/s</span>
             </span>
             <span id="ascTessStats">
                 <img src="Pictures/WowTessaract.png" class="corruptionImg" title="Tesseract Information" loading="lazy">
-                <span><span id="ascTess">x</span> T<span id="unit2">/s</span></span>
+                <span id="ascTess">x</span> T<span id="unit2">/s</span>
             </span>
             <span id="ascHyperStats">
                 <img src="Pictures/WowHypercube.png" class="corruptionImg" title="Hypercube Information" loading="lazy">
-                <span><span id="ascHyper">x</span> Hy<span id="unit3">/s</span></span>
+                <span id="ascHyper">x</span> Hy<span id="unit3">/s</span>
             </span>
             <span id="ascPlatonicStats">
                 <img src="Pictures/Platonic%20Cube.png" class="corruptionImg" title="Platonic Information" loading="lazy">
-                <span><span id="ascPlatonic">x</span> P<span id="unit4">/s</span></span>
+                <span id="ascPlatonic">x</span> P<span id="unit4">/s</span>
             </span>
             <span id="ascHepteractStats">
                 <img src="Pictures/Hepteract.png" class="corruptionImg" title="Hepteract Information" loading="lazy">
-                <span><span id="ascHepteract">x</span> He<span id="unit5">/s</span></span>
+                <span id="ascHepteract">x</span> He<span id="unit5">/s</span>
             </span>
             <span id="ascTimeTakenStats">
                 <img src="Pictures/questionable.png" class="corruptionImg" title="Ascension Timer" loading="lazy">


### PR DESCRIPTION
If the window is small enough, ascension stats will take up multiple rows at a certain point, which doesn't look great.

This commit fixes this, and adds a minimum 10px gap between stat trackers in case the window is small enough that the stats are visually too close together.