### PR TITLE
Adding alt text to some things

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,59 +136,59 @@
             <div class="currenciesContainer">
                 <div class="currencyRow">
                     <div class="currencyContainer">
-                        <img class="img coin" src="Pictures/Coin.png" title='Coin' alt="" loading="lazy">
+                        <img class="img coin" src="Pictures/Coin.png" title='Coin' alt="Coin" loading="lazy">
                         <div class="statDisplay" id="coinDisplay">1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="prestigeunlock img diamond" src="Pictures/Diamond.png" title='Diamond'  alt="" loading="lazy">
+                        <img class="prestigeunlock img diamond" src="Pictures/Diamond.png" title='Diamond'  alt="Diamond" loading="lazy">
                         <div class="prestigeunlock statDisplay" id="diamondDisplay">1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="prestigeunlock img offering" src="Pictures/Offering.png" title='Offering'  alt="" loading="lazy">
+                        <img class="prestigeunlock img offering" src="Pictures/Offering.png" title='Offering'  alt="Offering" loading="lazy">
                         <div class="prestigeunlock statDisplay" id="offeringDisplay" >1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="img quark" src="Pictures/Quark.png" title='Quark' alt="" loading="lazy">
+                        <img class="img quark" src="Pictures/Quark.png" title='Quark' alt="Quark" loading="lazy">
                         <div class="statDisplay" id="quarkDisplay">1</div>
                     </div>
                 </div>
                 <div class="currencyRow">
                     <div class="currencyContainer">
-                        <img class="transcendunlock img mythos" src="Pictures/Mythos.png" title='Mythos' alt="" loading="lazy">
+                        <img class="transcendunlock img mythos" src="Pictures/Mythos.png" title='Mythos' alt="Mythos" loading="lazy">
                         <div class="transcendunlock statDisplay" id="mythosDisplay">1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="transcendunlock img mythosshard" src="Pictures/MythosShard.png" title='Mythos Shard' alt="" loading="lazy">
+                        <img class="transcendunlock img mythosshard" src="Pictures/MythosShard.png" title='Mythos Shard' alt="Mythos Shards" loading="lazy">
                         <div class="transcendunlock statDisplay" id="mythosshardDisplay">1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="reincarnationunlock img particle" src="Pictures/Particle.png" title='Particle'  alt="" loading="lazy">
+                        <img class="reincarnationunlock img particle" src="Pictures/Particle.png" title='Particle'  alt="Particles" loading="lazy">
                         <div class="reincarnationunlock statDisplay" id="particlesDisplay">1</div>
                     </div>
                     <div class="currencyContainer">
-                        <img class="reincarnationunlock img obtanium" src="Pictures/Obtainium.png" title='Obtainium' alt="" loading="lazy">
+                        <img class="reincarnationunlock img obtanium" src="Pictures/Obtainium.png" title='Obtainium' alt="Obtainium" loading="lazy">
                         <div class="reincarnationunlock statDisplay" id="obtainiumDisplay">1</div>
                     </div>
                 </div>
             </div>
             <div class="resetInformationContainer">
                 <div class="resetsContainer">
-                    <img class="resetbtn coinunlock4" id="prestigebtn" src="Pictures/Transparent Pics/Prestige.png" alt="" loading="lazy">
-                    <img class="resetbtn prestigeunlock" id="transcendbtn" src="Pictures/Transparent Pics/Transcend.png" alt="" loading="lazy">
-                    <img class="resetbtn transcendunlock" id="reincarnatebtn" src="Pictures/Transparent Pics/Reincarnate.png" alt="" loading="lazy">
-                    <img class="resetbtn transcendunlock" id="acceleratorboostbtn" src="Pictures/Transparent Pics/AcceleratorBoost.png" alt="" loading="lazy">
-                    <img class="resetbtn transcendunlock" id="challengebtn" src="Pictures/Transparent Pics/Challenge.png" alt="" loading="lazy">
-                    <img class="resetbtn reincarnationunlock" id="reincarnatechallengebtn" src="Pictures/Transparent Pics/ChallengeReincarnation.png" alt="" loading="lazy">
-                    <img class="resetbtn ascendunlock" id="ascendChallengeBtn" src="Pictures/Transparent Pics/ChallengeAscension.png" alt="" loading="lazy">
-                    <img class="resetbtn chal10" id="ascendbtn" src="Pictures/questionable.png" alt="" loading="lazy">
+                    <img class="resetbtn coinunlock4" id="prestigebtn" src="Pictures/Transparent Pics/Prestige.png" alt="Prestige button" loading="lazy">
+                    <img class="resetbtn prestigeunlock" id="transcendbtn" src="Pictures/Transparent Pics/Transcend.png" alt="Transcend button" loading="lazy">
+                    <img class="resetbtn transcendunlock" id="reincarnatebtn" src="Pictures/Transparent Pics/Reincarnate.png" alt="Reincarnate button" loading="lazy">
+                    <img class="resetbtn transcendunlock" id="acceleratorboostbtn" src="Pictures/Transparent Pics/AcceleratorBoost.png" alt="Accelerator Boost button" loading="lazy">
+                    <img class="resetbtn transcendunlock" id="challengebtn" src="Pictures/Transparent Pics/Challenge.png" alt="Exit Transcend Challenge" loading="lazy">
+                    <img class="resetbtn reincarnationunlock" id="reincarnatechallengebtn" src="Pictures/Transparent Pics/ChallengeReincarnation.png" alt="Exit Reincarnate Challenge" loading="lazy">
+                    <img class="resetbtn ascendunlock" id="ascendChallengeBtn" src="Pictures/Transparent Pics/ChallengeAscension.png" alt="Exit Ascend Challenge" loading="lazy">
+                    <img class="resetbtn chal10" id="ascendbtn" src="Pictures/questionable.png" alt="Ascend button" loading="lazy">
                     <div id="resetrow">
                         <div id="resetrewards" style="display: block;">
                             <div>
-                                <img id="resetofferings1" src="Pictures/Offering.png" style="display: none;" alt="" loading="lazy">
+                                <img id="resetofferings1" src="Pictures/Offering.png" style="display: none;" alt="offerings" loading="lazy">
                                 <div id="resetofferings2" style="color: gold"></div>
-                                <img id="resetcurrency1" src="" style="display: none;" alt="" loading="lazy">
+                                <img id="resetcurrency1" src="" style="display: none;" alt="reset currency" loading="lazy">
                                 <div id="resetcurrency2" style="color:gold"></div>
-                                <img id="resetobtainium" src="Pictures/Obtainium.png" style="display: none;" alt="" loading="lazy">
+                                <img id="resetobtainium" src="Pictures/Obtainium.png" style="display: none;" alt="obtainium" loading="lazy">
                                 <div id="resetobtainium2" style="color:pink;"></div>
                             </div>
                         </div>

--- a/index.html
+++ b/index.html
@@ -844,11 +844,9 @@
         </div>
 
         <div id="upgradesrow3">
-            <section id="descriptionOfHoveredUpgrade">
-                <p id="upgradedescription" style="color: beige">Hover over an upgrade icon to see details!</p>
-                <p id="upgradecost"></p>
-                <p id="upgradeeffect"></p>
-            </section>
+            <p id="upgradedescription" style="color: beige">Hover over an upgrade icon to see details!</p>
+            <p id="upgradecost"></p>
+            <p id="upgradeeffect"></p>
             <button class="auto autobuyerToggleButton" id="toggle9" toggleid="9" format="Hover-to-Buy [$]" style="border:2px solid green">Hover-To-Buy: Off</button>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -626,42 +626,42 @@
             <div>
                 <img src="Pictures/Coin.png" alt="" loading="lazy">
                 <p id="cointext" style="color: gold">Coin Upgrades</p>
-                <table id="coinupgradestable" style="padding: 0; font-size:0; display: inline-block;">
+                <table id="coinupgradestable" style="padding: 0; font-size:0; display: inline-block;" alt="Coin Upgrades Table">
 
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img src="Pictures/Transparent Pics/Coin1.png" id="upg1" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Coin2.png" id="upg2" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Coin3.png" id="upg3" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Coin4.png" id="upg4" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Coin5.png" id="upg5" alt="" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Coin1.png" id="upg1" alt="Coin upgrade 1" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Coin2.png" id="upg2" alt="Coin upgrade 2" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Coin3.png" id="upg3" alt="Coin upgrade 3" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Coin4.png" id="upg4" alt="Coin upgrade 4" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Coin5.png" id="upg5" alt="Coin upgrade 5" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin6.png" id="upg6" alt="" loading="lazy"></td>
-                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin7.png" id="upg7" alt="" loading="lazy"></td>
-                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin8.png" id="upg8" alt="" loading="lazy"></td>
-                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin9.png" id="upg9" alt="" loading="lazy"></td>
-                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin10.png" id="upg10" alt="" loading="lazy"></td>
+                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin6.png" id="upg6" alt="Coin upgrade 6" loading="lazy"></td>
+                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin7.png" id="upg7" alt="Coin upgrade 7" loading="lazy"></td>
+                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin8.png" id="upg8" alt="Coin upgrade 8" loading="lazy"></td>
+                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin9.png" id="upg9" alt="Coin upgrade 9" loading="lazy"></td>
+                        <td><img class="prestigeunlock" src="Pictures/Transparent Pics/Coin10.png" id="upg10" alt="Coin upgrade 10" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin11.png" id="upg11" alt="" loading="lazy"></td>
-                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin12.png" id="upg12" alt="" loading="lazy"></td>
-                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin13.png" id="upg13" alt="" loading="lazy"></td>
-                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin14.png" id="upg14" alt="" loading="lazy"></td>
-                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin15.png" id="upg15" alt="" loading="lazy"></td>
+                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin11.png" id="upg11" alt="Coin upgrade 11" loading="lazy"></td>
+                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin12.png" id="upg12" alt="Coin upgrade 12" loading="lazy"></td>
+                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin13.png" id="upg13" alt="Coin upgrade 13" loading="lazy"></td>
+                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin14.png" id="upg14" alt="Coin upgrade 14" loading="lazy"></td>
+                        <td><img class="generationunlock" src="Pictures/Transparent Pics/Coin15.png" id="upg15" alt="Coin upgrade 15" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin16.png" id="upg16" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin17.png" id="upg17" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin18.png" id="upg18" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin19.png" id="upg19" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin20.png" id="upg20" alt="" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin16.png" id="upg16" alt="Coin upgrade 16" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin17.png" id="upg17" alt="Coin upgrade 17" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin18.png" id="upg18" alt="Coin upgrade 18" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin19.png" id="upg19" alt="Coin upgrade 19" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Coin20.png" id="upg20" alt="Coin upgrade 20" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin21.png" id="upg121" alt="" loading="lazy"></td>
-                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin22.png" id="upg122" alt="" loading="lazy"></td>
-                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin23.png" id="upg123" alt="" loading="lazy"></td>
-                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin24.png" id="upg124" alt="" loading="lazy"></td>
-                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/ConstantUpgrade1.png" id="upg125" alt="" loading="lazy"></td>
+                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin21.png" id="upg121" alt="Coin upgrade 21" loading="lazy"></td>
+                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin22.png" id="upg122" alt="Coin upgrade 22" loading="lazy"></td>
+                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin23.png" id="upg123" alt="Coin upgrade 23" loading="lazy"></td>
+                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/Coin24.png" id="upg124" alt="Coin upgrade 24" loading="lazy"></td>
+                        <td><img class="cubeUpgrade19" src="Pictures/Transparent Pics/ConstantUpgrade1.png" id="upg125" alt="Coin upgrade 25" loading="lazy"></td>
                     </tr>
                 </table>
                 <button class="autobuyerToggleButton upgradeToggle" id="coinAutoUpgrade" style="border:2px solid green">Auto: ON</button>
@@ -669,34 +669,34 @@
             <div>
                 <img class="prestigeunlock" src="Pictures/Diamond.png" alt="" loading="lazy">
                 <p class="prestigeunlock" id="prestigetext" style="color: cyan">Diamond Upgrades</p>
-                <table class="prestigeunlock" id="prestigeupgradestable" style="padding: 0; font-size:0;">
+                <table class="prestigeunlock" id="prestigeupgradestable" style="padding: 0; font-size:0; "alt="Diamond Upgrades Table">
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img src="Pictures/Transparent Pics/Diamond1.png" id="upg21" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond2.png" id="upg22" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond3.png" id="upg23" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond4.png" id="upg24" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond5.png" id="upg25" alt="" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond1.png" id="upg21" alt="Diamond upgrade 1" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond2.png" id="upg22" alt="Diamond upgrade 2" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond3.png" id="upg23" alt="Diamond upgrade 3" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond4.png" id="upg24" alt="Diamond upgrade 4" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond5.png" id="upg25" alt="Diamond upgrade 5" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img src="Pictures/Transparent Pics/Diamond6.png" id="upg26" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond7.png" id="upg27" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond8.png" id="upg28" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond9.png" id="upg29" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Diamond10.png" id="upg30" alt="" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond6.png" id="upg26" alt="Diamond upgrade 6" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond7.png" id="upg27" alt="Diamond upgrade 7" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond8.png" id="upg28" alt="Diamond upgrade 8" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond9.png" id="upg29" alt="Diamond upgrade 9" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Diamond10.png" id="upg30" alt="Diamond upgrade 10" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond11.png" id="upg31" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond12.png" id="upg32" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond13.png" id="upg33" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond14.png" id="upg34" alt="" loading="lazy"></td>
-                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond15.png" id="upg35" alt="" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond11.png" id="upg31" alt="Diamond upgrade 11" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond12.png" id="upg32" alt="Diamond upgrade 12" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond13.png" id="upg33" alt="Diamond upgrade 13" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond14.png" id="upg34" alt="Diamond upgrade 14" loading="lazy"></td>
+                        <td><img class="transcendunlock" src="Pictures/Transparent Pics/Diamond15.png" id="upg35" alt="Diamond upgrade 15" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Diamond16.png" id="upg36" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Diamond17.png" id="upg37" alt="" loading="lazy"></td>
-                        <td><img class="chal7" src="Pictures/Transparent Pics/Diamond18.png" id="upg38" alt="" loading="lazy"></td>
-                        <td><img class="chal8" src="Pictures/Transparent Pics/Diamond19.png" id="upg39" alt="" loading="lazy"></td>
-                        <td><img class="chal9" src="Pictures/Transparent Pics/Diamond20.png" id="upg40" alt="" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Diamond16.png" id="upg36" alt="Diamond upgrade 16" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Diamond17.png" id="upg37" alt="Diamond upgrade 17" loading="lazy"></td>
+                        <td><img class="chal7" src="Pictures/Transparent Pics/Diamond18.png" id="upg38" alt="Diamond upgrade 18" loading="lazy"></td>
+                        <td><img class="chal8" src="Pictures/Transparent Pics/Diamond19.png" id="upg39" alt="Diamond upgrade 19" loading="lazy"></td>
+                        <td><img class="chal9" src="Pictures/Transparent Pics/Diamond20.png" id="upg40" alt="Diamond upgrade 20" loading="lazy"></td>
                     </tr>
 
                 </table>
@@ -705,34 +705,34 @@
             <div>
                 <img class="transcendunlock" src="Pictures/Mythos.png" alt="" loading="lazy">
                 <p class="transcendunlock" id="transcendtext" style="color: plum">Mythos Upgrades</p>
-                <table class="transcendunlock" id="transcendupgradestable" style="padding: 0; font-size:0;">
+                <table class="transcendunlock" id="transcendupgradestable" style="padding: 0; font-size:0;" alt="Mythos Upgrades Table">
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img src="Pictures/Transparent Pics/Mythos1.png" id="upg41" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos2.png" id="upg42" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos3.png" id="upg43" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos4.png" id="upg44" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos5.png" id="upg45" alt="" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos1.png" id="upg41" alt="Mythos upgrade 1" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos2.png" id="upg42" alt="Mythos upgrade 2" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos3.png" id="upg43" alt="Mythos upgrade 3" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos4.png" id="upg44" alt="Mythos upgrade 4" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos5.png" id="upg45" alt="Mythos upgrade 5" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img src="Pictures/Transparent Pics/Mythos6.png" id="upg46" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos7.png" id="upg47" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos8.png" id="upg48" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos9.png" id="upg49" alt="" loading="lazy"></td>
-                        <td><img src="Pictures/Transparent Pics/Mythos10.png" id="upg50" alt="" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos6.png" id="upg46" alt="Mythos upgrade 6" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos7.png" id="upg47" alt="Mythos upgrade 7" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos8.png" id="upg48" alt="Mythos upgrade 8" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos9.png" id="upg49" alt="Mythos upgrade 9" loading="lazy"></td>
+                        <td><img src="Pictures/Transparent Pics/Mythos10.png" id="upg50" alt="Mythos upgrade 10" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos11.png" id="upg51" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos12.png" id="upg52" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos13.png" id="upg53" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos14.png" id="upg54" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos15.png" id="upg55" alt="" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos11.png" id="upg51" alt="Mythos upgrade 11" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos12.png" id="upg52" alt="Mythos upgrade 12" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos13.png" id="upg53" alt="Mythos upgrade 13" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos14.png" id="upg54" alt="Mythos upgrade 14" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos15.png" id="upg55" alt="Mythos upgrade 15" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos16.png" id="upg56" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos17.png" id="upg57" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos18.png" id="upg58" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos19.png" id="upg59" alt="" loading="lazy"></td>
-                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos20.png" id="upg60" alt="" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos16.png" id="upg56" alt="Mythos upgrade 16" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos17.png" id="upg57" alt="Mythos upgrade 17" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos18.png" id="upg58" alt="Mythos upgrade 18" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos19.png" id="upg59" alt="Mythos upgrade 19" loading="lazy"></td>
+                        <td><img class="reincarnationunlock" src="Pictures/Transparent Pics/Mythos20.png" id="upg60" alt="Mythos upgrade 20" loading="lazy"></td>
                     </tr>
                 </table>
                 <button class="autobuyerToggleButton upgradeToggle" id="transcendAutoUpgrade" style="border:2px solid green">Auto: ON</button>
@@ -740,34 +740,34 @@
             <div>
                 <img class="prestigeunlock" src="Pictures/Generators.png" alt="" loading="lazy">
                 <p class="prestigeunlock" id="generatortext" style="color: lightgray">Generator Shop</p>
-                <table class="prestigeunlock" id="generatortable" style="padding: 0; font-size:0;">
+                <table class="prestigeunlock" id="generatortable" style="padding: 0; font-size:0;" alt="Generator Shop Table">
                     <tr>
-                        <td><img id="upg101" src="Pictures/Transparent Pics/GeneratorOne.png" alt="" loading="lazy"></td>
-                        <td><img id="upg102" class="generationunlock" src="Pictures/Transparent Pics/GeneratorTwo.png" alt="" loading="lazy"></td>
-                        <td><img id="upg103" class="generationunlock" src="Pictures/Transparent Pics/GeneratorThree.png" alt="" loading="lazy"></td>
-                        <td><img id="upg104" class="generationunlock" src="Pictures/Transparent Pics/GeneratorFour.png" alt="" loading="lazy"></td>
-                        <td><img id="upg105" class="generationunlock" src="Pictures/Transparent Pics/GeneratorFive.png" alt="" loading="lazy"></td>
+                        <td><img id="upg101" src="Pictures/Transparent Pics/GeneratorOne.png" alt="Generator 1" loading="lazy"></td>
+                        <td><img id="upg102" class="generationunlock" src="Pictures/Transparent Pics/GeneratorTwo.png" alt="Generator 2" loading="lazy"></td>
+                        <td><img id="upg103" class="generationunlock" src="Pictures/Transparent Pics/GeneratorThree.png" alt="Generator 3" loading="lazy"></td>
+                        <td><img id="upg104" class="generationunlock" src="Pictures/Transparent Pics/GeneratorFour.png" alt="Generator 4" loading="lazy"></td>
+                        <td><img id="upg105" class="generationunlock" src="Pictures/Transparent Pics/GeneratorFive.png" alt="Generator 5" loading="lazy"></td>
                     </tr>
                     <tr>
-                        <td><img id="upg106" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSix.png" alt="" loading="lazy"></td>
-                        <td><img id="upg107" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSeven.png" alt="" loading="lazy"></td>
-                        <td><img id="upg108" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEight.png" alt="" loading="lazy"></td>
-                        <td><img id="upg109" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorNine.png" alt="" loading="lazy"></td>
-                        <td><img id="upg110" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTen.png" alt="" loading="lazy"></td>
+                        <td><img id="upg106" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSix.png" alt="Generator 6" loading="lazy"></td>
+                        <td><img id="upg107" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSeven.png" alt="Generator 7" loading="lazy"></td>
+                        <td><img id="upg108" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEight.png" alt="Generator 8" loading="lazy"></td>
+                        <td><img id="upg109" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorNine.png" alt="Generator 9" loading="lazy"></td>
+                        <td><img id="upg110" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTen.png" alt="Generator 10" loading="lazy"></td>
                     </tr>
                     <tr>
-                        <td><img id="upg111" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEleven.png" alt="" loading="lazy"></td>
-                        <td><img id="upg112" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTwelve.png" alt="" loading="lazy"></td>
-                        <td><img id="upg113" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorThirteen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg114" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorFourteen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg115" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorFifteen.png" alt="" loading="lazy"></td>
+                        <td><img id="upg111" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEleven.png" alt="Generator 11" loading="lazy"></td>
+                        <td><img id="upg112" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTwelve.png" alt="Generator 12" loading="lazy"></td>
+                        <td><img id="upg113" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorThirteen.png" alt="Generator 13" loading="lazy"></td>
+                        <td><img id="upg114" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorFourteen.png" alt="Generator 14" loading="lazy"></td>
+                        <td><img id="upg115" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorFifteen.png" alt="Generator 15" loading="lazy"></td>
                     </tr>
                     <tr>
-                        <td><img id="upg116" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSixteen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg117" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSeventeen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg118" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEighteen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg119" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorNineteen.png" alt="" loading="lazy"></td>
-                        <td><img id="upg120" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTwenty.png" alt="" loading="lazy"></td>
+                        <td><img id="upg116" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSixteen.png" alt="Generator 16" loading="lazy"></td>
+                        <td><img id="upg117" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorSeventeen.png" alt="Generator 17" loading="lazy"></td>
+                        <td><img id="upg118" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorEighteen.png" alt="Generator 18" loading="lazy"></td>
+                        <td><img id="upg119" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorNineteen.png" alt="Generator 19" loading="lazy"></td>
+                        <td><img id="upg120" class="transcendunlock" src="Pictures/Transparent Pics/GeneratorTwenty.png" alt="Generator 20" loading="lazy"></td>
                     </tr>
                 </table>
                 <button class="autobuyerToggleButton upgradeToggle" id="generatorsAutoUpgrade" style="border:2px solid green">Auto: ON</button>
@@ -775,68 +775,68 @@
             <div>
                 <img class="prestigeunlock" src="Pictures/Automation.png" alt="" loading="lazy">
                 <p class="prestigeunlock" id="automationtext" style="color: crimson">Automation Shop</p>
-                <table class="prestigeunlock" id="automationtable" style="padding: 0; font-size:0;">
+                <table class="prestigeunlock" id="automationtable" style="padding: 0; font-size:0;" alt="Automation Shop Table">
                     <tr>
-                       <td><img id="upg81" src="Pictures/Transparent Pics/AutomationOne.png" alt="" loading="lazy"></td>
-                       <td><img id="upg82" src="Pictures/Transparent Pics/AutomationTwo.png" alt="" loading="lazy"></td>
-                       <td><img id="upg83" src="Pictures/Transparent Pics/AutomationThree.png" alt="" loading="lazy"></td>
-                       <td><img id="upg84" src="Pictures/Transparent Pics/AutomationFour.png" alt="" loading="lazy"></td>
-                       <td><img id="upg85" src="Pictures/Transparent Pics/AutomationFive.png" alt="" loading="lazy"></td>
+                       <td><img id="upg81" src="Pictures/Transparent Pics/AutomationOne.png" alt="Automation 1" loading="lazy"></td>
+                       <td><img id="upg82" src="Pictures/Transparent Pics/AutomationTwo.png" alt="Automation 2" loading="lazy"></td>
+                       <td><img id="upg83" src="Pictures/Transparent Pics/AutomationThree.png" alt="Automation 3" loading="lazy"></td>
+                       <td><img id="upg84" src="Pictures/Transparent Pics/AutomationFour.png" alt="Automation 4" loading="lazy"></td>
+                       <td><img id="upg85" src="Pictures/Transparent Pics/AutomationFive.png" alt="Automation 5" loading="lazy"></td>
                    </tr>
                    <tr>
-                       <td><img id="upg86" src="Pictures/Transparent Pics/AutomationSix.png" alt="" loading="lazy"></td>
-                       <td><img id="upg87" src="Pictures/Transparent Pics/AutomationSeven.png" alt="" loading="lazy"></td>
-                       <td><img id="upg88" class="transcendunlock" id="auto8" src="Pictures/Transparent Pics/AutomationEight.png" alt="" loading="lazy"></td>
-                       <td><img id="upg89" class="transcendunlock" id="auto9" src="Pictures/Transparent Pics/AutomationNine.png" alt="" loading="lazy"></td>
-                       <td><img id="upg90" class="transcendunlock" id="auto10" src="Pictures/Transparent Pics/AutomationTen.png" alt="" loading="lazy"></td>
+                       <td><img id="upg86" src="Pictures/Transparent Pics/AutomationSix.png" alt="Automation 6" loading="lazy"></td>
+                       <td><img id="upg87" src="Pictures/Transparent Pics/AutomationSeven.png" alt="Automation 7" loading="lazy"></td>
+                       <td><img id="upg88" class="transcendunlock" id="auto8" src="Pictures/Transparent Pics/AutomationEight.png" alt="Automation 8" loading="lazy"></td>
+                       <td><img id="upg89" class="transcendunlock" id="auto9" src="Pictures/Transparent Pics/AutomationNine.png" alt="Automation 9" loading="lazy"></td>
+                       <td><img id="upg90" class="transcendunlock" id="auto10" src="Pictures/Transparent Pics/AutomationTen.png" alt="Automation 10" loading="lazy"></td>
                    </tr>
                    <tr>
-                       <td><img id="upg91" class="transcendunlock" src="Pictures/Transparent Pics/AutomationEleven.png" alt="" loading="lazy"></td>
-                       <td><img id="upg92" class="transcendunlock" src="Pictures/Transparent Pics/AutomationTwelve.png" alt="" loading="lazy"></td>
-                       <td><img id="upg93" class="transcendunlock" src="Pictures/Transparent Pics/AutomationThirteen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg94" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationFourteen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg95" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationFifteen.png" alt="" loading="lazy"></td>
+                       <td><img id="upg91" class="transcendunlock" src="Pictures/Transparent Pics/AutomationEleven.png" alt="Automation 11" loading="lazy"></td>
+                       <td><img id="upg92" class="transcendunlock" src="Pictures/Transparent Pics/AutomationTwelve.png" alt="Automation 12" loading="lazy"></td>
+                       <td><img id="upg93" class="transcendunlock" src="Pictures/Transparent Pics/AutomationThirteen.png" alt="Automation 13" loading="lazy"></td>
+                       <td><img id="upg94" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationFourteen.png" alt="Automation 14" loading="lazy"></td>
+                       <td><img id="upg95" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationFifteen.png" alt="Automation 15" loading="lazy"></td>
                    </tr>
                    <tr>
-                       <td><img id="upg96" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationSixteen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg97" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationSeventeen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg98" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationEighteen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg99" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationNineteen.png" alt="" loading="lazy"></td>
-                       <td><img id="upg100" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationTwenty.png" alt="" loading="lazy"></td>
+                       <td><img id="upg96" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationSixteen.png" alt="Automation 16" loading="lazy"></td>
+                       <td><img id="upg97" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationSeventeen.png" alt="Automation 17" loading="lazy"></td>
+                       <td><img id="upg98" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationEighteen.png" alt="Automation 18" loading="lazy"></td>
+                       <td><img id="upg99" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationNineteen.png" alt="Automation 19" loading="lazy"></td>
+                       <td><img id="upg100" class="reincarnationunlock" src="Pictures/Transparent Pics/AutomationTwenty.png" alt="Automation 20" loading="lazy"></td>
                    </tr>
                </table>
             </div>
             <div>
                 <img class="reincarnationunlock" src="Pictures/Particle.png" alt="" loading="lazy">
                 <p class="reincarnationunlock" id="reincarnationtext" style="color: limegreen">Particles Upgrades</p>
-                <table class="reincarnationunlock" id="reincarnationupgradestable" style="padding: 0; font-size:0;">
+                <table class="reincarnationunlock" id="reincarnationupgradestable" style="padding: 0; font-size:0;" alt="Particles Upgrades Table">
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle1.png" id="upg61" alt="" loading="lazy"></td>
-                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle2.png" id="upg62" alt="" loading="lazy"></td>
-                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle3.png" id="upg63" alt="" loading="lazy"></td>
-                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle4.png" id="upg64" alt="" loading="lazy"></td>
-                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle5.png" id="upg65" alt="" loading="lazy"></td>
+                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle1.png" id="upg61" alt="Particles upgrade 1" loading="lazy"></td>
+                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle2.png" id="upg62" alt="Particles upgrade 2" loading="lazy"></td>
+                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle3.png" id="upg63" alt="Particles upgrade 3" loading="lazy"></td>
+                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle4.png" id="upg64" alt="Particles upgrade 4" loading="lazy"></td>
+                        <td><img class="reinrow1" src="Pictures/Transparent Pics/Particle5.png" id="upg65" alt="Particles upgrade 5" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle6.png" id="upg66" alt="" loading="lazy"></td>
-                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle7.png" id="upg67" alt="" loading="lazy"></td>
-                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle8.png" id="upg68" alt="" loading="lazy"></td>
-                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle9.png" id="upg69" alt="" loading="lazy"></td>
-                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle10.png" id="upg70" alt="" loading="lazy"></td>
+                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle6.png" id="upg66" alt="Particles upgrade 6" loading="lazy"></td>
+                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle7.png" id="upg67" alt="Particles upgrade 7" loading="lazy"></td>
+                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle8.png" id="upg68" alt="Particles upgrade 8" loading="lazy"></td>
+                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle9.png" id="upg69" alt="Particles upgrade 9" loading="lazy"></td>
+                        <td><img class="reinrow2" src="Pictures/Transparent Pics/Particle10.png" id="upg70" alt="Particles upgrade 10" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle11.png" id="upg71" alt="" loading="lazy"></td>
-                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle12.png" id="upg72" alt="" loading="lazy"></td>
-                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle13.png" id="upg73" alt="" loading="lazy"></td>
-                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle14.png" id="upg74" alt="" loading="lazy"></td>
-                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle15.png" id="upg75" alt="" loading="lazy"></td>
+                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle11.png" id="upg71" alt="Particles upgrade 11" loading="lazy"></td>
+                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle12.png" id="upg72" alt="Particles upgrade 12" loading="lazy"></td>
+                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle13.png" id="upg73" alt="Particles upgrade 13" loading="lazy"></td>
+                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle14.png" id="upg74" alt="Particles upgrade 14" loading="lazy"></td>
+                        <td><img class="reinrow3" src="Pictures/Transparent Pics/Particle15.png" id="upg75" alt="Particles upgrade 15" loading="lazy"></td>
                     </tr>
                     <tr style="text-align:center; border-collapse:collapse;">
-                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle16.png" id="upg76" alt="" loading="lazy"></td>
-                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle17.png" id="upg77" alt="" loading="lazy"></td>
-                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle18.png" id="upg78" alt="" loading="lazy"></td>
-                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle19.png" id="upg79" alt="" loading="lazy"></td>
-                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle20.png" id="upg80" alt="" loading="lazy"></td>
+                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle16.png" id="upg76" alt="Particles upgrade 16" loading="lazy"></td>
+                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle17.png" id="upg77" alt="Particles upgrade 17" loading="lazy"></td>
+                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle18.png" id="upg78" alt="Particles upgrade 18" loading="lazy"></td>
+                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle19.png" id="upg79" alt="Particles upgrade 19" loading="lazy"></td>
+                        <td><img class="reinrow4" src="Pictures/Transparent Pics/Particle20.png" id="upg80" alt="Particles upgrade 20" loading="lazy"></td>
                     </tr>
                 </table>
                 <button class="autobuyerToggleButton upgradeToggle" id="reincarnateAutoUpgrade" style="border: 2px solid green">Auto: ON</button>
@@ -844,9 +844,11 @@
         </div>
 
         <div id="upgradesrow3">
-            <p id="upgradedescription" style="color: beige">Hover over an upgrade icon to see details!</p>
-            <p id="upgradecost"></p>
-            <p id="upgradeeffect"></p>
+            <section id="descriptionOfHoveredUpgrade">
+                <p id="upgradedescription" style="color: beige">Hover over an upgrade icon to see details!</p>
+                <p id="upgradecost"></p>
+                <p id="upgradeeffect"></p>
+            </section>
             <button class="auto autobuyerToggleButton" id="toggle9" toggleid="9" format="Hover-to-Buy [$]" style="border:2px solid green">Hover-To-Buy: Off</button>
         </div>
     </div>

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -307,6 +307,15 @@ export const upgradedescriptions = (i: number) => {
     const el = document.getElementById("upgradedescription");
     el.textContent = y + z;
     el.style.color = player.upgrades[i] > 0.5 ? 'gold' : 'white';
+    
+    
+    //to disassociate the descriptions with the previously hovered upgrade (might not be needed, IDK)
+    if ("of" in el.dataset) {
+        document.getElementById(el.dataset.of).removeAttribute('aria-describedby');
+    }
+    el.dataset.of = "upg" + number;
+    //this will associate the descriptions with the hovered upgrade
+    document.getElementById(el.dataset.of).setAttribute('aria-describedby', "upgradedescription upgradecost upgradeeffect");
 
     if (player.toggles[9] === true) {
         let type = ''


### PR DESCRIPTION
Added alt text to all the resource icons and reset buttons, and all the Upgrade tab upgrades. Hopefully this helps people find the reset buttons and upgrades easier.

Also added a hopefully-helpful dynamic adding and removing of `aria-describedby` to things when hovered, so a screen reader will automatically read the dynamically updated descriptions fields right after reading the image's alt text. 

Keeping the score small for this, want to get this into the hands of someone who actually know what they're doing with screen readers and keyboard navigation to tell if this is actually helpful or not before going all in on everything else. My screen reader does what I expect it to when hovering around in a jsfiddle, but I have no idea how actual users of keyboard navigation do keyboard navigation.