### PR TITLE
Autobuy all tesseract buildings simultaneously

### DIFF
--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -719,7 +719,181 @@ export const tesseractBuildingCosts = [1, 10, 100, 1000, 10000] as const;
 //   tesseractBuildingCosts[i-1] * n^3.
 // so the first n tesseract buildings of tier i costs
 //   cost(n) = tesseractBuildingCosts[i-1] * (n * (n+1) / 2)^2
-// in total. Use cost(owned+buyAmount) - cost(owned) to figure the cost of 
+// in total. Use cost(owned+buyAmount) - cost(owned) to figure the cost of
+// buying multiple buildings.
+
+export type TesseractBuildings = [number|null, number|null, number|null, number|null, number|null];
+
+const buyTessBuildingsToCheapestPrice = (ownedBuildings: TesseractBuildings, cheapestPrice: number): [number, TesseractBuildings] => {
+    const buyToBuildings = ownedBuildings.map((currentlyOwned, index) => {
+        if (currentlyOwned === null) {
+            return null;
+        }
+        // thisPrice >= cheapestPrice = tesseractBuildingCosts[index] * (buyTo+1)^3
+        // buyTo = cuberoot(cheapestPrice / tesseractBuildingCosts[index]) - 1
+        // If buyTo has a fractional part, we want to round UP so that this
+        // price costs more than the cheapest price.
+        // If buyTo doesn't have a fractional part, thisPrice = cheapestPrice.
+        const buyTo = Math.ceil(Math.pow(cheapestPrice / tesseractBuildingCosts[index], 1/3) - 1);
+        // It could be possible that cheapestPrice is less than the CURRENT
+        // price of this building, so take the max of the number of buildings
+        // we currently have.
+        return Math.max(currentlyOwned, buyTo);
+    }) as TesseractBuildings;
+
+    let price = 0;
+    for (let i = 0; i < ownedBuildings.length; i++) {
+        const buyFrom = ownedBuildings[i];
+        const buyTo = buyToBuildings[i];
+        if (buyFrom === null || buyTo === null) {
+            continue;
+        }
+        price += tesseractBuildingCosts[i] * (Math.pow(buyTo * (buyTo + 1) / 2, 2) - Math.pow(buyFrom * (buyFrom + 1) / 2, 2));
+    }
+
+    return [price, buyToBuildings];
+};
+
+/**
+ * Calculate the result of repeatedly buying the cheapest tesseract building,
+ * given an initial list of owned buildings and a budget.
+ * 
+ * This function is pure and does not rely on any global state other than
+ * constants for ease of testing.
+ * 
+ * For tests:
+ * calculateInBudget([0, 0, 0, 0, 0], 100) = [3, 1, 0, 0, 0]
+ * calculateInBudget([null, 0, 0, 0, 0], 100) = [null, 2, 0, 0, 0]
+ * calculateInBudget([3, 1, 0, 0, 0], 64+80-1) = [4, 1, 0, 0, 0]
+ * calculateInBudget([3, 1, 0, 0, 0], 64+80) = [4, 2, 0, 0, 0]
+ * calculateInBudget([9, 100, 100, 0, 100], 1000) = [9, 100, 100, 1, 100]
+ * calculateInBudget([9, 100, 100, 0, 100], 2000) = [10, 100, 100, 1, 100]
+ * 
+ * and calculateInBudget([0, 0, 0, 0, 0], 1e46) should run in less than a
+ * second.
+ * 
+ * @param ownedBuildings The amount of buildings owned, or null if the building
+ * should not be bought.
+ * @param budget The number of tesseracts to spend.
+ * @returns The amount of buildings owned after repeatedly buying the cheapest
+ * building with the budget.
+ */
+export const calculateTessBuildingsInBudget = (ownedBuildings: TesseractBuildings, budget: number): TesseractBuildings => {
+    // Nothing is affordable.
+    // Also catches the case when budget <= 0, and all values are null.
+    let minCurrentPrice: number|null = null;
+    for (let i = 0; i < ownedBuildings.length; i++) {
+        const owned = ownedBuildings[i];
+        if (owned === null) {
+            continue;
+        }
+        const price = tesseractBuildingCosts[i] * Math.pow(owned + 1, 3);
+        if (minCurrentPrice === null || price < minCurrentPrice) {
+            minCurrentPrice = price;
+        }
+    }
+
+    if (minCurrentPrice === null || minCurrentPrice > budget) {
+        return ownedBuildings;
+    }
+
+    // Every time the cheapest building is bought, the cheapest price either
+    // stays constant (if there are two or more cheapest buildings), or
+    // increases.
+    //
+    // Additionally, given the price of a building, calculating
+    // - the amount of buildings needed to hit that price and
+    // - the cumulative cost to buy to that amount of buildings
+    // can be done with a constant number of floating point operations.
+    //
+    // Therefore, by binary searching over "cheapest price when finished", we
+    // are able to efficiently (O(log budget)) determine the number of buildings
+    // owned after repeatedly buying the cheapest building. Calculating the
+    // cheapest building and buying one at a time would take O(budget^(1/4))
+    // time - and as the budget could get very large (this is Synergism after
+    // all), this is probably too slow.
+    //
+    // That is, we have a function f(cheapestPrice) which returns the cost of
+    // buying buildings until all prices to buy are cheapestPrice or higher, and
+    // we want to find the maximum value of cheapestPrice such that
+    // f(cheapestPrice) <= budget.
+    // In this case, f(x) = buyTessBuildingsToCheapestPrice(ownedBuildings, x)[0].
+    
+    // f(minCurrentPrice) = 0 < budget. We also know that we can definitely buy
+    // at least one thing.
+    let lo = minCurrentPrice;
+    // Do an exponential search to find the upper bound.
+    let hi = lo * 2;
+    while (buyTessBuildingsToCheapestPrice(ownedBuildings, hi)[0] <= budget) {
+        lo = hi;
+        hi *= 2;
+    }
+    // Invariant:
+    // f(lo) <= budget < f(hi).
+    while (hi - lo > 0.5) {
+        const mid = lo + (hi - lo) / 2;
+        // It's possible to get into an infinite loop if mid here is equal to
+        // the boundaries, even if hi !== lo (due to floating point inaccuracy).
+        if (mid === lo || mid === hi) {
+            break;
+        }
+        if (buyTessBuildingsToCheapestPrice(ownedBuildings, mid)[0] <= budget) {
+            lo = mid;
+        } else {
+            hi = mid;
+        }
+    }
+
+    // Binary search is done (with lo being the best candidate).
+    const [cost, buildings] = buyTessBuildingsToCheapestPrice(ownedBuildings, lo);
+
+    // Note that this has a slight edge case when 2 <= N <= 5 buildings are the
+    // same price, and it is optimal to buy only M < N of them at that price.
+    // The result of this edge case is that we can finish the binary search with
+    // a set of buildings which are affordable, but more buildings can still be
+    // bought. To fix this, we greedily buy the cheapest building one at a time,
+    // which should take 4 or less iterations to run out of budget.
+    let remainingBudget = budget - cost;
+    const currentPrices = buildings.map((num, index) => {
+        if (num === null) {
+            return null;
+        }
+        return tesseractBuildingCosts[index] * Math.pow(num+1, 3);
+    });
+
+    for (let iteration = 1; iteration <= 5; iteration++) {
+        let minimum: {price: number, index: number}|null = null;
+        for (let index = 0; index < currentPrices.length; index++) {
+            const price = currentPrices[index];
+            if (price === null) {
+                continue;
+            }
+            // <= is used instead of < to prioritise the higher tier buildings
+            // over the lower tier ones if they have the same price.
+            if (minimum === null || price <= minimum.price) {
+                minimum = {price, index};
+            }
+        }
+        if (minimum !== null && minimum.price <= remainingBudget) {
+            remainingBudget -= minimum.price;
+            // buildings[minimum.index] should always be a number.
+            // In extreme situations (when buildings[minimum.index] is bigger
+            // than Number.MAX_SAFE_INTEGER), this below increment won't work.
+            // However, that requires 1e47 tesseracts to get to, which shouldn't
+            // ever happen.
+            buildings[minimum.index]!++;
+            currentPrices[minimum.index] = tesseractBuildingCosts[minimum.index] * Math.pow(buildings[minimum.index]!+1, 3);
+            if (iteration === 5) {
+                console.warn(`Error in calculateInBudget(${JSON.stringify(ownedBuildings)}, ${JSON.stringify(budget)}). Copy this message and report this to a developer.`);
+            }
+        } else {
+            // Can't afford cheapest any more - break.
+            break;
+        }
+    }
+
+    return buildings;
+};
 
 /**
  * @param index Which tesseract building to get the cost of.
@@ -727,10 +901,10 @@ export const tesseractBuildingCosts = [1, 10, 100, 1000, 10000] as const;
  * @param checkCanAfford Whether to limit the purchase amount to the number of buildings the player can afford.
  * @returns A pair of [number of buildings after purchase, cost of purchase].
  */
-export const getTesseractCost = (index: OneToFive, amount?: number, checkCanAfford = true): [number, number] => {
+export const getTesseractCost = (index: OneToFive, amount?: number, checkCanAfford = true, buyFrom?: number): [number, number] => {
     amount ??= player.tesseractbuyamount;
+    buyFrom ??= player[`ascendBuilding${index}` as const]['owned'];
     const intCost = tesseractBuildingCosts[index - 1];
-    const buyFrom = player[`ascendBuilding${index}` as const]['owned'];
     const subCost = intCost * Math.pow(buyFrom * (buyFrom + 1) / 2, 2);
 
     let actualBuy: number;

--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -918,8 +918,7 @@ export const getTesseractCost = (index: OneToFive, amount?: number, checkCanAffo
     return [actualBuy, actualCost];
 }
 
-export const buyTesseractBuilding = (index: OneToFive, amount?: number) => {
-    amount ??= player.tesseractbuyamount;
+export const buyTesseractBuilding = (index: OneToFive, amount = player.tesseractbuyamount) => {
     const intCost = tesseractBuildingCosts[index - 1];
     const ascendBuildingIndex = `ascendBuilding${index}` as const;
     // Destructuring FTW!

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2875,7 +2875,7 @@ export const updateAll = (): void => {
         for (let i = 5; i >= 1; i--) {
             const buyFrom = ownedBuildings[i-1];
             const buyTo = buyToBuildings[i-1];
-            if (buyFrom !== null && buyTo !== null) {
+            if (buyFrom !== null && buyTo !== null && buyTo !== buyFrom) {
                 buyTesseractBuilding(i as OneToFive, buyTo - buyFrom);
             }
         }

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2860,20 +2860,20 @@ export const updateAll = (): void => {
         }
     }
 
-//Loops through all buildings which have AutoBuy turned 'on' and purchases the cheapest available building that player can afford
+//Loops through all buildings which have AutoBuy turned 'on' and purchases one of the cheapest available building that player can afford
     if ((player.researches[190] > 0) && (player.tesseractAutoBuyerToggle == 1)) {
         const cheapestTesseractBuilding: {cost: number, index: 0|OneToFive} = { cost:0, index:0 };
-        for (let i = 0; i < tesseractBuildingCosts.length; i++){
-            const iPlusOne = i+1 as OneToFive;
-            if ((Number(player.wowTesseracts) >= tesseractBuildingCosts[i] * Math.pow(player.tesseractbuyamount + player[`ascendBuilding${iPlusOne}` as const]['owned'], 3) + player.tesseractAutoBuyerAmount) && player.autoTesseracts[iPlusOne]) {
-                if ((getTesseractCost(iPlusOne)[1] < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
-                    cheapestTesseractBuilding.cost = getTesseractCost(iPlusOne)[1];
-                    cheapestTesseractBuilding.index = iPlusOne;
+        for (let i = 1; i <= 5; i++){
+            const cost = getTesseractCost(i as OneToFive, 1, false)[1];
+            if ((Number(player.wowTesseracts) >= cost + player.tesseractAutoBuyerAmount) && player.autoTesseracts[i]) {
+                if ((cost < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
+                    cheapestTesseractBuilding.cost = cost;
+                    cheapestTesseractBuilding.index = i as OneToFive;
                 }
             }
         }
         if (cheapestTesseractBuilding.index !== 0){
-            buyTesseractBuilding(cheapestTesseractBuilding.index, true);
+            buyTesseractBuilding(cheapestTesseractBuilding.index, 1);
         }
     }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -21,7 +21,7 @@ import { antSacrificePointsToMultiplier, autoBuyAnts, calculateCrumbToCoinExp } 
 import { calculatetax } from './Tax';
 import { ascensionAchievementCheck, challengeachievementcheck, achievementaward, resetachievementcheck, buildingAchievementCheck } from './Achievements';
 import { reset } from './Reset';
-import { buyMax, buyAccelerator, buyMultiplier, boostAccelerator, buyCrystalUpgrades, buyParticleBuilding, getReductionValue, getCost, buyRuneBonusLevels, buyTesseractBuilding, getTesseractCost, tesseractBuildingCosts } from './Buy';
+import { buyMax, buyAccelerator, buyMultiplier, boostAccelerator, buyCrystalUpgrades, buyParticleBuilding, getReductionValue, getCost, buyRuneBonusLevels, buyTesseractBuilding, TesseractBuildings, calculateTessBuildingsInBudget } from './Buy';
 import { autoUpgrades } from './Automation';
 import { redeemShards } from './Runes';
 import { updateCubeUpgradeBG } from './Cubes';
@@ -2860,20 +2860,24 @@ export const updateAll = (): void => {
         }
     }
 
-//Loops through all buildings which have AutoBuy turned 'on' and purchases one of the cheapest available building that player can afford
+//Autobuy tesseract buildings
     if ((player.researches[190] > 0) && (player.tesseractAutoBuyerToggle == 1)) {
-        const cheapestTesseractBuilding: {cost: number, index: 0|OneToFive} = { cost:0, index:0 };
-        for (let i = 1; i <= 5; i++){
-            const cost = getTesseractCost(i as OneToFive, 1, false)[1];
-            if ((Number(player.wowTesseracts) >= cost + player.tesseractAutoBuyerAmount) && player.autoTesseracts[i]) {
-                if ((cost < cheapestTesseractBuilding.cost) || (cheapestTesseractBuilding.cost == 0)){
-                    cheapestTesseractBuilding.cost = cost;
-                    cheapestTesseractBuilding.index = i as OneToFive;
-                }
+        const ownedBuildings: TesseractBuildings = [null, null, null, null, null];
+        for (let i = 1; i <= 5; i++) {
+            if (player.autoTesseracts[i]) {
+                ownedBuildings[i-1] = player[`ascendBuilding${i as OneToFive}` as const]['owned'];
             }
         }
-        if (cheapestTesseractBuilding.index !== 0){
-            buyTesseractBuilding(cheapestTesseractBuilding.index, 1);
+        const budget = Number(player.wowTesseracts) - player.tesseractAutoBuyerAmount;
+        const buyToBuildings = calculateTessBuildingsInBudget(ownedBuildings, budget);
+        // Prioritise buying buildings from highest tier to lowest,
+        // in case there are any off-by-ones or floating point errors.
+        for (let i = 5; i >= 1; i--) {
+            const buyFrom = ownedBuildings[i-1];
+            const buyTo = buyToBuildings[i-1];
+            if (buyFrom !== null && buyTo !== null) {
+                buyTesseractBuilding(i as OneToFive, buyTo - buyFrom);
+            }
         }
     }
 


### PR DESCRIPTION
This fixes the bug mentioned in #68 (by not buying multiples at all), and fixes some edge cases with the previous logic.

As a counterexample to the previous logic, imagine:

- No buildings bought (costs are [1, 10, 100, ...])
- tesseractbuyamount is 10.
- Player has 100 tesseracts.

The previous logic would buy two tier 2s (10+80=90), which is cheaper than buying four tier 1s (1+8+27+64=100) or one tier 3 (100). However, the expected behavior here is to buy three tier 1s and one tier 2.

~~As a result, however, autobuying is slower and takes N ticks to buy N buildings. Let me know if this is a problem - I can implement an O(log tesseracts) binary search to buy the exact amount of buildings needed instead of buying them one-by-one if needed.~~

Instead of buying one-by-one, this PR now buys all tesseracts in one shot, even with ridiculous numbers of tesseracts (accurate up to 1e47 tesseracts, still works up to 1e300).