### PR TITLE
Increased width to fix display overlap

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -1555,7 +1555,7 @@ nav li:hover {
 }
 
 #researchDetails > p {
-    width: 750px;
+    width: 850px;
     margin: auto;
 }
 


### PR DESCRIPTION
r8x25 description overlapped cost display after adding tax reduction. Increasing the width close to the width of researchtable fixes that.