### PR TITLE
Fix requests every tick when cache is disabled

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -56,7 +56,7 @@ export const resetdetails = (input: resetNames) => {
 
     switch(input){
         case "prestige":
-            if(currencyImage1.src !== "Pictures/Diamond.png"){
+            if (!currencyImage1.src.endsWith("Pictures/Diamond.png")) {
                 currencyImage1.src = "Pictures/Diamond.png"
             }
             currencyImage1.style.display = "block"
@@ -65,7 +65,7 @@ export const resetdetails = (input: resetNames) => {
             resetInfo.style.color = "turquoise";
             break;
         case "transcension":
-            if(currencyImage1.src !== "Pictures/Mythos.png"){
+            if (!currencyImage1.src.endsWith("Pictures/Mythos.png")) {
                 currencyImage1.src = "Pictures/Mythos.png"
             }
             currencyImage1.style.display = "block"
@@ -74,7 +74,7 @@ export const resetdetails = (input: resetNames) => {
             resetInfo.style.color = "orchid";
             break;
         case "reincarnation":
-            if(currencyImage1.src !== "Pictures/Particle.png"){
+            if (!currencyImage1.src.endsWith("Pictures/Particle.png")) {
                 currencyImage1.src = "Pictures/Particle.png"
             }
             currencyImage1.style.display = "block"
@@ -83,7 +83,7 @@ export const resetdetails = (input: resetNames) => {
             resetInfo.style.color = "limegreen";
             break;
         case "acceleratorBoost":
-            if(currencyImage1.src !== "Pictures/Diamond.png") {
+            if (!currencyImage1.src.endsWith("Pictures/Diamond.png")) {
                 currencyImage1.src = "Pictures/Diamond.png"
             }
             currencyImage1.style.display = "block"


### PR DESCRIPTION
When the cache is disabled, currency images get repeatedly requested from the server when the current "reset details" shows a currency image. The root cause of this is that accessing the .src property of an element actually returns the full URL, and not a relative URL.

This commit fixes this by using !endsWith instead of !==.