### PR TITLE
Maintain last updated date automatically

### DIFF
--- a/.github/workflows/deploy-ghpages.yml
+++ b/.github/workflows/deploy-ghpages.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Build
         run: |
           npm install
+          npm run-script set-updated-date
           npm run-script build:esbuild
       - name: Prepare for deploy
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
 *.js
+!update-last-updated.js
 dist
 !.eslintrc.js

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "build:esbuild": "npx esbuild src/Synergism.ts --bundle --minify --sourcemap --target=\"chrome58,firefox57,safari11,edge29\" --outfile=\"./dist/out.js\"",
     "watch:esbuild": "npx esbuild src/Synergism.ts --bundle --minify --sourcemap --target=\"chrome58,firefox57,safari11,edge29\" --outfile=\"./dist/out.js\" --watch",
     "check:tsc": "npx -p typescript tsc",
-    "watch:tsc": "npx -p typescript tsc --watch"
+    "watch:tsc": "npx -p typescript tsc --watch",
+    "set-updated-date": "node update-last-updated.js"
   },
   "repository": {
     "type": "git",

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1303,7 +1303,7 @@ export const calculateAscensionScore = () => {
     baseScore *= Math.pow(1.03 + 0.005 * player.cubeUpgrades[39] + 0.0025 * (player.platonicUpgrades[5] + player.platonicUpgrades[10]), player.highestchallengecompletions[10]);
     // Corruption Multiplier is the product of all Corruption Score multipliers based on used corruptions
     for (let i = 1; i <= 10; i++) {
-        let exponent = ((i === 1 || i === 2) && player.usedCorruptions[i] >= 7 && player.platonicUpgrades[17] > 0) ? 1 + 0.15 * (player.usedCorruptions[i] - 5) + 0.01* (player.platonicUpgrades[17] - 1)*(player.usedCorruptions[i] - 7) : 1;
+        const exponent = ((i === 1 || i === 2) && player.usedCorruptions[i] >= 7 && player.platonicUpgrades[17] > 0) ? 1 + 0.15 * (player.usedCorruptions[i] - 5) + 0.01* (player.platonicUpgrades[17] - 1)*(player.usedCorruptions[i] - 7) : 1;
         corruptionMultiplier *= Math.pow(G['corruptionPointMultipliers'][player.usedCorruptions[i]], exponent);
     }
 

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -1,4 +1,5 @@
-import { player, format, resetCheck, isTesting, blankSave} from './Synergism';
+import { player, format, resetCheck, blankSave} from './Synergism';
+import { testing } from './Config';
 import { Player } from './types/Synergism';
 import Decimal from 'break_infinity.js';
 import { calculateMaxRunes, calculateTimeAcceleration } from './Calculate';
@@ -305,7 +306,7 @@ export const checkVariablesOnLoad = (data: Player) => {
     // in old versions of the game (pre 2.5.0), the import function will only work
     // if this variable = "YES!". Don't ask Platonic why.
     if (typeof data.exporttest === 'string') {
-        player.exporttest = !isTesting;
+        player.exporttest = !testing;
     } else {
         player.exporttest = data.exporttest;
     }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,3 +1,3 @@
 export const version = '2.5.5';
 export const testing = false;
-export const lastUpdated: Date = new Date('##LAST_UPDATED##');
+export const lastUpdated = new Date('##LAST_UPDATED##');

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -1,0 +1,3 @@
+export const version = '2.5.5';
+export const testing = false;
+export const lastUpdated: Date = new Date('##LAST_UPDATED##');

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -1,6 +1,6 @@
 import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation } from "./Toggles"
 import { resetrepeat, updateAutoReset, updateTesseractAutoBuyAmount } from "./Reset"
-import { isTesting, player, resetCheck, saveSynergy } from "./Synergism"
+import { player, resetCheck, saveSynergy } from "./Synergism"
 import { boostAccelerator, buyAccelerator, buyMultiplier, buyProducer, buyCrystalUpgrades, buyParticleBuilding, buyTesseractBuilding, buyUpgrades, buyRuneBonusLevels } from "./Buy"
 import { crystalupgradedescriptions, constantUpgradeDescriptions, buyConstantUpgrades, upgradedescriptions } from "./Upgrades"
 import { buyAutobuyers } from "./Automation"
@@ -22,6 +22,7 @@ import { changeTabColor } from "./UpdateHTML"
 import { hepteractDescriptions, hepteractToOverfluxOrbDescription, tradeHepteractToOverfluxOrb, overfluxPowderDescription, overfluxPowderWarp } from "./Hepteracts"
 import { exitOffline, forcedDailyReset, timeWarp } from "./Calculate"
 import type { OneToFive, Player } from "./types/Synergism"
+import { testing } from './Config';
 
 /* STYLE GUIDE */
 /* 
@@ -43,7 +44,7 @@ import type { OneToFive, Player } from "./types/Synergism"
 export const generateEventHandlers = () => {
     const ordinals = ['null','first','second','third','fourth','fifth','sixth','seventh','eighth'] as const
 
-    if (isTesting) {
+    if (testing) {
         const warp = document.createElement('button');
         const dayReset = document.createElement('button');
         warp.textContent = 'Click here to warp time! [TESTING ONLY]';

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -1,4 +1,5 @@
-import { player, saveSynergy, blankSave, isTesting, reloadShit, version, format } from './Synergism';
+import { player, saveSynergy, blankSave, reloadShit, format } from './Synergism';
+import { testing, version } from './Config';
 import { getElementById } from './Utility';
 import LZString from 'lz-string';
 import { achievementaward } from './Achievements';
@@ -135,8 +136,8 @@ export const importSynergism = (input: string, reset = false) => {
 
     if (
         (f.exporttest === "YES!" || f.exporttest === true) ||
-        (f.exporttest === false && isTesting) ||
-        (f.exporttest === 'NO!' && isTesting)
+        (f.exporttest === false && testing) ||
+        (f.exporttest === 'NO!' && testing)
     ) {
         localStorage.setItem('Synergysave2', btoa(JSON.stringify(f)));
         localStorage.setItem('saveScumIsCheating', Date.now().toString());

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -37,13 +37,14 @@ import { WowCubes, WowHypercubes, WowPlatonicCubes, WowTesseracts } from './Cube
 import './Hotkeys';
 import { startHotkeys } from './Hotkeys';
 import { updatePlatonicUpgradeBG } from './Platonic';
+import { testing, version, lastUpdated } from './Config';
 
 /**
  * Whether or not the current version is a testing version or a main version.
  * This should be detected when importing a file.
  */
-export const isTesting = false;
-export const version = '2.5.5';
+//export const isTesting = false;
+//export const version = '2.5.5';
 
 export const intervalHold = new Set<ReturnType<typeof setInterval>>();
 export const interval = new Proxy(setInterval, {
@@ -601,7 +602,7 @@ export const player: Player = {
     autoTesseracts: [false, false, false, false, false, false],
 
     saveString: "Synergism-$VERSION$-$TIME$.txt",
-    exporttest: !isTesting,
+    exporttest: !testing,
 
     dayCheck: null,
     dayTimer: 0,
@@ -673,7 +674,7 @@ const loadSynergy = (reset = false) => {
     const save = localStorage.getItem("Synergysave2");
     const data = save ? JSON.parse(atob(save)) : null;
 
-    if (isTesting) {
+    if (testing) {
         Object.defineProperty(window, 'player', {
             value: player
         });
@@ -684,7 +685,7 @@ const loadSynergy = (reset = false) => {
     if (data) {
         if (
             (data.exporttest === false || data.exporttest === 'NO!') &&
-            !isTesting
+            !testing
         ) {
             return Alert(`You can't load this save anymore!`);
         }
@@ -1480,7 +1481,7 @@ export const format = (
     } else if (power >= 1e6) {
         // if the power is greater than 1e6 apply notation scientific notation
         // Makes mantissa be rounded down to 2 decimal places
-        const mantissaLook = isTesting && truncate ? '' : (Math.floor(mantissa * 100) / 100).toLocaleString(undefined, locOpts);
+        const mantissaLook = testing && truncate ? '' : (Math.floor(mantissa * 100) / 100).toLocaleString(undefined, locOpts);
         
         // Drops the power down to 4 digits total but never greater than 1000 in increments that equate to notations, (1234000 -> 1.234) ( 12340000 -> 12.34) (123400000 -> 123.4) (1234000000 -> 1.234)
         const powerDigits = Math.ceil(Math.log10(power));
@@ -3379,8 +3380,9 @@ export const reloadShit = async (reset = false) => {
 window.addEventListener('load', () => {
     const ver = document.getElementById('versionnumber');
     ver && (ver.textContent = 
-        `You're ${isTesting ? 'testing' : 'playing'} v${version} - Seal of the Merchant [Last Update: 8:10 UTC-8 2-Jul-2021].` + 
-        ` ${isTesting ? 'Savefiles cannot be used in live!' : ''}`
+        `You're ${testing ? 'testing' : 'playing'} v${version} - Seal of the Merchant` +
+        ` [Last Update: ${lastUpdated.getHours()}:${lastUpdated.getMinutes()} UTC ${lastUpdated.getDate()}-${lastUpdated.toLocaleString('en-us', {month: 'short'})}-${lastUpdated.getFullYear()}].` + 
+        ` ${testing ? 'Savefiles cannot be used in live!' : ''}`
     );
     document.title = `Synergism v${version}`;
 

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -1,6 +1,7 @@
 import Decimal from 'break_infinity.js';
 import { Globals as G } from './Variables';
-import { player, format, formatTimeShort, version } from './Synergism';
+import { player, format, formatTimeShort } from './Synergism';
+import { version } from './Config';
 import { CalcECC } from './Challenges';
 import { calculateSigmoidExponential, calculateMaxRunes, calculateRuneExpToLevel, calculateSummationLinear, calculateRecycleMultiplier, calculateCorruptionPoints, CalcCorruptionStuff, calculateAutomaticObtainium, calculateTimeAcceleration } from './Calculate';
 import { displayRuneInformation } from './Runes';

--- a/update-last-updated.js
+++ b/update-last-updated.js
@@ -1,0 +1,28 @@
+const {readFileSync, writeFileSync} = require('fs');
+
+const currentDate = new Date();
+const UTC = `Date.UTC(${currentDate.getUTCFullYear()}, ${currentDate.getUTCMonth()}, ${currentDate.getUTCDate()}, ${currentDate.getUTCHours()}, ${currentDate.getUTCMinutes()}, ${currentDate.getUTCSeconds()})`;
+console.log('\x1b[33m%s\x1b[0m', `Updating last updated config date to ${UTC}`);
+
+
+try {
+    console.log('\x1b[33m%s\x1b[0m', 'Reading file & updating ##LAST_UPDATED##')
+    let config = readFileSync(`${__dirname}/src/Config.ts`).toString();
+
+    if (!config.match(/'##LAST_UPDATED##'/g)) {
+        throw new Error('File does not contain the \'##LAST_UPDATED##\' placeholder');
+    }
+
+    config = config.replace(/'##LAST_UPDATED##'/g, UTC);
+
+    if (!config.match(/Date\.UTC\(/g)) {
+        throw new Error('Couldn\'t replace the placeholder');
+    }
+
+    console.log('\x1b[33m%s\x1b[0m', 'writing file back to source')
+    writeFileSync(`${__dirname}/src/Config.ts`, Buffer.from(config));
+    console.log('\x1b[32m%s\x1b[0m', 'Date updated');
+} catch (e) {
+    console.error(e);
+    process.exit(1);
+}

--- a/update-last-updated.js
+++ b/update-last-updated.js
@@ -7,20 +7,20 @@ console.log('\x1b[33m%s\x1b[0m', `Updating last updated config date to ${UTC}`);
 
 try {
     console.log('\x1b[33m%s\x1b[0m', 'Reading file & updating ##LAST_UPDATED##')
-    let config = readFileSync(`${__dirname}/src/Config.ts`).toString();
+    let config = readFileSync(`${__dirname}/src/Config.ts`, 'utf-8');
 
-    if (!config.match(/'##LAST_UPDATED##'/g)) {
+    if (!/'##LAST_UPDATED##'/g.test(config)) {
         throw new Error('File does not contain the \'##LAST_UPDATED##\' placeholder');
     }
 
     config = config.replace(/'##LAST_UPDATED##'/g, UTC);
 
-    if (!config.match(/Date\.UTC\(/g)) {
+    if (!/Date\.UTC\(/g.test(config)) {
         throw new Error('Couldn\'t replace the placeholder');
     }
 
     console.log('\x1b[33m%s\x1b[0m', 'writing file back to source')
-    writeFileSync(`${__dirname}/src/Config.ts`, Buffer.from(config));
+    writeFileSync(`${__dirname}/src/Config.ts`, config);
     console.log('\x1b[32m%s\x1b[0m', 'Date updated');
 } catch (e) {
     console.error(e);


### PR DESCRIPTION
Changes do a few things:

- Moves the version number & testing flag into a config file, and adds a new config for last updated date (stored with a placeholder for easy identification).
- Updates all places that used the version/testing vars from Synergism.ts to read them from Config.ts.
- Adds a node script that goes to the new config file and replaces the placeholder with a UTC definition for the current date.
- Adds a script to the package to run it.
- Updates the gh-pages workflow to run the script before it builds.
- Lint fixes from previous commit by other contributers.

Since version number isn't something that is generally maintained, this aims to at least keep a track of when a build was last pushed out to players.