### PR TITLE
Hepteract history

### DIFF
--- a/src/History.ts
+++ b/src/History.ts
@@ -52,6 +52,7 @@ export type ResetHistoryEntryAscend = ResetHistoryEntryBase & {
     wowTesseracts: number
     wowHypercubes: number
     wowPlatonicCubes: number
+    wowHepteracts: number
     currentChallenge?: number
     kind: 'ascend'
 }
@@ -92,7 +93,8 @@ export type ResetHistoryGainType = keyof Pick<ResetHistoryEntryIntersect,
     | "wowCubes"
     | "wowTesseracts"
     | "wowHypercubes"
-    | "wowPlatonicCubes">
+    | "wowPlatonicCubes"
+    | "wowHepteracts">
 
 // A formatter that allows formatting a string. The string should be in a form parsable by break_infinity.js.
 const formatDecimalSource = (numOrStr: DecimalSource) => {
@@ -174,13 +176,19 @@ const historyGains: Record<
         imgTitle: "Platonic Cubes",
         onlyif: () => player.challengecompletions[14] > 0,
     },
+    wowHepteracts: {
+        img: "Pictures/Hepteract.png",
+        formatter: conditionalFormatPerSecond,
+        imgTitle: "Hepteracts",
+        onlyif: () => player.achievements[255] > 0,
+    },
 };
 
 // Order in which to display the above
 const historyGainsOrder: ResetHistoryGainType[] = [
     "offerings", "obtainium",
     "particles", "diamonds", "mythos",
-    "wowCubes", "wowTesseracts", "wowHypercubes", "wowPlatonicCubes",
+    "wowCubes", "wowTesseracts", "wowHypercubes", "wowPlatonicCubes", "wowHepteracts"
 ];
 
 // The various kinds and their associated images.
@@ -322,7 +330,7 @@ const resetHistoryRenderRow = (
     rowContentHtml += gains.reduce((acc, value) => {
         return `${acc}<td class="history-gain">${value}</td>`;
     }, "");
-    rowContentHtml += `<td class="history-filler" colspan="${6 - colsUsed}"></td>`;
+    rowContentHtml += `<td class="history-filler" colspan="${7 - colsUsed}"></td>`;
 
     // Render the other stuff
     rowContentHtml += extra.reduce((acc, value) => {

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -231,6 +231,7 @@ const resetAddHistoryEntry = (input: resetNames, from = 'unknown') => {
                 wowTesseracts: corruptionMetaData[5],
                 wowHypercubes: corruptionMetaData[6],
                 wowPlatonicCubes: corruptionMetaData[7],
+                wowHepteracts: corruptionMetaData[8],
                 kind: "ascend",
             }
 

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -325,6 +325,7 @@ export const revealStuff = () => {
     document.getElementById("ascensionStats").style.visibility = player.achievements[197] > 0 ? "visible" : "hidden";
     document.getElementById("ascHyperStats").style.display = player.challengecompletions[13] > 0 ? "" : "none";
     document.getElementById("ascPlatonicStats").style.display = player.challengecompletions[14] > 0 ? "" : "none";
+    document.getElementById("ascHepteractStats").style.display = player.achievements[255] > 0 ? "" : "none";
 
     //I'll clean this up later. Note to 2019 Platonic: Fuck you
     // note to 2019 and 2020 Platonic, you're welcome
@@ -788,14 +789,14 @@ const updateAscensionStats = () => {
     const [cubes, tess, hyper, platonic, hepteract] = CalcCorruptionStuff().splice(4);
     const fillers: Record<string, string> = {
         "ascLen": formatTimeShort(player.ascensionCounter),
-        "ascCubes": format(cubes * (player.ascStatToggles[1] ? 1 : 1 / t), 2, true),
-        "ascTess": format(tess * (player.ascStatToggles[2] ? 1 : 1 / t), 3, true),
-        "ascHyper": format(hyper * (player.ascStatToggles[3] ? 1 : 1 / t), 4, true),
-        "ascPlatonic": format(platonic * (player.ascStatToggles[4] ? 1 : 1 / t), 5, true),
-        "ascHepteract": format(hepteract * (player.ascStatToggles[5] ? 1 : 1 / t), 3, true),
+        "ascCubes": format(cubes * (player.ascStatToggles[1] ? 1 : 1 / t), 2),
+        "ascTess": format(tess * (player.ascStatToggles[2] ? 1 : 1 / t), 3),
+        "ascHyper": format(hyper * (player.ascStatToggles[3] ? 1 : 1 / t), 4),
+        "ascPlatonic": format(platonic * (player.ascStatToggles[4] ? 1 : 1 / t), 5),
+        "ascHepteract": format(hepteract * (player.ascStatToggles[5] ? 1 : 1 / t), 3),
         "ascC10": player.challengecompletions[10] + '',
-        "ascTimeAccel": `${format(calculateTimeAcceleration(), 3, true)}x`,
-        "ascAscensionTimeAccel": `${format(calculateAscensionAcceleration(), 3, true)}x`
+        "ascTimeAccel": `${format(calculateTimeAcceleration(), 3)}x`,
+        "ascAscensionTimeAccel": `${format(calculateAscensionAcceleration(), 3)}x`
     }
     for (const key in fillers) {
         document.getElementById(key).textContent = fillers[key];


### PR DESCRIPTION
- Updates ascension history to keep track and display hepteracts
- Hides the hepteract display in histroy & in the top stats bar when the player doesn't have achievement 255 (to be consistent with when the hepteract count is displayed in the corruptions tab)
- Changes stat display to shorten numbers into e notation at e6, rather than e13