### PR TITLE
fix import/load glitches & adjustments to offline ants accuracy

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -811,8 +811,7 @@ export const calculateOffline = (forceTime = 0) => {
     document.getElementById('preload').style.display = (forceTime > 0) ? 'none' : 'block';
     document.getElementById("offlineContainer").style.display = "flex";
 
-    player.offlinetick = (player.offlinetick < 1.5e12) ? (Date.now()) : player.offlinetick;
-    const runOffline = interval(resourceSimulator, 0)
+    player.offlinetick = (player.offlinetick < 1.5e12) ? (Date.now()) : player.offlinetick;    
 
     //Set the preload as a blank black background for now (to allow aesthetic offline counter things)
     const preloadImage = getElementById<HTMLImageElement>("preload"); 
@@ -846,12 +845,13 @@ export const calculateOffline = (forceTime = 0) => {
     player.prestigeCount += resetAdd.prestige;
     player.transcendCount += resetAdd.transcension;
     player.reincarnationCount += resetAdd.reincarnation;
-    
     timerAdd.ascension = player.ascensionCounter - timerAdd.ascension
     timerAdd.quarks = quarkHandler().gain - timerAdd.quarks
-
-    //200 simulated all ticks [June 18, 2021]
-    function resourceSimulator() {
+    
+    let runOffline: ReturnType<typeof setTimeout>;
+    runOffline = interval(() => resourceSimulator(), 0);
+    //200 simulated all ticks [July 12, 2021]
+    const resourceSimulator = () => {
         G['timeMultiplier'] = calculateTimeAcceleration();
         calculateObtainium();
 

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -848,9 +848,8 @@ export const calculateOffline = (forceTime = 0) => {
     timerAdd.ascension = player.ascensionCounter - timerAdd.ascension
     timerAdd.quarks = quarkHandler().gain - timerAdd.quarks
     
-    const runOffline = interval(() => resourceSimulator(), 0);
     //200 simulated all ticks [July 12, 2021]
-    const resourceSimulator = () => {
+    const runOffline = interval(() => {
         G['timeMultiplier'] = calculateTimeAcceleration();
         calculateObtainium();
 
@@ -884,7 +883,7 @@ export const calculateOffline = (forceTime = 0) => {
             clearInt(runOffline);
             G['timeWarp'] = false;
         }
-    }
+    }, 0);
 
     document.getElementById('offlinePrestigeCountNumber').textContent = format(resetAdd.prestige, 0, true)
     document.getElementById('offlinePrestigeTimerNumber').textContent = format(timerAdd.prestige, 2, false)

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -798,7 +798,8 @@ export const calculateOffline = (forceTime = 0) => {
     const maximumTimer = 86400 * 3 + 7200 * 2 * player.researches[31] + 7200 * 2 * player.researches[32];
     const updatedTime = Date.now();
     const timeAdd = Math.min(maximumTimer, Math.max(forceTime, (updatedTime - player.offlinetick) / 1000))
-    let antTicks = 200;
+    const timeTick = timeAdd/200;
+    let resourceTicks = 200;
 
     document.getElementById("offlineTimer").textContent = "You have " + format(timeAdd, 0) + " seconds of Offline Progress!";
 
@@ -811,7 +812,7 @@ export const calculateOffline = (forceTime = 0) => {
     document.getElementById("offlineContainer").style.display = "flex";
 
     player.offlinetick = (player.offlinetick < 1.5e12) ? (Date.now()) : player.offlinetick;
-    const runOffline = interval(antSimulator, 0)
+    const runOffline = interval(resourceSimulator, 0)
 
     //Set the preload as a blank black background for now (to allow aesthetic offline counter things)
     const preloadImage = getElementById<HTMLImageElement>("preload"); 
@@ -839,50 +840,48 @@ export const calculateOffline = (forceTime = 0) => {
         quarks: quarkHandler().gain //Calculate this after the fact
     };
 
-    //Reset Stuff lmao!
-    addTimers('prestige', timeAdd);
-    addTimers('transcension', timeAdd);
-    addTimers('reincarnation', timeAdd);
     addTimers('ascension', timeAdd);
     addTimers('quarks', timeAdd);
 
     player.prestigeCount += resetAdd.prestige;
     player.transcendCount += resetAdd.transcension;
     player.reincarnationCount += resetAdd.reincarnation;
-
+    
     timerAdd.ascension = player.ascensionCounter - timerAdd.ascension
     timerAdd.quarks = quarkHandler().gain - timerAdd.quarks
 
-    document.getElementById('offlineAscensionTimerNumber').textContent = format(timerAdd.ascension, 2, true)
-    document.getElementById('offlineQuarkCountNumber').textContent = format(timerAdd.quarks, 0, true)
-
-    //Auto Obtainium Stuff
-    if (player.researches[61] > 0 && player.currentChallenge.ascension !== 14)
-        automaticTools('addObtainium', timeAdd);
-
-    //Auto Ant Sacrifice Stuff
-    if (player.achievements[173] > 0)
-        automaticTools('antSacrifice', timeAdd);
-
-    //Auto Offerings
-    automaticTools('addOfferings', timeAdd);
-    //Auto Rune Sacrifice Stuff
-    if (player.shopUpgrades.offeringAuto > 0 && player.autoSacrificeToggle)
-        automaticTools('runeSacrifice', timeAdd);
-    
-    document.getElementById('progressbardescription').textContent = 'You have gained the following from offline progression!'
-
     //200 simulated all ticks [June 18, 2021]
-    function antSimulator() {
+    function resourceSimulator() {
         G['timeMultiplier'] = calculateTimeAcceleration();
         calculateObtainium();
-        resourceGain(timeAdd/200 * G['timeMultiplier']);
-        if (antTicks % 5 === 1) // 196, 191, ... , 6, 1 ticks remaining
+
+        //Reset Stuff lmao!
+        addTimers('prestige', timeTick);
+        addTimers('transcension', timeTick);
+        addTimers('reincarnation', timeTick);
+
+        resourceGain(timeTick * G['timeMultiplier']);
+
+        //Auto Obtainium Stuff
+         if (player.researches[61] > 0 && player.currentChallenge.ascension !== 14)
+          automaticTools('addObtainium', timeTick);
+
+        //Auto Ant Sacrifice Stuff
+        if (player.achievements[173] > 0)
+            automaticTools('antSacrifice', timeTick);
+
+        //Auto Offerings
+        automaticTools('addOfferings', timeTick);
+        //Auto Rune Sacrifice Stuff
+        if (player.shopUpgrades.offeringAuto > 0 && player.autoSacrificeToggle)
+            automaticTools('runeSacrifice', timeTick);
+        
+        if (resourceTicks % 5 === 1) // 196, 191, ... , 6, 1 ticks remaining
             updateAll();
 
-        antTicks -= 1;
+        resourceTicks -= 1;
         //Misc functions
-        if (antTicks < 1) {
+        if (resourceTicks < 1) {
             clearInt(runOffline);
             G['timeWarp'] = false;
         }
@@ -898,6 +897,10 @@ export const calculateOffline = (forceTime = 0) => {
     document.getElementById('offlineObtainiumCountNumber').textContent = format(resetAdd.obtainium, 0, true)
     document.getElementById('offlineAntTimerNumber').textContent = format(timerAdd.ants, 2, false)
     document.getElementById('offlineRealAntTimerNumber').textContent = format(timerAdd.antsReal, 2, true)
+    document.getElementById('offlineAscensionTimerNumber').textContent = format(timerAdd.ascension, 2, true)
+    document.getElementById('offlineQuarkCountNumber').textContent = format(timerAdd.quarks, 0, true)
+
+    document.getElementById('progressbardescription').textContent = 'You have gained the following from offline progression!'
 
     player.offlinetick = updatedTime
     if (!player.loadedNov13Vers) {

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -848,8 +848,7 @@ export const calculateOffline = (forceTime = 0) => {
     timerAdd.ascension = player.ascensionCounter - timerAdd.ascension
     timerAdd.quarks = quarkHandler().gain - timerAdd.quarks
     
-    let runOffline: ReturnType<typeof setTimeout>;
-    runOffline = interval(() => resourceSimulator(), 0);
+    const runOffline = interval(() => resourceSimulator(), 0);
     //200 simulated all ticks [July 12, 2021]
     const resourceSimulator = () => {
         G['timeMultiplier'] = calculateTimeAcceleration();

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -669,7 +669,7 @@ const toAdapt = new Map<keyof Player, (data: Player) => unknown>([
     ['wowPlatonicCubes', data => new WowPlatonicCubes(Number(data.wowPlatonicCubes))]
 ]);
 
-const loadSynergy = (reset = false) => {
+const loadSynergy = () => {
     console.log('loaded attempted')
     const save = localStorage.getItem("Synergysave2");
     const data = save ? JSON.parse(atob(save)) : null;
@@ -1333,11 +1333,6 @@ const loadSynergy = (reset = false) => {
             document.getElementById("rune" + player.autoSacrifice).style.backgroundColor = "orange"
         }
 
-        if (!reset) 
-            calculateOffline();
-        else
-            player.worlds = new QuarkHandler({quarks: 0})
-        
         toggleTalismanBuy(player.buyTalismanShardPercent);
         updateTalismanInventory();
         calculateObtainium();
@@ -3365,7 +3360,11 @@ export const reloadShit = async (reset = false) => {
         await Alert('Transferred save to new format successfully!');
     }
 
-    loadSynergy(reset);
+    loadSynergy();
+    if (!reset) 
+            calculateOffline();
+    else
+        player.worlds = new QuarkHandler({quarks: 0})
     saveSynergy();
     toggleauto();
     revealStuff();


### PR DESCRIPTION
Load/Import - There was a weird bug where loads and imports would not be consistent (even if done back to back, and wildly inconsistent if moving between different saves). I resolved this by taking calculateOffline out of loadSynergy and instead having it run after loadSynergy has completed as part of reloadShit.

Offline Ants - I adjusted calculateOffline so that all resource generating/impacting items are in the loop that simulates growth which has made the results completely accurate when compared to a game left open (from my testing at least).


![](https://i.imgur.com/3mDvJeD.png)

