### PR TITLE
Allow renaming of corruption loadouts, add 4th loadout

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2512,6 +2512,11 @@ p[id$="BlessingsTotal"] {
     color: red;
 }
 
+.corrLoadoutName:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
 #corruptionDescription {
     color: darkviolet;
 }

--- a/Synergism.css
+++ b/Synergism.css
@@ -2654,15 +2654,18 @@ img.small {
 
 .corrSave {
     border: 1px solid dodgerblue;
-    margin-left: 10px;
-    padding: 3px 4px;
+    padding: 2px 5px;
     transition-duration: 0.15s;
+    width: 100%;
+    margin-bottom: 1px;
 }
 
 .corrLoad {
     border: 1px solid #5b5ddc;
-    padding: 3px 4px;
+    padding: 2px 5px;
     transition-duration: 0.15s;
+    width: 100%;
+    margin-bottom: 1px;
 }
 
 .corrSave:hover,

--- a/Synergism.css
+++ b/Synergism.css
@@ -2512,11 +2512,6 @@ p[id$="BlessingsTotal"] {
     color: red;
 }
 
-.corrLoadoutName:hover {
-    text-decoration: underline;
-    cursor: pointer;
-}
-
 #corruptionDescription {
     color: darkviolet;
 }
@@ -2604,6 +2599,15 @@ p[id$="BlessingsTotal"] {
     min-width: 150px;
     margin: auto;
     text-align: center;
+}
+
+.corrLoadoutName:hover {
+    text-decoration: underline;
+    cursor: pointer;
+}
+
+.corrLoadoutNameCol {
+    width: 17%;
 }
 
 .corrBtn {

--- a/index.html
+++ b/index.html
@@ -2586,7 +2586,7 @@
                 <div id="corruptionLoadouts" style="display: none">
                     <table id="corruptionLoadoutTable">
                         <tr>
-                            <th></th>
+                            <th class="corrLoadoutNameCol"></th>
                             <th>
                                 <img src="Pictures/Divisiveness Level 7.png" class="corruptionImg small" alt="" loading="lazy">
                             </th>

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -166,13 +166,15 @@ export const checkVariablesOnLoad = (data: Player) => {
         player.usedCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
         player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     }
+
     if (player.corruptionLoadouts === undefined) {
-        player.corruptionLoadouts = {
-            1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-            3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        };
+        player.corruptionLoadouts = { ...blankSave.corruptionLoadouts };
         player.corruptionShowStats = true
+    } else if (Object.keys(player.corruptionLoadouts).length !== Object.keys(blankSave.corruptionLoadouts).length) {
+        for (const key of Object.keys(blankSave.corruptionLoadouts)) {
+            if (player.corruptionLoadouts[Number(key)]) continue;
+            player.corruptionLoadouts[Number(key)] = blankSave.corruptionLoadouts[Number(key)];
+        }
     }
 
     for (let i = 0; i <= 4; i++) {

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -255,6 +255,7 @@ const corruptionLoadoutSaveLoad = (save = true, loadout = 1) => {
 
 async function corruptionLoadoutGetNewName(loadout = 0) {
     const maxChars = 9
+    // eslint-disable-next-line
     const regex = /^[\x00-\xFF]*$/
     const renamePrompt = await Prompt(
         `What would you like to name Loadout ${loadout + 1}? ` +

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -236,11 +236,11 @@ const corruptionLoadoutSaveLoad = (save = true, loadout = 1) => {
     }
 }
 
-async function corruptionLoadoutGetNewName(loadout = 1) {
+async function corruptionLoadoutGetNewName(loadout = 0) {
     const maxChars = 9
     const regex = /^[\x00-\xFF]*$/
     const renamePrompt = await Prompt(
-        `What would you like to name Loadout ${loadout - 1}? ` +
+        `What would you like to name Loadout ${loadout + 1}? ` +
         `Names cannot be longer than ${maxChars} characters. Nothing crazy!`
     );
    
@@ -254,20 +254,20 @@ async function corruptionLoadoutGetNewName(loadout = 1) {
         return Alert("The Loadout Renamer didn't like a character in your name! Try something else.")
     }
     else {
-        player.corruptionLoadoutNames[loadout - 1] = renamePrompt
+        player.corruptionLoadoutNames[loadout] = renamePrompt
         updateCorruptionLoadoutNames();
     }
 }
 
 export const updateCorruptionLoadoutNames = () => {
     const rows = getElementById<HTMLTableElement>("corruptionLoadoutTable").rows
-    for (let i = 1; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
-        const cells = rows[i + 1].cells
+    for (let i = 0; i < Object.keys(player.corruptionLoadouts).length; i++) {
+        const cells = rows[i + 2].cells  //start changes on 2nd row
         if (cells[0].textContent.length === 0) {  //first time setup
             cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i)); //get name function handles -1 for array
             cells[0].classList.add('corrLoadoutName');
         }
-        cells[0].textContent = `${player.corruptionLoadoutNames[i - 1]}:`;
+        cells[0].textContent = `${player.corruptionLoadoutNames[i]}:`;
     }    
 }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -264,7 +264,7 @@ export const updateCorruptionLoadoutNames = () => {
     for (let i = 1; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
         const cells = rows[i + 1].cells
         if (cells[0].textContent.length === 0) {  //first time setup
-            cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i - 1));
+            cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i)); //get name function handles -1 for array
             cells[0].classList.add('corrLoadoutName');
         }
         cells[0].textContent = `${player.corruptionLoadoutNames[i - 1]}:`;

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -240,7 +240,7 @@ async function corruptionLoadoutGetNewName(loadout = 1) {
     const maxChars = 9
     const regex = /^[\x00-\xFF]*$/
     const renamePrompt = await Prompt(
-        `What would you like to name Loadout ${loadout}? ` +
+        `What would you like to name Loadout ${loadout - 1}? ` +
         `Names cannot be longer than ${maxChars} characters. Nothing crazy!`
     );
    
@@ -254,7 +254,7 @@ async function corruptionLoadoutGetNewName(loadout = 1) {
         return Alert("The Loadout Renamer didn't like a character in your name! Try something else.")
     }
     else {
-        player.corruptionLoadoutNames[loadout] = renamePrompt
+        player.corruptionLoadoutNames[loadout - 1] = renamePrompt
         updateCorruptionLoadoutNames();
     }
 }
@@ -264,10 +264,10 @@ export const updateCorruptionLoadoutNames = () => {
     for (let i = 1; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
         const cells = rows[i + 1].cells
         if (cells[0].textContent.length === 0) {  //first time setup
-            cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i));
+            cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i - 1));
             cells[0].classList.add('corrLoadoutName');
         }
-        cells[0].textContent = `${player.corruptionLoadoutNames[i]}:`;
+        cells[0].textContent = `${player.corruptionLoadoutNames[i - 1]}:`;
     }    
 }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -278,7 +278,6 @@ async function corruptionLoadoutGetNewName(loadout = 0) {
 
 export const updateCorruptionLoadoutNames = () => {
     const rows = getElementById<HTMLTableElement>("corruptionLoadoutTable").rows
-    console.log(Object.keys(player.corruptionLoadouts).length)
     for (let i = 0; i < Object.keys(player.corruptionLoadouts).length; i++) {
         const cells = rows[i + 2].cells  //start changes on 2nd row
         if (cells[0].textContent.length === 0) {  //first time setup

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -199,21 +199,33 @@ export const corruptionLoadoutTableCreate = () => {
                 cell.style.textAlign = "center"
             }
         }
-        if (i === 0) continue;
+        if (i === 0) {
+            let cell = row.insertCell();
+            //empty
 
-        let cell = row.insertCell();
-        let btn = document.createElement("button");
-        btn.className = "corrSave"
-        btn.textContent = "Save"
-        btn.onclick = () => corruptionLoadoutSaveLoad(true, i);
-        cell.appendChild(btn);
+            cell = row.insertCell();
+            let btn = document.createElement("button");
+            btn.className = "corrLoad"
+            btn.textContent = "Zero"
+            btn.onclick = () => corruptionLoadoutSaveLoad(false, i);
+            cell.appendChild(btn);
+            cell.title = "Reset corruptions to zero on your next ascension"
+        }
+        else {
+            let cell = row.insertCell();
+            let btn = document.createElement("button");
+            btn.className = "corrSave"
+            btn.textContent = "Save"
+            btn.onclick = () => corruptionLoadoutSaveLoad(true, i);
+            cell.appendChild(btn);
 
-        cell = row.insertCell();
-        btn = document.createElement("button");
-        btn.className = "corrLoad"
-        btn.textContent = "Load"
-        btn.onclick = () => corruptionLoadoutSaveLoad(false, i);
-        cell.appendChild(btn);
+            cell = row.insertCell();
+            btn = document.createElement("button");
+            btn.className = "corrLoad"
+            btn.textContent = "Load"
+            btn.onclick = () => corruptionLoadoutSaveLoad(false, i);
+            cell.appendChild(btn);
+        }
     }
 }
 
@@ -230,7 +242,12 @@ const corruptionLoadoutSaveLoad = (save = true, loadout = 1) => {
         player.corruptionLoadouts[loadout] = Array.from(player.prototypeCorruptions)
         corruptionLoadoutTableUpdate(loadout)
     } else {
-        player.prototypeCorruptions = Array.from(player.corruptionLoadouts[loadout])
+        if (loadout === 0) {
+            player.prototypeCorruptions = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        }
+        else {
+            player.prototypeCorruptions = Array.from(player.corruptionLoadouts[loadout])
+        }
         corruptionLoadoutTableUpdate()
         corruptionStatsUpdate();
     }

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -278,7 +278,8 @@ async function corruptionLoadoutGetNewName(loadout = 0) {
 
 export const updateCorruptionLoadoutNames = () => {
     const rows = getElementById<HTMLTableElement>("corruptionLoadoutTable").rows
-    for (let i = 0; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
+    console.log(Object.keys(player.corruptionLoadouts).length)
+    for (let i = 0; i < Object.keys(player.corruptionLoadouts).length; i++) {
         const cells = rows[i + 2].cells  //start changes on 2nd row
         if (cells[0].textContent.length === 0) {  //first time setup
             cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i)); //get name function handles -1 for array

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -238,16 +238,21 @@ const corruptionLoadoutSaveLoad = (save = true, loadout = 1) => {
 
 async function corruptionLoadoutGetNewName(loadout = 1) {
     const maxChars = 9
-    let renamePrompt = await Prompt('What would you like to name Loadout ' + loadout + '? Names cannot be longer than ' + maxChars + ' characters. Nothing crazy!');
-    renamePrompt = String(renamePrompt)
-    let regex = /^[\x00-\xFF]*$/
-
-    if (!renamePrompt)
+    const regex = /^[\x00-\xFF]*$/
+    const renamePrompt = await Prompt(
+        `What would you like to name Loadout ${loadout}? ` +
+        `Names cannot be longer than ${maxChars} characters. Nothing crazy!`
+    );
+   
+    if (!renamePrompt) {
         return Alert('Okay, maybe next time.');
-    else if (renamePrompt.length > maxChars)
+    }
+    else if (renamePrompt.length > maxChars) {
         return Alert('The name you provided is too long! Try again.')
-    else if (!renamePrompt.match(regex))
+    }
+    else if (!regex.test(renamePrompt)) {
         return Alert("The Loadout Renamer didn't like a character in your name! Try something else.")
+    }
     else {
         player.corruptionLoadoutNames[loadout] = renamePrompt
         updateCorruptionLoadoutNames();
@@ -257,12 +262,12 @@ async function corruptionLoadoutGetNewName(loadout = 1) {
 export const updateCorruptionLoadoutNames = () => {
     const rows = getElementById<HTMLTableElement>("corruptionLoadoutTable").rows
     for (let i = 1; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
-        let cells = rows[i + 1].cells
-        if (!cells[0].innerHTML) {  //first time setup
-            cells[0].onclick = () => corruptionLoadoutGetNewName(i);
-            cells[0].className = 'corrLoadoutName'
+        const cells = rows[i + 1].cells
+        if (cells[0].textContent.length === 0) {  //first time setup
+            cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i));
+            cells[0].classList.add('corrLoadoutName');
         }
-        cells[0].innerHTML = player.corruptionLoadoutNames[i] + ':'
+        cells[0].textContent = `${player.corruptionLoadoutNames[i]}:`;
     }    
 }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -278,7 +278,7 @@ async function corruptionLoadoutGetNewName(loadout = 0) {
 
 export const updateCorruptionLoadoutNames = () => {
     const rows = getElementById<HTMLTableElement>("corruptionLoadoutTable").rows
-    for (let i = 0; i < Object.keys(player.corruptionLoadouts).length; i++) {
+    for (let i = 0; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
         const cells = rows[i + 2].cells  //start changes on 2nd row
         if (cells[0].textContent.length === 0) {  //first time setup
             cells[0].addEventListener('click', () => corruptionLoadoutGetNewName(i)); //get name function handles -1 for array

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -578,12 +578,12 @@ export const player: Player = {
         3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     },
-    corruptionLoadoutNames: {
-        1: "Loadout 1",
-        2: "Loadout 2",
-        3: "Loadout 3",
-        4: "Loadout 4",
-    },
+    corruptionLoadoutNames: [
+        "Loadout 1",
+        "Loadout 2",
+        "Loadout 3",
+        "Loadout 4",
+    ],
     corruptionShowStats: true,
 
     constantUpgrades: [null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -25,7 +25,7 @@ import { buyMax, buyAccelerator, buyMultiplier, boostAccelerator, buyCrystalUpgr
 import { autoUpgrades } from './Automation';
 import { redeemShards } from './Runes';
 import { updateCubeUpgradeBG } from './Cubes';
-import { corruptionLoadoutTableUpdate, corruptionButtonsAdd, corruptionLoadoutTableCreate, corruptionStatsUpdate } from './Corruptions';
+import { corruptionLoadoutTableUpdate, corruptionButtonsAdd, corruptionLoadoutTableCreate, corruptionStatsUpdate, updateCorruptionLoadoutNames } from './Corruptions';
 import { generateEventHandlers } from './EventListeners';
 import { addTimers, automaticTools } from './Helper';
 //import { LegacyShopUpgrades } from './types/LegacySynergism';
@@ -572,10 +572,17 @@ export const player: Player = {
 
     prototypeCorruptions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
     usedCorruptions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-    corruptionLoadouts: {
+    corruptionLoadouts: {  //If you add loadouts don't forget to add loadout names!
         1: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
         2: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-        3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        3: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        4: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+    },
+    corruptionLoadoutNames: {
+        1: "Loadout 1",
+        2: "Loadout 2",
+        3: "Loadout 3",
+        4: "Loadout 4",
     },
     corruptionShowStats: true,
 
@@ -1211,6 +1218,7 @@ const loadSynergy = () => {
             corruptionLoadoutTableUpdate(i);
         }
         showCorruptionStatsLoadouts()
+        updateCorruptionLoadoutNames()
 
         for (let j = 1; j <= 5; j++) {
             const ouch = document.getElementById("tesseractAutoToggle" + j);
@@ -3362,7 +3370,7 @@ export const reloadShit = async (reset = false) => {
 
     loadSynergy();
     if (!reset) 
-            calculateOffline();
+        calculateOffline();
     else
         player.worlds = new QuarkHandler({quarks: 0})
     saveSynergy();

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -448,6 +448,7 @@ export interface Player {
     prototypeCorruptions: number[]
     usedCorruptions: number[]
     corruptionLoadouts: Record<number, number[]>
+    corruptionLoadoutNames: Record<number, string>
     corruptionShowStats: boolean,
 
     constantUpgrades: number[]

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -448,7 +448,7 @@ export interface Player {
     prototypeCorruptions: number[]
     usedCorruptions: number[]
     corruptionLoadouts: Record<number, number[]>
-    corruptionLoadoutNames: Record<number, string>
+    corruptionLoadoutNames: string[]
     corruptionShowStats: boolean,
 
     constantUpgrades: number[]


### PR DESCRIPTION
Players requested more loadouts for corruptions due to complexity as game goes on. Adding one more for now until design decisions for further are discussed.

Here are the changes:
Corruptions.ts: Move loadout name label to separate function, add function to prompt for name.

Synergism.ts: Import new corruption loadout name function, call during other display updates. Add 4th loadout. Add new corruptionLoadoutNames type initialization.

Synergism.d.ts: add corruptionLoadoutNames Record declaration.

Synergism.css: add styling for corrLoadoutName class.