### PR TITLE
Fix for the c15 ascend exploit and "buy into debt" for Plat upgrades

### DIFF
--- a/src/Platonic.ts
+++ b/src/Platonic.ts
@@ -256,7 +256,7 @@ const checkPlatonicUpgrade = (index: number): Record<keyof (IPlatBaseCost & { ca
 
     //Let's do a proper loop over everything here instead of the appended extra check for Abyssals - more future-for Octeracts
 		
-	let res_owned=0;
+    let res_owned=0;
     for (let i = 0; i < resources.length; i++) {
 				if (resourceNames[i] === "wowAbyssals") {
 				    res_owned=player.hepteractCrafts.abyss.BAL

--- a/src/Platonic.ts
+++ b/src/Platonic.ts
@@ -254,15 +254,13 @@ const checkPlatonicUpgrade = (index: number): Record<keyof (IPlatBaseCost & { ca
         canBuy: false,
     }
 
-    //Let's do a proper loop over everything here instead of the appended extra check for Abyssals - more future-for Octeracts
-		
     let res_owned=0;
     for (let i = 0; i < resources.length; i++) {
-				if (resourceNames[i] === "wowAbyssals") {
-				    res_owned=player.hepteractCrafts.abyss.BAL
-				} else {
-						res_owned=player[resourceNames[i]]
-				}
+	if (resourceNames[i] === "wowAbyssals") {
+		res_owned=player.hepteractCrafts.abyss.BAL
+	} else {
+		res_owned=player[resourceNames[i]]
+	}
         if (platUpgradeBaseCosts[index][resources[i]] <= res_owned) {
             checksum++;
             checks[resources[i]] = true

--- a/src/Platonic.ts
+++ b/src/Platonic.ts
@@ -253,16 +253,20 @@ const checkPlatonicUpgrade = (index: number): Record<keyof (IPlatBaseCost & { ca
         abyssals: false,
         canBuy: false,
     }
-    for (let i = 0; i < resources.length - 1; i++) {
-        if (platUpgradeBaseCosts[index][resources[i]] <= player[resourceNames[i]]) {
+
+    //Let's do a proper loop over everything here instead of the appended extra check for Abyssals - more future-for Octeracts
+		
+	let res_owned=0;
+    for (let i = 0; i < resources.length; i++) {
+				if (resourceNames[i] === "wowAbyssals") {
+				    res_owned=player.hepteractCrafts.abyss.BAL
+				} else {
+						res_owned=player[resourceNames[i]]
+				}
+        if (platUpgradeBaseCosts[index][resources[i]] <= res_owned) {
             checksum++;
             checks[resources[i]] = true
         }
-    }
-
-    if (player.hepteractCrafts.abyss.BAL > 0 || platUpgradeBaseCosts[index].abyssals == 0) {
-        checksum ++
-        checks['abyssals'] = true
     }
 
     if (checksum === resources.length && player.platonicUpgrades[index] < platUpgradeBaseCosts[index].maxLevel) {

--- a/src/Platonic.ts
+++ b/src/Platonic.ts
@@ -254,17 +254,16 @@ const checkPlatonicUpgrade = (index: number): Record<keyof (IPlatBaseCost & { ca
         canBuy: false,
     }
 
-    let res_owned=0;
-    for (let i = 0; i < resources.length; i++) {
-	if (resourceNames[i] === "wowAbyssals") {
-		res_owned=player.hepteractCrafts.abyss.BAL
-	} else {
-		res_owned=player[resourceNames[i]]
-	}
-        if (platUpgradeBaseCosts[index][resources[i]] <= res_owned) {
+    for (let i = 0; i < resources.length-1; i++) {
+        if (platUpgradeBaseCosts[index][resources[i]] <= player[resourceNames[i]]) {
             checksum++;
             checks[resources[i]] = true
         }
+    }
+
+    if (player.hepteractCrafts.abyss.BAL >= platUpgradeBaseCosts[index][resources[resources.length-1]] || platUpgradeBaseCosts[index].abyssals == 0) {
+        checksum ++
+        checks['abyssals'] = true
     }
 
     if (checksum === resources.length && player.platonicUpgrades[index] < platUpgradeBaseCosts[index].maxLevel) {

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -612,6 +612,14 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
             }
         }
         player.usedCorruptions = Array.from(player.prototypeCorruptions)
+        if (player.currentChallenge.ascension === 15) {
+             player.usedCorruptions[0] = 0;
+             player.prototypeCorruptions[0] = 0;
+             for (let i = 1; i <= 9; i++) {
+                 player.usedCorruptions[i] = 11;
+             }
+        }
+
         corruptionStatsUpdate();
     }
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -612,7 +612,7 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
             }
         }
         player.usedCorruptions = Array.from(player.prototypeCorruptions)
-        if (player.currentChallenge.ascension === 15) {
+        if (player.currentChallenge.ascension === 15 && input === 'ascension') {
              player.usedCorruptions[0] = 0;
              player.prototypeCorruptions[0] = 0;
              for (let i = 1; i <= 9; i++) {


### PR DESCRIPTION
Ascending in c15 could let a player play the challenge with less than the specified corruption if corruption/completes were high enough to avoid dumping them out of the challenge, for a highly inflated expo. This change ensures the c15 all-11 corruption array is kept intact. As a side effect it seems to even prevent the player from accidentally completing c15 with an ascend.