### PR TITLE
Fix c13 for some saves

### DIFF
--- a/src/Tax.ts
+++ b/src/Tax.ts
@@ -48,7 +48,7 @@ export const calculatetax = () => {
     //im doing this to spite xander, basically changes w5x9 to not impact tax scaling in c13 || Sean#7236
     if (player.currentChallenge.ascension === 13) {
         e *= 700 * (1 + 1 / 6 * player.challengecompletions[13])
-        e *= Math.pow(1.05, Math.max(0, sumContents(player.challengecompletions) - player.challengecompletions[11] - player.challengecompletions[12] - player.challengecompletions[13] - player.challengecompletions[14] - player.challengecompletions[15] - 3 * player.cubeUpgrades[49]))
+        e *= Math.pow(1.05, Math.max(0, sumContents(player.challengecompletions) - player.challengecompletions[0] - player.challengecompletions[11] - player.challengecompletions[12] - player.challengecompletions[13] - player.challengecompletions[14] - player.challengecompletions[15] - 3 * player.cubeUpgrades[49]))
     }
     if (player.challengecompletions[6] > 0) {
         f /= 1.075


### PR DESCRIPTION
Some saves have data in player.challengecompletions[0] which messes with their ability to complete c13. Now properly only counts c1 to 10.