### PR TITLE
Apply max rune level

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -244,7 +244,7 @@ export const calculateMaxRunes = (i: number) => {
         -998
     ]
 
-    max += increaseMaxLevel[i]
+    max = (increaseMaxLevel[i] > G['runeMaxLvl'] ? G['runeMaxLvl'] : max + increaseMaxLevel[i])
     return max
 }
 

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -183,8 +183,10 @@ export const visualUpdateRunes = () => {
         for (let i = 1; i <= 7; i++) { //First one updates level, second one updates TNL, third updates orange bonus levels
             let place = G[talismans[i-1]];
             if (i > 5) place = 0;
-            document.getElementById('rune' + i + 'level').childNodes[0].textContent = "Level: " + format(player.runelevels[i - 1]) + "/" + format(calculateMaxRunes(i))
-            document.getElementById('rune' + i + 'exp').textContent = "+1 in " + format(calculateRuneExpToLevel(i - 1) - player.runeexp[i - 1], 2) + " EXP"
+            let runeLevel = player.runelevels[i - 1]
+            let maxLevel = calculateMaxRunes(i)
+            document.getElementById('rune' + i + 'level').childNodes[0].textContent = "Level: " + format(runeLevel) + "/" + format(maxLevel)
+            document.getElementById('rune' + i + 'exp').textContent = (runeLevel < maxLevel ? "+1 in " + format(calculateRuneExpToLevel(i - 1) - player.runeexp[i - 1], 2) + " EXP" : "Max level!")
             if (i <= 5) document.getElementById('bonusrune' + i).textContent = " [Bonus: " + format(7 * player.constantUpgrades[7] + Math.min(1e7, player.antUpgrades[9-1] + G['bonusant9']) + place) + "]"
             else document.getElementById('bonusrune' + i).textContent = "[Bonus: Nope!]"
             displayRuneInformation(i, false)

--- a/src/Variables.ts
+++ b/src/Variables.ts
@@ -4,6 +4,7 @@ import { GlobalVariables } from './types/Synergism';
 export const Globals: GlobalVariables = {
     runediv: [1.5, 2, 3, 5, 8, 1, 1],
     runeexpbase: [1, 4, 9, 16, 1000, 1e75, 1e200],
+    runeMaxLvl: 40000,
 
     // this shows the logarithm of costs. ex: upgrade one will cost 1e+6 coins, upgrade 2 1e+7, etc.
     upgradeCosts: [0, 6, 7, 8, 10, 12, 20, 25, 30, 35, 45, 55, 75, 110, 150, 200, 250, 500, 750, 1000, 1500,

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -514,6 +514,7 @@ export interface Player {
 export interface GlobalVariables {
     runediv: number[]
     runeexpbase: number[]
+    runeMaxLvl: number
     upgradeCosts: number[]
 
     // Mega list of Variables to be used elsewhere


### PR DESCRIPTION
- declare global variable representing max rune level limit of 40000
- consider this limit when calculating current max rune level
- use this max limit when displaying levels on Runes tab
- consider current level vs max level when displaying EXP to next rune level