### PR TITLE
Fix p4x2

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1309,7 +1309,7 @@ export const calculateAscensionScore = () => {
     baseScore *= Math.pow(1.03 + 0.005 * player.cubeUpgrades[39] + 0.0025 * (player.platonicUpgrades[5] + player.platonicUpgrades[10]), player.highestchallengecompletions[10]);
     // Corruption Multiplier is the product of all Corruption Score multipliers based on used corruptions
     for (let i = 1; i <= 10; i++) {
-        const exponent = ((i === 1 || i === 2) && player.usedCorruptions[i] >= 10) ? 1.75 + 0.0175 * player.platonicUpgrades[17] : 1;
+        const exponent = ((i === 1 || i === 2) && player.usedCorruptions[i] >= 10 && player.platonicUpgrades[17] > 0) ? 1.75 + 0.02 * player.platonicUpgrades[17] : 1;
         corruptionMultiplier *= Math.pow(G['corruptionPointMultipliers'][player.usedCorruptions[i]], exponent);
     }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -12,8 +12,8 @@ export const corruptionDisplay = (index: number) => {
         document.getElementById("corruptionSelectedPic").style.visibility = "visible"
     }
     G['corruptionTrigger'] = index
-    const currentExponent = ((index === 1 || index === 2) && player.usedCorruptions[index] >= 10) ? 1 + 0.02 * player.platonicUpgrades[17] + 0.75 * Math.min(1, player.platonicUpgrades[17]) : 1;
-    const protoExponent = ((index === 1 || index === 2) && player.prototypeCorruptions[index] >= 10) ? 1 + 0.02 * player.platonicUpgrades[17] + 0.75 * Math.min(1, player.platonicUpgrades[17]) : 1;
+    const currentExponent = ((index === 1 || index === 2) && player.usedCorruptions[i] >= 10 && player.platonicUpgrades[17] > 0) ? 1.75 + 0.02 * player.platonicUpgrades[17] : 1;
+    const protoExponent = ((index === 1 || index === 2) && player.prototypeCorruptions[i] >= 10 && player.platonicUpgrades[17] > 0) ? 1.75 + 0.02 * player.platonicUpgrades[17] : 1;
     const corruptionTexts: Record<'name' | 'description' | 'current' | 'planned' | 'multiplier' | 'spiritContribution' | 'image', string>[] = [
         {
             name: "Corruption I: Divisiveness",


### PR DESCRIPTION
Add a check to ensure a player has purchased p4x2 before applying the bonus. Use the same formula everywhere for the exponent calculation, and ensure it matches the formula in the description. 