### PR TITLE
Fix for c15 ascend bug/exploit

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -613,6 +613,15 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
             }
         }
         player.usedCorruptions = Array.from(player.prototypeCorruptions)
+        //fix c15 ascension bug by restoring the corruptions if the player ascended instead of leaving
+        if (player.currentChallenge.ascension === 15 && input === 'ascension') {
+           player.usedCorruptions[0] = 0;
+           player.prototypeCorruptions[0] = 0;
+           for (let i = 1; i <= 9; i++) {
+             player.usedCorruptions[i] = 11;
+           }
+        }
+
         corruptionStatsUpdate();
     }
 


### PR DESCRIPTION
This fixes the behavior of ascend in c15 by ensuring corruptions get set as needed. No more accidental completions, no more insane expos from abusing them. Ascend will now behave like in every other asc challenge - reset the current attempt. That's all.