### PR TITLE
Updated Loadout Loading and Minor .json Changes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "synergismofficial",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,10 +6,10 @@
   "packages": {
     "": {
       "name": "synergismofficial",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "MIT",
       "dependencies": {
-        "break_infinity.js": "github:Patashu/break_infinity.js",
+        "break_infinity.js": "^1.2.0",
         "eventemitter3": "^4.0.7",
         "lz-string": "^1.4.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synergismofficial",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "",
   "main": "dist/bundle.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "dist/bundle.js",
   "dependencies": {
-    "break_infinity.js": "github:Patashu/break_infinity.js",
+    "break_infinity.js": "^1.2.0",
     "eventemitter3": "^4.0.7",
     "lz-string": "^1.4.4"
   },

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -115,7 +115,7 @@ export class HepteractCraft {
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
-            else if (Object.prototype.isPrototypeOf(Cube))
+            else if (Object.prototype.isPrototypeOf.call(Cube, player[item as keyof Player]))
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -115,7 +115,7 @@ export class HepteractCraft {
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
-            else if (Object.prototype.isPrototypeOf.call(Cube, player[item as keyof Player]))
+            else if (Object.prototype.isPrototypeOf(Cube))
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1220,7 +1220,7 @@ const loadSynergy = () => {
         getElementById<HTMLInputElement>("enterAutoChallengeTimerInput").value = player.autoChallengeTimer.enter + '';
 
         corruptionStatsUpdate();
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
             corruptionLoadoutTableUpdate(i);
         }
         showCorruptionStatsLoadouts()


### PR DESCRIPTION
Fixed Loadout 4 visually loading its corruption values on save import but not on game load. Updated package.json and package-lock.json dependencies for break_infinity.js to its latest version number so 'npm install' doesn't freak out. In addition, updated version numbers from 2.5.6 to 2.5.7.