### PR TITLE
Minor Fixes to Hepts + Corruptions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "synergismofficial",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "synergismofficial",
-      "version": "2.5.6",
+      "version": "2.5.7",
       "license": "MIT",
       "dependencies": {
-        "break_infinity.js": "github:Patashu/break_infinity.js",
+        "break_infinity.js": "^1.2.0",
         "eventemitter3": "^4.0.7",
         "lz-string": "^1.4.4"
       },

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "synergismofficial",
-  "version": "2.5.6",
+  "version": "2.5.7",
   "description": "",
   "main": "dist/bundle.js",
   "dependencies": {
-    "break_infinity.js": "github:Patashu/break_infinity.js",
+    "break_infinity.js": "^1.2.0",
     "eventemitter3": "^4.0.7",
     "lz-string": "^1.4.4"
   },

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -115,7 +115,7 @@ export class HepteractCraft {
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
-            else if (Object.prototype.isPrototypeOf.call(Cube, player[item as keyof Player]))
+            else if (player[item as keyof Player] instanceof Cube)
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -115,7 +115,7 @@ export class HepteractCraft {
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
-            else if (Object.prototype.isPrototypeOf(Cube))
+            else if (Object.prototype.isPrototypeOf.call(Cube, player[item as keyof Player]))
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -115,7 +115,7 @@ export class HepteractCraft {
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
-            else if (Object.prototype.isPrototypeOf.call(Cube, player[item as keyof Player]))
+            else if (Object.prototype.isPrototypeOf(Cube))
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1220,7 +1220,7 @@ const loadSynergy = () => {
         getElementById<HTMLInputElement>("enterAutoChallengeTimerInput").value = player.autoChallengeTimer.enter + '';
 
         corruptionStatsUpdate();
-        for (let i = 0; i < 4; i++) {
+        for (let i = 0; i < Object.keys(player.corruptionLoadouts).length + 1; i++) {
             corruptionLoadoutTableUpdate(i);
         }
         showCorruptionStatsLoadouts()


### PR DESCRIPTION
- Fixed Loadout 4 always loading corruption levels as 0 when loading the game normally rather than through importing.
- Fixed Hepteracts not using up other Cube types when crafting.
- Changed version references from 2.5.6 to 2.5.7.
- Changed dependency reference of break_infinity.js to use a version number instead so `npm install` actually works.