### PR TITLE
Always show confirmation message for non-refundable items.

### DIFF
--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -399,7 +399,7 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const maxLevel = player.shopUpgrades[input] === shopData[input].maxLevel;
     const canAfford = Number(player.worlds) >= getShopCosts(input);
 
-    if (G['shopConfirmation']) {
+    if (G['shopConfirmation'] || !shopData[input].refundable) {
         if (maxLevel) {
             await Alert("You can't purchase " + friendlyShopName(input) + " because you already have the max level!")
         }


### PR DESCRIPTION
Far too often people (including myself) have complained that they accidentally bought non-refundable items, especially worse with the new Buy Max option. This makes it so that you always see shop confirmation message for non-refundable items.