### PR TITLE
Game freeze bug fix

### DIFF
--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -612,6 +612,9 @@ export const boostAccelerator = (automated?: boolean) => {
 
             player.transcendnoaccelerator = false;
             player.reincarnatenoaccelerator = false;
+            if (player.acceleratorBoostBought === buyFrom) {
+                break;
+            }
         }
     }
 


### PR DESCRIPTION
Avoid infinite loops caused by calculations over 2 ^ 53 precision in acceleratorBoostBought
This patch is not a great way to do it, so if you have any, please