### PR TITLE
Game freeze bug fix

### DIFF
--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -584,6 +584,11 @@ export const boostAccelerator = (automated?: boolean) => {
             }
         }
     } else {
+        if (player.acceleratorBoostBought >= 1e15 || player.prestigePoints.gte(Decimal.pow(10, 1e30))){
+            player.acceleratorBoostBought = 1e15;
+            player.acceleratorBoostCost = Decimal.pow(10, 1e30);
+            return;
+        }
         const buyStart = player.acceleratorBoostBought;
         let buyInc = 1;
         let cost = getAcceleratorBoostCost(buyStart + buyInc);


### PR DESCRIPTION
Accelerator Boost freezes the game when it exceeds 2 ^ 53
Cap in 1e15 in the same way as commit #a12fbbf