### PR TITLE
Stop resources going negative

### DIFF
--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -950,6 +950,10 @@ export const buyRuneBonusLevels = (type: 'Blessings' | 'Spirits', index: number)
 
     player.runeshards -= cost;
 
+    if (player.runeshards < 0) {
+        player.runeshards = 0;
+    }
+
     if (index === 1) {
         const requirementArray = [0, 1e5, 1e8, 1e11]
         for (let i = 1; i <= 3; i++) {

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -121,10 +121,19 @@ export class HepteractCraft {
         this.BAL += amountToCraft
 
         // Subtract spent items from player
-        player.wowAbyssals -= amountToCraft * this.HEPTERACT_CONVERSION
+        player.wowAbyssals -= amountToCraft * this.HEPTERACT_CONVERSION;
+
+        if (player.wowAbyssals < 0) {
+            player.wowAbyssals = 0;
+        }
+
         for (const item in this.OTHER_CONVERSIONS) {
             if (typeof player[item as keyof Player] === 'number')
                 (player[item as keyof Player] as number) -= amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player];
+
+                if ((player[item as keyof Player] as number) < 0) {
+                    (player[item as keyof Player] as number) = 0;
+                }
             else if (player[item as keyof Player] instanceof Cube)
                 (player[item as keyof Player] as Cube).sub(amountToCraft * this.OTHER_CONVERSIONS[item as keyof Player]);
             else if (item == 'worlds')


### PR DESCRIPTION
Added checks when buying blessings, spirits and hepteract forge balance to stop resources from going negative