### PR TITLE
Some changes on Hept Forge and c15 desc

### DIFF
--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -322,7 +322,7 @@ export const challengeDisplay = (i: number, changefocus?: boolean) => {
     if (i === 15 && G['challengefocus'] === 15) {
         a.textContent = "SADISTIC CHALLENGE II || " + player.challengecompletions[15] + "/" + format(maxChallenges) +  " Completions"
         b.textContent = "The worst sin a man can do is making others suffer."
-        c.textContent = "Ascend and reach the goal but you're FULLY corrupt and must stay that way."
+        c.textContent = "Ascend and reach the goal but you're stuck in all corruptions level 11 and must stay that way."
         d.textContent = "Goal: " + format(challengeRequirement(i, player.challengecompletions[i], 15)) + " Coins, but get bonuses based on your best attempt."
         e.textContent = "You have no idea "
         f.textContent = "what you have just done "

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -139,7 +139,7 @@ export class HepteractCraft {
             else if (item == 'worlds')
                 player.worlds.sub(amountToCraft * this.OTHER_CONVERSIONS[item])
         }
-        return Alert('You have successfully crafted ' + format(amountToCraft, 0, true) + ' hepteracts. If this is less than your input, you either hit the inventory limit or you had insufficient resources.');
+        return Alert('You have successfully crafted ' + format(amountToCraft, 0, true) + ' hepteracts.' + (max ? '' : ' If this is less than your input, you either hit the inventory limit or you had insufficient resources.'));
     }
 
     // Reduce balance through spending
@@ -272,7 +272,7 @@ export const hepteractDescriptions = (type: hepteractTypes) => {
             effectText.textContent = "This hepteract bends time, in your favor. +0.06% Ascension Speed per Chronos Hepteract."
             currentEffectText.textContent = "Current Effect: Ascension Speed +" + format(hepteractEffective('chronos') * 6 / 100, 2, true) + "%"
             balanceText.textContent = "Inventory: " + format(player.hepteractCrafts.chronos.BAL) + " / " + format(player.hepteractCrafts.chronos.CAP)
-            costText.textContent = "One of these will cost you " + format(player.hepteractCrafts.chronos.HEPTERACT_CONVERSION, 0, true) + " Hepteracts and 1e115 Obtainium [WIP]"
+            costText.textContent = "One of these will cost you " + format(player.hepteractCrafts.chronos.HEPTERACT_CONVERSION, 0, true) + " Hepteracts and 1e115 Obtainium"
             break;
         case 'hyperrealism':
             unlockedText.textContent = (player.hepteractCrafts.hyperrealism.UNLOCKED) ? "< UNLOCKED >": "< LOCKED >"


### PR DESCRIPTION
Hide ‘If this is less than your input, you either hit the inventory limit or you had insufficient resources.’ If you craft max of them, because input didn’t even exist when crafting max.
Remove [WIP] on first Hept forge, it is implemented.