### PR TITLE
Update Challenge HTML with Auto Ascend

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3037,7 +3037,7 @@ export const updateAll = (): void => {
 
     if (player.autoAscend) {
         if (player.autoAscendMode === "c10Completions" && player.challengecompletions[10] >= Math.max(1, player.autoAscendThreshold)) {
-            reset("ascension", true)
+            reset("ascension", false)
         }
     }
     let metaData = null;


### PR DESCRIPTION
I use Auto Ascend to reset the challenge, but I've always been annoyed that the HTML on the Challenge tab doesn't update to the reset state
Normally, don't ascend often, so the game doesn't get heavy, and it runs at most once per second