### PR TITLE
Set Platonic Cubes to 0 from reset

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1065,6 +1065,7 @@ const loadSynergy = async () => {
             player.wowCubes = new WowCubes(0);
             player.wowTesseracts = new WowTesseracts(0);
             player.wowHypercubes = new WowHypercubes(0);
+            player.wowPlatonicCubes = new WowPlatonicCubes(0);
             player.cubeBlessings = {
                 accelerator: 0,
                 multiplier: 0,


### PR DESCRIPTION
Fixes an issue where Platonic Cubes are null when unlocking Platonic Cubes without ever loading after Singularity.
If it loads even once after Singularity, player.wowPlatonicCubes will be set to 0 and it looks fine.
If you can access Platonic Cubes without reloading it at all, this will be an eternal resource and a fatal bug that will destroy your game.
I'm creating a custom Synergism, but I've determined that this issue is at an urgent level, so I sent a pull request.