### PR TITLE
Artemis' Tribute caps with 1e300

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -973,7 +973,7 @@ export const calculateCubeBlessings = () => {
             mult = 1;
         }
 
-        G['cubeBonusMultiplier'][i] = 1 + mult * G['blessingbase'][i]! * Math.pow(cubeArray[i-1], power * (1 + powerBonus[i-1])) * G['tesseractBonusMultiplier'][i]!;
+        G['cubeBonusMultiplier'][i] = Math.min(1e300, 1 + mult * G['blessingbase'][i]! * Math.pow(cubeArray[i-1], power * (1 + powerBonus[i-1])) * G['tesseractBonusMultiplier'][i]!);
     }
     calculateRuneLevels();
     calculateAntSacrificeELO();


### PR DESCRIPTION
Artemis' Tribute will stop producing ants when it reaches Infinity. This happens with 1e85 open cubes.
When the ants stop, the coin production will be 0 at C10 and you will not be able to ascend.