### PR TITLE
fix ant buy

### DIFF
--- a/src/Ants.ts
+++ b/src/Ants.ts
@@ -168,7 +168,8 @@ export const buyAntProducers = (pos: FirstToEighth, originalCost: DecimalSource,
     const tag = index === 1 ? 'reincarnationPoints' : 'antPoints';
     const key = `${pos}OwnedAnts` as const;
 
-    let buyTo = player[key] + 1;
+    const buydefault = player[key] + smallestInc(player[key]);
+    let buyTo = buydefault;
     let cashToBuy = getAntCost(originalCost, buyTo, index);
     while (player[tag].gte(cashToBuy)) {
         // Multiply by 4 until the desired amount. Iterate from there
@@ -176,7 +177,7 @@ export const buyAntProducers = (pos: FirstToEighth, originalCost: DecimalSource,
         cashToBuy = getAntCost(originalCost, buyTo, index);
     }
     let stepdown = Math.floor(buyTo / 8);
-    while (stepdown >= 1) {
+    while (stepdown >= smallestInc(buyTo)) {
         if (getAntCost(originalCost, buyTo - stepdown, index).lte(player[tag])) {
             stepdown = Math.floor(stepdown / 2);
         } else {
@@ -185,14 +186,14 @@ export const buyAntProducers = (pos: FirstToEighth, originalCost: DecimalSource,
     }
 
     if (!player.antMax) {
-        if (1 + player[key] < buyTo) {
-            buyTo = player[key] + 1;
+        if (buydefault < buyTo) {
+            buyTo = buydefault;
         }
     }
     // go down by 7 steps below the last one able to be bought and spend the cost of 25 up to the one that you started with and stop if coin goes below requirement
-    let buyFrom = Math.max(buyTo - 6 - smallestInc(buyTo), player[key] + 1);
+    let buyFrom = Math.max(buyTo - 6 - smallestInc(buyTo), buydefault);
     let thisCost = getAntCost(originalCost, buyFrom, index);
-    while (buyFrom < buyTo && player[tag].gte(thisCost)) {
+    while (buyFrom <= buyTo && player[tag].gte(thisCost)) {
         player[tag] = player[tag].sub(thisCost);
         player[key] = buyFrom;
         buyFrom = buyFrom + smallestInc(buyFrom);
@@ -224,7 +225,8 @@ export const buyAntProducers = (pos: FirstToEighth, originalCost: DecimalSource,
 export const buyAntUpgrade = (originalCost: DecimalSource, auto: boolean, index: number) => {
     if (player.currentChallenge.ascension !== 11) {
         originalCost = new Decimal(originalCost);
-        let buyTo = 1 + player.antUpgrades[index-1]!;
+        const buydefault = player.antUpgrades[index-1]! + smallestInc(player.antUpgrades[index-1]!);
+        let buyTo = buydefault;
         let cashToBuy = getAntUpgradeCost(originalCost, buyTo, index);
         while (player.antPoints.gte(cashToBuy)) {
             // Multiply by 4 until the desired amount. Iterate from there
@@ -232,7 +234,7 @@ export const buyAntUpgrade = (originalCost: DecimalSource, auto: boolean, index:
             cashToBuy = getAntUpgradeCost(originalCost, buyTo, index);
         }
         let stepdown = Math.floor(buyTo / 8);
-        while (stepdown >= 1) {
+        while (stepdown >= smallestInc(buyTo)) {
             if (getAntUpgradeCost(originalCost, buyTo - stepdown, index).lte(player.antPoints)) {
                 stepdown = Math.floor(stepdown / 2);
             } else {
@@ -240,14 +242,14 @@ export const buyAntUpgrade = (originalCost: DecimalSource, auto: boolean, index:
             }
         }
         if (!player.antMax) {
-            if (player.antUpgrades[index-1]! + 1 < buyTo) {
-                buyTo = 1 + player.antUpgrades[index-1]!
+            if (buydefault < buyTo) {
+                buyTo = buydefault;
             }
         }
         // go down by 7 steps below the last one able to be bought and spend the cost of 25 up to the one that you started with and stop if coin goes below requirement
-        let buyFrom = Math.max(buyTo - 6 - smallestInc(buyTo), 1 + player.antUpgrades[index-1]!);
+        let buyFrom = Math.max(buyTo - 6 - smallestInc(buyTo), buydefault);
         let thisCost = getAntUpgradeCost(originalCost, buyFrom, index);
-        while (buyFrom < buyTo && player.antPoints.gte(thisCost)) {
+        while (buyFrom <= buyTo && player.antPoints.gte(thisCost)) {
             player.antPoints = player.antPoints.sub(thisCost);
             player.antUpgrades[index-1] = buyFrom;
             buyFrom = buyFrom + smallestInc(buyFrom);

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -16,12 +16,14 @@ export const isDecimal = (o: unknown): o is Decimal =>
  * guaranteed to affect the numbers value
  * @param x
  * @returns {number} 1 if x < 2^53 and 2^ceil(log2(x)-53) otherwise
+ * Since ceil(log2(x)-53) was 53 until 2^53+23, I changed it to floor(log2(x)-52)
+ * This is incremented to 53 at 2^53-21 and is probably guaranteed thereafter. from by httpsnet
  */
 export const smallestInc = (x = 0): number => {
     if (x <= Number.MAX_SAFE_INTEGER) {
         return 1;
     } else {
-        return 2**Math.ceil(Math.log2(x)-53)
+        return 2 ** Math.floor(Math.log2(x) - 52)
     }
 }
 


### PR DESCRIPTION
Fixed a general bug where level 1 purchases for each ant and each ant tier would fail.
Fixed a bug where Buy Max: OFF would fail to purchase at level 2 ^ 53 and above.
Fixed a bug that caused an infinite loop between levels 2 ^ 53 ± 25 due to incorrect calculation of smallestInc().