### PR TITLE
bug fixes

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -358,7 +358,7 @@ export function calculateOfferings(input: resetNames, calcMult = true, statistic
         1 + 2.5 * player.platonicUpgrades[10], // Platonic BETA
         1 + 5 * player.platonicUpgrades[15], // Platonic OMEGA
         G['challenge15Rewards'].offering, // C15 Reward
-        1 + 5 * +player.singularityUpgrades.starterPack.getEffect().bonus, // Starter Pack Upgrade
+        1 + 5 * (player.singularityUpgrades.starterPack.getEffect().bonus ? 1 : 0), // Starter Pack Upgrade
         +player.singularityUpgrades.singOfferings1.getEffect().bonus, // Offering Charge GQ Upgrade
         +player.singularityUpgrades.singOfferings2.getEffect().bonus, // Offering Storm GQ Upgrade
         +player.singularityUpgrades.singOfferings3.getEffect().bonus, // Offering Tempest GQ Upgrade
@@ -462,7 +462,7 @@ export const calculateObtainium = () => {
     G['obtainiumGain'] *= (1 + 2.5 * player.platonicUpgrades[10])
     G['obtainiumGain'] *= (1 + 5 * player.platonicUpgrades[15])
     G['obtainiumGain'] *= G['challenge15Rewards'].obtainium
-    G['obtainiumGain'] *= 1 + 5 * +player.singularityUpgrades.starterPack.getEffect().bonus
+    G['obtainiumGain'] *= 1 + 5 * (player.singularityUpgrades.starterPack.getEffect().bonus ? 1 : 0)
     G['obtainiumGain'] *= +player.singularityUpgrades.singObtainium1.getEffect().bonus
     G['obtainiumGain'] *= +player.singularityUpgrades.singObtainium2.getEffect().bonus
     G['obtainiumGain'] *= +player.singularityUpgrades.singObtainium3.getEffect().bonus
@@ -1031,13 +1031,13 @@ export const calculateAllCubeMultiplier = () => {
         // Wow Pass Y
         1 + 0.5 * player.shopUpgrades.seasonPassY / 100,
         // BUY THIS! Golden Quark Upgrade
-        1 + 4 * player.singularityUpgrades.starterPack.level,
+        1 + 4 * (player.singularityUpgrades.starterPack.getEffect().bonus ? 1 : 0),
         // Cube Flame [GQ]
-        1 + 0.02 * player.singularityUpgrades.singCubes1.level,
+        +player.singularityUpgrades.singCubes1.getEffect().bonus,
         // Cube Blaze [GQ]
-        1 + 0.08 * player.singularityUpgrades.singCubes2.level,
+        +player.singularityUpgrades.singCubes2.getEffect().bonus,
         // Cube Inferno [GQ]
-        1 + 0.04 * player.singularityUpgrades.singCubes3.level,
+        +player.singularityUpgrades.singCubes3.getEffect().bonus,
         // Wow Pass Z
         1 + player.shopUpgrades.seasonPassZ * player.singularityCount / 100,
         // Cookie Upgrade 16
@@ -1264,7 +1264,7 @@ export const calculateTimeAcceleration = () => {
     timeMult /= calculateSingularityDebuff('Global Speed');
     timeMult *= G['platonicBonusMultiplier'][7]
     timeMult *= (1 + 2 * +G['isEvent'])
-    timeMult *= 1 + player.singularityUpgrades.intermediatePack.level
+    timeMult *= 1 + (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0)
 
     if (player.usedCorruptions[3] >= 6 && player.achievements[241] < 1) {
         achievementaward(241)
@@ -1287,15 +1287,15 @@ export const calculateAscensionAcceleration = () => {
         1 + 0.002 * sumContents(player.usedCorruptions) * player.platonicUpgrades[15],                  // PLAT Omega
         G['challenge15Rewards'].ascensionSpeed,                                                         // C15
         1 + 1/400 * player.cubeUpgrades[59],                                                            // Cookie Upgrade 9
-        1 + 0.5 * player.singularityUpgrades.intermediatePack.level,                                    // Intermediate Pack, Sing Shop
-        1 + 1/1000 * player.singularityCount * player.shopUpgrades.chronometerZ                        // Chronometer Z
+        1 + 0.5 * (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0),              // Intermediate Pack, Sing Shop
+        1 + 1/1000 * player.singularityCount * player.shopUpgrades.chronometerZ                         // Chronometer Z
     ]
     return productContents(arr) / calculateSingularityDebuff('Ascension Speed')
 }
 
 export const calculateCorruptionPoints = () => {
     let basePoints = 400;
-    const bonusLevel = (player.singularityUpgrades.corruptionFifteen.level > 0) ? 1 : 0;
+    const bonusLevel = player.singularityUpgrades.corruptionFifteen.getEffect().bonus ? 1 : 0;
 
     for (let i = 1; i <= 9; i++) {
         basePoints += 16 * Math.pow(player.usedCorruptions[i] + bonusLevel, 2)
@@ -1464,7 +1464,7 @@ export const calculateAscensionScore = () => {
     let corruptionMultiplier = 1;
     let effectiveScore = 0;
 
-    const bonusLevel = player.singularityUpgrades.corruptionFifteen.getEffect().bonus > 0 ? 1 : 0;
+    const bonusLevel = player.singularityUpgrades.corruptionFifteen.getEffect().bonus ? 1 : 0;
     // Init Arrays with challenge values :)
     const challengeScoreArrays1 = [0, 8, 10, 12, 15, 20, 60, 80, 120, 180, 300];
     const challengeScoreArrays2 = [0, 10, 12, 15, 20, 30, 80, 120, 180, 300, 450];
@@ -1506,7 +1506,7 @@ export const calculateAscensionScore = () => {
         const exponent = ((i === 2) && player.usedCorruptions[i] >= 10) ? 1 + 2 * Math.min(1, player.platonicUpgrades[17]) + 0.04 * player.platonicUpgrades[17] : 1;
         corruptionMultiplier *= (Math.pow(G['corruptionPointMultipliers'][player.usedCorruptions[i] + bonusLevel], exponent) + bonusVal);
 
-        if (player.usedCorruptions[i] >= 14 && player.singularityUpgrades.masterPack.level > 0) {
+        if (player.usedCorruptions[i] >= 14 && player.singularityUpgrades.masterPack.getEffect().bonus) {
             corruptionMultiplier *= 1.1
         }
     }

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -903,7 +903,7 @@ export const singularity = async (): Promise<void> => {
     hold.dailyCodeUsed = player.dailyCodeUsed
     hold.runeBlessingBuyAmount = player.runeBlessingBuyAmount
     hold.runeSpiritBuyAmount = player.runeSpiritBuyAmount
-    hold.transcendamount = player.prestigeamount
+    hold.prestigeamount= player.prestigeamount
     hold.transcendamount = player.transcendamount
     hold.reincarnationamount = player.reincarnationamount
     hold.talismanOne = player.talismanOne

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -26,7 +26,7 @@ import { Synergism } from './Events';
 import type { Player, resetNames } from './types/Synergism';
 import { updateClassList } from './Utility';
 import { corrChallengeMinimum, corruptionStatsUpdate, maxCorruptionLevel } from './Corruptions';
-import { toggleAutoChallengeModeText } from './Toggles';
+import { toggleAutoChallengeModeText, toggleSubTab, toggleTabs } from './Toggles';
 import { DOMCacheGetOrSet } from './Cache/DOM';
 import { WowCubes } from './CubeExperimental';
 import { importSynergism } from './ImportExport';
@@ -870,6 +870,13 @@ export const singularity = async (): Promise<void> => {
     const hold = Object.assign({}, blankSave, {
         codes: Array.from(blankSave.codes)
     }) as Player;
+    //Reset Displays
+    toggleTabs('buildings');
+    toggleSubTab(1, 0);
+    toggleSubTab(4, 0); // Set 'runes' subtab back to 'runes' tab
+    toggleSubTab(8, 0); // Set 'cube tribues' subtab back to 'cubes' tab
+    toggleSubTab(9, 0); // set 'corruption main'
+    toggleSubTab(-1, 0); // set 'statistics main'
 
     hold.singularityCount = player.singularityCount;
     hold.goldenQuarks = player.goldenQuarks;
@@ -903,7 +910,7 @@ export const singularity = async (): Promise<void> => {
     hold.dailyCodeUsed = player.dailyCodeUsed
     hold.runeBlessingBuyAmount = player.runeBlessingBuyAmount
     hold.runeSpiritBuyAmount = player.runeSpiritBuyAmount
-    hold.prestigeamount= player.prestigeamount
+    hold.prestigeamount = player.prestigeamount
     hold.transcendamount = player.transcendamount
     hold.reincarnationamount = player.reincarnationamount
     hold.talismanOne = player.talismanOne

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -9,7 +9,7 @@ import { CalcECC, getChallengeConditions, challengeDisplay, highestChallengeRewa
 import type { OneToFive, Player, resetNames, ZeroToFour } from './types/Synergism';
 import { upgradeupdate, getConstUpgradeMetadata, buyConstantUpgrades, ascendBuildingDR } from './Upgrades';
 import { updateResearchBG, maxRoombaResearchIndex, buyResearch } from './Research';
-import { updateChallengeDisplay, revealStuff, showCorruptionStatsLoadouts, CSSAscend, updateAchievementBG, updateChallengeLevel, buttoncolorchange, htmlInserts, hideStuff, changeTabColor, Confirm, Alert, Notification } from './UpdateHTML';
+import { updateChallengeDisplay, revealStuff, showCorruptionStatsLoadouts, CSSAscend, updateAchievementBG, updateChallengeLevel, buttoncolorchange, htmlInserts, changeTabColor, Confirm, Alert, Notification } from './UpdateHTML';
 import { calculateHypercubeBlessings } from './Hypercubes';
 import { calculateTesseractBlessings } from './Tesseracts';
 import { calculateCubeBlessings, calculateObtainium, calculateAnts, calculateRuneLevels, calculateOffline, calculateSigmoidExponential, calculateCorruptionPoints, calculateTotalCoinOwned, calculateTotalAcceleratorBoost, dailyResetCheck, calculateOfferings, calculateAcceleratorMultiplier, calculateTimeAcceleration, eventCheck, exitOffline } from './Calculate';

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -14,7 +14,7 @@ import { calculateHypercubeBlessings } from './Hypercubes';
 import { calculateTesseractBlessings } from './Tesseracts';
 import { calculateCubeBlessings, calculateObtainium, calculateAnts, calculateRuneLevels, calculateOffline, calculateSigmoidExponential, calculateCorruptionPoints, calculateTotalCoinOwned, calculateTotalAcceleratorBoost, dailyResetCheck, calculateOfferings, calculateAcceleratorMultiplier, calculateTimeAcceleration, eventCheck, exitOffline } from './Calculate';
 import { updateTalismanAppearance, toggleTalismanBuy, updateTalismanInventory, buyTalismanEnhance, buyTalismanLevels } from './Talismans';
-import { toggleAscStatPerSecond, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleChallenges, toggleauto, toggleAutoChallengeModeText, toggleShops } from './Toggles';
+import { toggleAscStatPerSecond, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleChallenges, toggleauto, toggleAutoChallengeModeText, toggleShops, toggleTabs, toggleSubTab } from './Toggles';
 import { c15RewardUpdate } from './Statistics';
 import { resetHistoryRenderAllTables } from './History';
 import { calculatePlatonicBlessings } from './PlatonicCubes';
@@ -1293,6 +1293,17 @@ const loadSynergy = async () => {
         revealStuff();
         toggleauto();
 
+        // Challenge summary should be displayed
+        if (player.currentChallenge.transcension > 0) {
+            challengeDisplay(player.currentChallenge.transcension);
+        } else if (player.currentChallenge.reincarnation > 0) {
+            challengeDisplay(player.currentChallenge.reincarnation);
+        } else if (player.currentChallenge.ascension > 0) {
+            challengeDisplay(player.currentChallenge.ascension);
+        } else {
+            challengeDisplay(1);
+        }
+
         DOMCacheGetOrSet('startTimerValue').textContent = format(player.autoChallengeTimer.start, 2, true) + 's'
         getElementById<HTMLInputElement>('startAutoChallengeTimerInput').value = player.autoChallengeTimer.start + '';
         DOMCacheGetOrSet('exitTimerValue').textContent = format(player.autoChallengeTimer.exit, 2, true) + 's'
@@ -1341,6 +1352,14 @@ const loadSynergy = async () => {
             toggleAscStatPerSecond(+id);
         }
 
+        getElementById<HTMLInputElement>('ascensionAmount').value = player.autoAscendThreshold.toString();
+        getElementById<HTMLInputElement>('autoAntSacrificeAmount').value = player.autoAntSacTimer.toString();
+        getElementById<HTMLInputElement>('buyRuneBlessingInput').value = player.runeBlessingBuyAmount.toString();
+        getElementById<HTMLInputElement>('buyRuneSpiritInput').value = player.runeSpiritBuyAmount.toString();
+        getElementById<HTMLInputElement>('prestigeamount').value = player.prestigeamount.toString();
+        getElementById<HTMLInputElement>('transcendamount').value = player.transcendamount.toString();
+        getElementById<HTMLInputElement>('reincarnationamount').value = player.reincarnationamount.toString();
+        getElementById<HTMLInputElement>('tesseractAmount').value = player.tesseractAutoBuyerAmount.toString();
 
         if (player.resettoggle1 === 1) {
             DOMCacheGetOrSet('prestigeautotoggle').textContent = 'Mode: AMOUNT'
@@ -1409,6 +1428,28 @@ const loadSynergy = async () => {
         if (!player.autoAscend) {
             DOMCacheGetOrSet('ascensionAutoEnable').textContent = 'Auto Ascend [OFF]';
             DOMCacheGetOrSet('ascensionAutoEnable').style.border = '2px solid red'
+        }
+
+        // Settings that are not saved in the data will be restored to their defaults by import or singularity
+        if (G['maxbuyresearch']) {
+            DOMCacheGetOrSet('toggleresearchbuy').textContent = 'Upgrade: MAX [if possible]'
+        } else {
+            DOMCacheGetOrSet('toggleresearchbuy').textContent = 'Upgrade: 1 Level'
+        }
+        if (G['shopConfirmation']) {
+            DOMCacheGetOrSet('toggleConfirmShop').textContent = 'Shop Confirmations: ON'
+        } else {
+            DOMCacheGetOrSet('toggleConfirmShop').textContent = 'Shop Confirmations: OFF'
+        }
+        if (G['shopBuyMax']) {
+            DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy Max: ON'
+        } else {
+            DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy Max: OFF'
+        }
+        if (G['buyMaxCubeUpgrades']) {
+            DOMCacheGetOrSet('toggleCubeBuy').textContent = 'Upgrade: MAX [if possible wow]'
+        } else {
+            DOMCacheGetOrSet('toggleCubeBuy').textContent = 'Upgrade: 1 Level wow'
         }
 
         for (let i = 1; i <= 2; i++) {
@@ -3595,10 +3636,16 @@ export const reloadShit = async (reset = false) => {
 
     await saveSynergy();
     toggleauto();
-    revealStuff();
-    hideStuff();
     htmlInserts();
     createTimer();
+
+    //Reset Displays
+    toggleTabs('buildings');
+    toggleSubTab(1, 0);
+    toggleSubTab(4, 0); // Set 'runes' subtab back to 'runes' tab
+    toggleSubTab(8, 0); // Set 'cube tribues' subtab back to 'cubes' tab
+    toggleSubTab(9, 0); // set 'corruption main'
+    toggleSubTab(-1, 0); // set 'statistics main'
 
     dailyResetCheck();
     interval(() => dailyResetCheck(), 30_000);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1321,6 +1321,10 @@ const loadSynergy = async () => {
 
         DOMCacheGetOrSet('talismanlevelup').style.display = 'none'
         DOMCacheGetOrSet('talismanrespec').style.display = 'none'
+
+        // This must be initialized at the beginning of the calculation
+        c15RewardUpdate();
+
         calculatePlatonicBlessings();
         calculateHypercubeBlessings();
         calculateTesseractBlessings();
@@ -1441,7 +1445,6 @@ const loadSynergy = async () => {
         calculateAnts();
         calculateRuneLevels();
         resetHistoryRenderAllTables();
-        c15RewardUpdate();
         updateSingularityAchievements();
     }
     CSSAscend();
@@ -1979,7 +1982,12 @@ export const updateAllMultiplier = (): void => {
         G['multiplierPower'] = 1;
     }
     if (player.currentChallenge.reincarnation === 10) {
-        G['multiplierPower'] = 1;
+        if (player.platonicUpgrades[20] > 0) {
+            // Not 1 because coins could not be produced completely
+            G['multiplierPower'] = 2;
+        } else {
+            G['multiplierPower'] = 1;
+        }
     }
 
     G['multiplierEffect'] = Decimal.pow(G['multiplierPower'], G['totalMultiplier']);


### PR DESCRIPTION
Changed to update the c15 score bonus on load before the calculation.
This will prevent the import from affecting the Obtainium bonus of the previous data.

Fixes that in cases like all levels 14 of Corruption, c10 can result in 0 coin production.
I could complete more than 100 challenges other than c10, but only c10 didn't move the coin with 2.
Even if the coin production ratio is 2, c10 can be easily achieved, so I think it is a problem.