### PR TITLE
Add auto research ability when at 10 sing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ node_modules/
 dist
 !.eslintrc.js
 .idea
+
+.project
+.settings/*

--- a/src/Research.ts
+++ b/src/Research.ts
@@ -16,7 +16,7 @@ const getResearchCost = (index: number, buyAmount = 1, linGrowth = 0): IMultiBuy
 export const updateAutoResearch = (index: number, auto: boolean) => {
     /* If Cube Upgrade 9 (1x9) is purchased, then automation behaves differently.
      If not purchased, then clicking on a research icon while auto toggled will update research for you.*/
-    if (player.cubeUpgrades[9] > 0 && auto && player.autoResearchMode === 'cheapest') {
+    if (autoResearchEnabled() && auto && player.autoResearchMode === 'cheapest') {
 
         player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex];
 
@@ -45,7 +45,7 @@ export const updateAutoResearch = (index: number, auto: boolean) => {
         }
 
         return
-    } else if (!auto && (player.cubeUpgrades[9] < 1 || player.autoResearchMode === 'manual')){
+    } else if (!auto && (!autoResearchEnabled() || player.autoResearchMode === 'manual')){
         /* We remove the old research HTML from the 'roomba' class and make the new index our 'roomba'
            class. We then update the index and consequently the coloring of the background based
            on what level (if any) the research has. This functionality is useless after
@@ -71,6 +71,13 @@ export const updateAutoResearch = (index: number, auto: boolean) => {
     } //There might be code needed here. I don't quite know yet. -Platonic
 }
 
+/**
+ * Should the user have access to autoResearch
+ * @returns boolean
+ */
+export const autoResearchEnabled = (): boolean => {
+    return (player.cubeUpgrades[9] === 1 || player.singularityCount > 10);
+}
 /**
  * Attempts to buy the research of the index selected. This is hopefully an improvement over buyResearch. Fuck
  * @param index

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -30,6 +30,7 @@ import { updateCubeUpgradeBG } from './Cubes';
 import { corruptionLoadoutTableUpdate, corruptionButtonsAdd, corruptionLoadoutTableCreate, corruptionStatsUpdate, updateCorruptionLoadoutNames, corruptionLoadoutSaveLoad } from './Corruptions';
 import { generateEventHandlers } from './EventListeners';
 import { addTimers, automaticTools } from './Helper';
+import { autoResearchEnabled } from './Research';
 //import { LegacyShopUpgrades } from './types/LegacySynergism';
 
 import { checkVariablesOnLoad } from './CheckVariables';
@@ -3344,6 +3345,11 @@ function tack(dt: number) {
             automaticTools('addObtainium', dt)
         } else {
             calculateObtainium();
+        }
+
+        //If auto research is enabled and runing; Make sure there is something to try to research if possible
+        if (player.autoResearchToggle && autoResearchEnabled() && player.autoResearchMode === 'cheapest'){
+            player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex];
         }
 
         //Automatically tries and buys researches lol

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -5,6 +5,7 @@ import Decimal from 'break_infinity.js';
 import { visualUpdateCubes } from './UpdateVisuals';
 import { calculateRuneLevels } from './Calculate';
 import { reset, resetrepeat } from './Reset';
+import { autoResearchEnabled } from './Research';
 import { achievementaward } from './Achievements';
 import { getChallengeConditions } from './Challenges';
 import { loadStatisticsCubeMultipliers, loadStatisticsOfferingMultipliers, loadStatisticsAccelerator, loadStatisticsMultiplier, loadPowderMultiplier } from './Statistics';
@@ -415,7 +416,7 @@ export const toggleAutoResearch = () => {
         el.textContent = 'Automatic: ON'
     }
 
-    if (player.autoResearchToggle && player.cubeUpgrades[9] === 1 && player.autoResearchMode === 'cheapest') {
+    if (player.autoResearchToggle && autoResearchEnabled() && player.autoResearchMode === 'cheapest') {
         player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex]
     }
 
@@ -432,7 +433,7 @@ export const toggleAutoResearchMode = () => {
     }
     DOMCacheGetOrSet(`res${player.autoResearch || 1}`).classList.remove('researchRoomba');
 
-    if (player.autoResearchToggle && player.cubeUpgrades[9] === 1 && player.autoResearchMode === 'cheapest') {
+    if (player.autoResearchToggle && autoResearchEnabled() && player.autoResearchMode === 'cheapest') {
         player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex]
     }
 }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -4,6 +4,7 @@ import Decimal from 'break_infinity.js';
 import { CalcCorruptionStuff, calculateAscensionAcceleration, calculateTimeAcceleration} from './Calculate';
 import { achievementaward, totalachievementpoints } from './Achievements';
 import { displayRuneInformation } from './Runes';
+import { autoResearchEnabled } from './Research';
 import { visualUpdateBuildings, visualUpdateUpgrades, visualUpdateAchievements, visualUpdateRunes, visualUpdateChallenges, visualUpdateResearch, visualUpdateSettings, visualUpdateShop, visualUpdateAnts, visualUpdateCubes, visualUpdateCorruptions } from './UpdateVisuals';
 import { getMaxChallenges } from './Challenges';
 import type { OneToFive, ZeroToFour, ZeroToSeven } from './types/Synergism';
@@ -350,7 +351,7 @@ export const revealStuff = () => {
         DOMCacheGetOrSet('toggleautoresearch').style.display = 'block' :
         DOMCacheGetOrSet('toggleautoresearch').style.display = 'none';
 
-    DOMCacheGetOrSet('toggleautoresearchmode').style.display = player.shopUpgrades.obtainiumAuto > 0 && player.cubeUpgrades[9] > 0 //Auto Research Shop Purchase Mode
+    DOMCacheGetOrSet('toggleautoresearchmode').style.display = player.shopUpgrades.obtainiumAuto > 0 && autoResearchEnabled() //Auto Research Shop Purchase Mode
         ? 'block'
         : 'none';
 


### PR DESCRIPTION
autoResearchEnabled is a function so that there is only one place where we check if they should have access to auto

auto is given when player.singularityCount > 10. 
Developer thoughts
**We could give it as a direct bonus in Reset.ts
**I decided to do this so that it will be checked and done no matter what stat the user is in; Found a few situations where it would not happen when put in Reset.ts

Synergism.ts
Add in a check here; I discovered that if you change auto settings outset of toggles ect that it created broken states in the game. By adding the check here, it prevents these issues