### PR TITLE
Improved Blessing and Spirit

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2598,7 +2598,7 @@ p[id$="BlessingsTotal"] {
 }
 
 #buyRuneBlessingInput {
-    width: 60px;
+    width: 100px;
     border: 2px solid crimson;
     margin-right: 20px;
     background-color: #171717;
@@ -2606,7 +2606,7 @@ p[id$="BlessingsTotal"] {
 }
 
 #buyRuneSpiritInput {
-    width: 60px;
+    width: 100px;
     border: 2px solid orange;
     margin-right: 20px;
     background-color: #171717;

--- a/index.html
+++ b/index.html
@@ -1453,6 +1453,7 @@
             </div>
             <div id="runeContainer3" alt="runeContainer3" label="runeContainer3" style="display: none">
                 <div class="runeBlessingPurchaseSettings">
+                    <button id="buyAllBlessings" class="runeButtons runeButtonsAvailable" style="width: 120px;">ALL Increase Level</button>
                     <input type="number" id="buyRuneBlessingInput" alt="buyRuneBlessingInput" label="buyRuneBlessingInput" min="1" max="999999999" defaultValue="1">
                     <span id="buyRuneBlessingToggle" alt="buyRuneBlessingToggle" label="buyRuneBlessingToggle" style="color: yellow">Buy up to <span id="buyRuneBlessingToggleValue" alt="buyRuneBlessingToggleValue" label="buyRuneBlessingToggleValue" style="color: orchid">1</span> Levels per purchase, if affordable. [Input to toggle]</span>
                 </div>
@@ -1489,6 +1490,7 @@
             </div>
             <div id="runeContainer4" alt="runeContainer4" label="runeContainer4" style="display: none">
                 <div class="runeBlessingPurchaseSettings">
+                    <button id="buyAllSpirits" class="runeButtons runeButtonsAvailable" style="width: 120px;">ALL Increase Level</button>
                     <input type="number" id="buyRuneSpiritInput" alt="buyRuneSpiritInput" label="buyRuneSpiritInput" min="1" max="999999999" defaultValue="1">
                     <span id="buyRuneSpiritToggle" alt="buyRuneSpiritToggle" label="buyRuneSpiritToggle" style="color: yellow">Buy up to <span id="buyRuneSpiritToggleValue" alt="buyRuneSpiritToggleValue" label="buyRuneSpiritToggleValue" style="color: orchid">1</span> Levels per purchase, if affordable. [Input to toggle]</span>
                 </div>

--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -1026,7 +1026,7 @@ export const buyAllBlessings = (type: 'Blessings' | 'Spirits', percentage = 100,
                 }
 
                 const [level, cost] = calculateSummationLinear(baseLevels, baseCost, runeshards, levelCap);
-                if (level > baseLevels && (!auto || (level - baseLevels) * 10000) > baseLevels) {
+                if (level > baseLevels && (!auto || (level - baseLevels) * 10000 > baseLevels)) {
                     if (type === 'Spirits') {
                         player.runeSpiritLevels[index] = level;
                     } else {

--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -944,19 +944,26 @@ export const buyTesseractBuilding = (index: OneToFive, amount = player.tesseract
 
 export const buyRuneBonusLevels = (type: 'Blessings' | 'Spirits', index: number) => {
     const unlocked = type === 'Spirits' ? player.challengecompletions[12] > 0 : player.achievements[134] === 1;
-
     if (unlocked && isFinite(player.runeshards) && player.runeshards > 0) {
-        let baseCost
-        let baseLevels
-        let levelCap
-        (type === 'Spirits') ?
-            (baseCost = G['spiritBaseCost'], baseLevels = player.runeSpiritLevels[index], levelCap = player.runeSpiritBuyAmount) :
-            (baseCost = G['blessingBaseCost'], baseLevels = player.runeBlessingLevels[index], levelCap = player.runeBlessingBuyAmount);
+        let baseCost;
+        let baseLevels;
+        let levelCap;
+        if (type === 'Spirits') {
+            baseCost = G['spiritBaseCost'];
+            baseLevels = player.runeSpiritLevels[index];
+            levelCap = player.runeSpiritBuyAmount;
+        } else {
+            baseCost = G['blessingBaseCost'];
+            baseLevels = player.runeBlessingLevels[index];
+            levelCap = player.runeBlessingBuyAmount;
+        }
 
         const [level, cost] = calculateSummationLinear(baseLevels, baseCost, player.runeshards, levelCap);
-        (type === 'Spirits') ?
-            player.runeSpiritLevels[index] = level :
+        if (type === 'Spirits') {
+            player.runeSpiritLevels[index] = level;
+        } else {
             player.runeBlessingLevels[index] = level;
+        }
 
         player.runeshards -= cost;
 
@@ -1007,12 +1014,21 @@ export const buyAllBlessings = (type: 'Blessings' | 'Spirits', percentage = 100,
         const runeshards = Math.floor(player.runeshards / 100 * percentage / 5);
         for (let index = 1; index < 6; index++) {
             if (isFinite(player.runeshards) && player.runeshards > 0) {
-                const baseCost = type === 'Spirits' ? G['spiritBaseCost'] : G['blessingBaseCost'];
-                const baseLevels = type === 'Spirits' ? player.runeSpiritLevels[index] : player.runeBlessingLevels[index];
-                const [level, cost] = calculateSummationLinear(baseLevels, baseCost, runeshards, 1e300);
+                let baseCost;
+                let baseLevels;
+                const levelCap = 1e300;
+                if (type === 'Spirits') {
+                    baseCost = G['spiritBaseCost'];
+                    baseLevels = player.runeSpiritLevels[index];
+                } else {
+                    baseCost = G['blessingBaseCost'];
+                    baseLevels = player.runeBlessingLevels[index];
+                }
+
+                const [level, cost] = calculateSummationLinear(baseLevels, baseCost, runeshards, levelCap);
                 if (level > baseLevels && (!auto || (level - baseLevels) * 10000) > baseLevels) {
                     if (type === 'Spirits') {
-                        player.runeSpiritLevels[index] = level
+                        player.runeSpiritLevels[index] = level;
                     } else {
                         player.runeBlessingLevels[index] = level;
                     }

--- a/src/Buy.ts
+++ b/src/Buy.ts
@@ -943,24 +943,32 @@ export const buyTesseractBuilding = (index: OneToFive, amount = player.tesseract
 }
 
 export const buyRuneBonusLevels = (type: 'Blessings' | 'Spirits', index: number) => {
-    let baseCost
-    let baseLevels
-    let levelCap
-    (type === 'Spirits') ?
-        (baseCost = G['spiritBaseCost'], baseLevels = player.runeSpiritLevels[index], levelCap = player.runeSpiritBuyAmount) :
-        (baseCost = G['blessingBaseCost'], baseLevels = player.runeBlessingLevels[index], levelCap = player.runeBlessingBuyAmount);
+    const unlocked = type === 'Spirits' ? player.challengecompletions[12] > 0 : player.achievements[134] === 1;
 
-    const [level, cost] = calculateSummationLinear(baseLevels, baseCost, player.runeshards, levelCap);
-    (type === 'Spirits') ?
-        player.runeSpiritLevels[index] = level :
-        player.runeBlessingLevels[index] = level;
+    if (unlocked && isFinite(player.runeshards) && player.runeshards > 0) {
+        let baseCost
+        let baseLevels
+        let levelCap
+        (type === 'Spirits') ?
+            (baseCost = G['spiritBaseCost'], baseLevels = player.runeSpiritLevels[index], levelCap = player.runeSpiritBuyAmount) :
+            (baseCost = G['blessingBaseCost'], baseLevels = player.runeBlessingLevels[index], levelCap = player.runeBlessingBuyAmount);
 
-    player.runeshards -= cost;
+        const [level, cost] = calculateSummationLinear(baseLevels, baseCost, player.runeshards, levelCap);
+        (type === 'Spirits') ?
+            player.runeSpiritLevels[index] = level :
+            player.runeBlessingLevels[index] = level;
 
-    if (player.runeshards < 0) {
-        player.runeshards = 0;
+        player.runeshards -= cost;
+
+        if (player.runeshards < 0) {
+            player.runeshards = 0;
+        }
+
+        updateRuneBlessing(type, index);
     }
+}
 
+export const updateRuneBlessing = (type: 'Blessings' | 'Spirits', index: number) => {
     if (index === 1) {
         const requirementArray = [0, 1e5, 1e8, 1e11]
         for (let i = 1; i <= 3; i++) {
@@ -990,5 +998,34 @@ export const buyRuneBonusLevels = (type: 'Blessings' | 'Spirits', index: number)
         const t = (index === 3) ? 1 : 0;
         DOMCacheGetOrSet('runeSpiritPower' + index + 'Value1').textContent = format(G['runeSpirits'][index])
         DOMCacheGetOrSet('runeSpiritPower' + index + 'Value2').textContent = format(1 - t + spiritMultiplierArray[index] * G['effectiveRuneSpiritPower'][index], 4, true)
+    }
+}
+
+export const buyAllBlessings = (type: 'Blessings' | 'Spirits', percentage = 100, auto = false) => {
+    const unlocked = type === 'Spirits' ? player.challengecompletions[12] > 0 : player.achievements[134] === 1;
+    if (unlocked) {
+        const runeshards = Math.floor(player.runeshards / 100 * percentage / 5);
+        for (let index = 1; index < 6; index++) {
+            if (isFinite(player.runeshards) && player.runeshards > 0) {
+                const baseCost = type === 'Spirits' ? G['spiritBaseCost'] : G['blessingBaseCost'];
+                const baseLevels = type === 'Spirits' ? player.runeSpiritLevels[index] : player.runeBlessingLevels[index];
+                const [level, cost] = calculateSummationLinear(baseLevels, baseCost, runeshards, 1e300);
+                if (level > baseLevels && (!auto || (level - baseLevels) * 10000) > baseLevels) {
+                    if (type === 'Spirits') {
+                        player.runeSpiritLevels[index] = level
+                    } else {
+                        player.runeBlessingLevels[index] = level;
+                    }
+
+                    player.runeshards -= cost;
+
+                    if (player.runeshards < 0) {
+                        player.runeshards = 0;
+                    }
+
+                    updateRuneBlessing(type, index);
+                }
+            }
+        }
     }
 }

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -1,7 +1,7 @@
 import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation, toggleAutoResearchMode, toggleBuyMaxShop, toggleHepteractAutoPercentage } from './Toggles'
 import { resetrepeat, updateAutoReset, updateTesseractAutoBuyAmount } from './Reset'
 import { player, resetCheck, saveSynergy } from './Synergism'
-import { boostAccelerator, buyAccelerator, buyMultiplier, buyProducer, buyCrystalUpgrades, buyParticleBuilding, buyTesseractBuilding, buyUpgrades, buyRuneBonusLevels } from './Buy'
+import { boostAccelerator, buyAccelerator, buyMultiplier, buyProducer, buyCrystalUpgrades, buyParticleBuilding, buyTesseractBuilding, buyUpgrades, buyRuneBonusLevels, buyAllBlessings } from './Buy'
 import { crystalupgradedescriptions, constantUpgradeDescriptions, buyConstantUpgrades, upgradedescriptions } from './Upgrades'
 import { buyAutobuyers } from './Automation'
 import { buyGenerator } from './Generators'
@@ -341,6 +341,9 @@ export const generateEventHandlers = () => {
     }
     DOMCacheGetOrSet('buyRuneBlessingInput').addEventListener('blur', () => updateRuneBlessingBuyAmount(1))
     DOMCacheGetOrSet('buyRuneSpiritInput').addEventListener('blur', () => updateRuneBlessingBuyAmount(2))
+
+    DOMCacheGetOrSet('buyAllBlessings').addEventListener('click', () => buyAllBlessings('Blessings'))
+    DOMCacheGetOrSet('buyAllSpirits').addEventListener('click', () => buyAllBlessings('Spirits'))
 
     // CHALLENGES TAB
     //Part 1: Challenges


### PR DESCRIPTION
Apply Blessing and Spirit equal purchases and automation
Auto Blessing and Spirit are enabled in Singularity 15 and work with Auto Rune: ON
Auto Rune buys up to 50% of the Offerings you have
Automatic Blessing and Spirit buy 25% of the Offerings you have evenly
Blessing and Spirit will not actually be available for purchase if locked
Ignore purchases if Offerings are infinite or NaN
From Singularity 30, Infinite Ascent auto purchase feature will be unlocked