### PR TITLE
Added a toggle to disable Singularity confirmation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2792,6 +2792,10 @@
                         <img class="sacrificeAnts settingpic" id="settingpic5" alt="settingpic5" label="settingpic5" src = "Pictures/Transparent%20Pics/Research124.png" loading="lazy">
                         <button class="auto square" id="toggle32" alt="toggle32" label="toggle32" toggleid="32" alt="32" label="32" format="[$]" style="border:2px solid green">[ON]</button>
                     </div>
+                    <div class="confirmationToggle">
+                        <img class="singularity settingpic" id="settingpic6" alt="settingpic6" label="settingpic6" src = "Pictures/Singularity.png" loading="lazy">
+                        <button class="auto square" id="toggle33" alt="toggle33" label="toggle33" toggleid="33" alt="33" label="33" format="[$]" style="border:2px solid green">[ON]</button>
+                    </div>
                     <div class="center"></div>
                 </div>
                 <p class="prestigeunlock" id="confirmationdisclaimer" alt="confirmationdisclaimer" label="confirmationdisclaimer" style="color: plum">These do not work with hotkeys. Too bad!</p>

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -214,7 +214,7 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.toggles[32] = true;
     }
 
-    if (data.toggles[33] === undefined) {
+    if (!data.toggles || data.toggles[33] === undefined) {
         player.toggles[33] = true;
     }
 

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -214,6 +214,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.toggles[32] = true;
     }
 
+    if (data.singularityCount === 0) {
+        player.toggles[33] = true;
+    }
+
     if (data.dayCheck === undefined) {
         player.dayCheck = null;
         player.dayTimer = 0;

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -214,7 +214,7 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.toggles[32] = true;
     }
 
-    if (data.singularityCount === 0) {
+    if (data.toggles[33] === undefined) {
         player.toggles[33] = true;
     }
 

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -194,8 +194,8 @@ export const generateEventHandlers = () => {
     }
 
     //Part 4: Toggles
-    // I'm just addressing all global toggles here
-    for (let index = 0; index < 32; index++) {
+    // I'm just addressing all global toggles here: toggle1 up to toggle33
+    for (let index = 0; index < 33; index++) {
         DOMCacheGetOrSet(`toggle${index+1}`).addEventListener('click', () => toggleSettings(index))
     }
     // Toggles auto reset type (between TIME and AMOUNT)

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2944,27 +2944,31 @@ export const resetCheck = async (i: resetNames, manual = true, leaving = false):
         if (player.runelevels[6] === 0) {
             return Alert('Hmph. Please return with an Antiquity. Thank you. -Ant God')
         }
-        await Alert('You have reached the end of the game, on singularity #' +format(player.singularityCount)+'. Platonic and the Ant God are proud of you.')
-        await Alert('You may choose to sit on your laurels, and consider the game \'beaten\', or you may do something more interesting.')
-        await Alert('You\'re too powerful for this current universe. The multiverse of Synergism is truly endless, but out there are even more challenging universes parallel to your very own.')
-        await Alert(`Start anew, and enter singularity #${format(player.singularityCount + 1)}. Your next universe is harder than your current one, but unlock a permanent +10% Quark Bonus, +10% Ascension Count Bonus, and Gain ${format(calculateGoldenQuarkGain(), 2, true)} golden quarks, which can purchase game-changing endgame upgrades [Boosted by ${format(player.worlds.BONUS)}% due to patreon bonus!].`)
-        await Alert('However, all your past accomplishments are gone! ALL Challenges, Refundable Shop upgrades, Upgrade Tab, Runes, All Cube upgrades, All Cube Openings, Hepteracts (Except for your Quark Hepteracts), Achievements will be wiped clean.')
-        let c1 = false
-        let c2 = false
-        let c3 = false
-        c1 = await Confirm('So, what do you say? Do you wish to enter the singularity?')
-        if (c1) {
-            c2 = await Confirm('Are you sure you wish to enter the Singularity?')
+
+        let confirmed = false;
+        if (!player.toggles[33]) {
+            confirmed = await Confirm(`Do you wish to start singularity #${format(player.singularityCount + 1)}? Your next universe is harder but gain ${format(calculateGoldenQuarkGain(), 2, true)} Golden Quarks.`)
+        } else {
+            await Alert('You have reached the end of the game, on singularity #' +format(player.singularityCount)+'. Platonic and the Ant God are proud of you.')
+            await Alert('You may choose to sit on your laurels, and consider the game \'beaten\', or you may do something more interesting.')
+            await Alert('You\'re too powerful for this current universe. The multiverse of Synergism is truly endless, but out there are even more challenging universes parallel to your very own.')
+            await Alert(`Start anew, and enter singularity #${format(player.singularityCount + 1)}. Your next universe is harder than your current one, but unlock a permanent +10% Quark Bonus, +10% Ascension Count Bonus, and Gain ${format(calculateGoldenQuarkGain(), 2, true)} golden quarks, which can purchase game-changing endgame upgrades [Boosted by ${format(player.worlds.BONUS)}% due to patreon bonus!].`)
+            await Alert('However, all your past accomplishments are gone! ALL Challenges, Refundable Shop upgrades, Upgrade Tab, Runes, All Cube upgrades, All Cube Openings, Hepteracts (Except for your Quark Hepteracts), Achievements will be wiped clean.')
+
+            confirmed = await Confirm('So, what do you say? Do you wish to enter the singularity?')
+            if (confirmed) {
+                confirmed = await Confirm('Are you sure you wish to enter the Singularity?')
+            }
+            if (confirmed) {
+                confirmed = await Confirm('Are you REALLY SURE? You cannot go back from this (without an older savefile)! Confirm one last time to finalize your decision.')
+            }
         }
-        if (c2) {
-            c3 = await Confirm('Are you REALLY SURE? You cannot go back from this (without an older savefile)! Confirm one last time to finalize your decision.')
-        }
-        if (c3) {
+
+        if (!confirmed) {
+            return Alert('If you decide to change your mind, let me know. -Ant God')
+        } else {
             await singularity();
             return Alert('Welcome to Singularity #' + format(player.singularityCount) + '. You\'re back to familiar territory, but something doesn\'t seem right.')
-        }
-        if (!c1 || !c2) {
-            return Alert('If you decide to change your mind, let me know. -Ant God')
         }
     }
 }

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -375,6 +375,11 @@ export const revealStuff = () => {
         (DOMCacheGetOrSet('singularitytab').style.display = 'block'):
         (DOMCacheGetOrSet('singularitytab').style.display = 'none');
 
+    // Singularity confirmation toggle pic
+    player.singularityCount > 0 && player.ascensionCount > 0 ?
+        (DOMCacheGetOrSet('settingpic6').style.display = 'block'):
+        (DOMCacheGetOrSet('settingpic6').style.display = 'none');
+
     if (player.singularityCount > 0) {
         (DOMCacheGetOrSet('shoptab').style.display = 'block');
     }
@@ -432,7 +437,8 @@ export const revealStuff = () => {
         'toggle29': player.transcendCount > 0.5 || player.reincarnationCount > 0.5,  // Settings - Confirmations - Transcension
         'toggle30': player.reincarnationCount > 0.5, // Settings - Confirmations - Reincarnation
         'toggle31': player.ascensionCount > 0, // Settings - Confirmations - Ascension
-        'toggle32': player.achievements[173] > 0 // Settings - Confirmations - Ant Sacrifice
+        'toggle32': player.achievements[173] > 0, // Settings - Confirmations - Ant Sacrifice
+        'toggle33': player.singularityCount > 0 && player.ascensionCount > 0 // Settings - Confirmations - Singularity
     }
 
     Object.keys(automationUnlocks).forEach(key => {


### PR DESCRIPTION
The new toggle appears when both singulartiyCount and ascensionCount are > 0 because when entering a new Sing, confirmations for Ascension and Ant Sac are hidden.
When the confirmation is OFF, clicking the Singularity button triggers only 1 Confirmation instead of 5 Alerts and 3 Confirmations when it's ON
![image](https://user-images.githubusercontent.com/9673110/174401224-fa12d0c7-ebcd-4121-bc67-dbfd860f6b52.png)
![image](https://user-images.githubusercontent.com/9673110/174401260-7df1d07f-d4ca-43ba-bcac-7894956a8c6c.png)
