### PR TITLE
Only display free levels of Sing upgrades when they are not 0

### DIFF
--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -85,10 +85,13 @@ export class SingularityUpgrade {
             ? `Minimum Singularity: ${this.minimumSingularity}`
             : 'No minimal Singularity to purchase required'
 
+        const freeLevelInfo = this.freeLevels > 0 ?
+            `<span style="color: orange"> [+${format(this.freeLevels, 1, true)}]</span>` : ''
+
         return `<span style="color: gold">${this.name}</span>
                 <span style="color: lightblue">${this.description}</span>
                 <span style="color: ${minReqColor}">${minimumSingularity}</span>
-                <span style="color: ${color}"> Level ${this.level}${maxLevel} <span style="color: orange"> [+${format(this.freeLevels, 1, true)}] </span> </span>
+                <span style="color: ${color}"> Level ${this.level}${maxLevel}${freeLevelInfo}</span>
                 <span style="color: gold">${this.getEffect().desc}</span>
                 Cost for next level: ${format(costNextLevel,0,true)} Golden Quarks.
                 Spent Quarks: ${format(this.goldenQuarksInvested, 0, true)}`


### PR DESCRIPTION
It's weird to display [+0,0] next to upgrades that will definitively never get free levels
Before
![image](https://user-images.githubusercontent.com/9673110/175539476-9b3fdd95-21ef-427e-88b9-85b458ff969c.png)
After
![image](https://user-images.githubusercontent.com/9673110/175539521-9824c632-b764-4aee-8205-d3f59fcdd8cd.png)
![image](https://user-images.githubusercontent.com/9673110/175539557-e72dc579-8b5e-4ac0-b311-41f9a08008b6.png)
