### PR TITLE
Improved event

### DIFF
--- a/index.html
+++ b/index.html
@@ -2829,7 +2829,7 @@
                 <label title="Use $VERSION$ for full version, $VER$ for version number,
 $TIME$ for 24h time, $TIME12$ for 12h,
 $YEAR$ or $Y$ for year, $MONTH$ or $M$ for month,
-$DAY$ or $D$ for year, $HOUR$ or $H$ for hour,
+$DAY$ or $D$ for day, $HOUR$ or $H$ for hour,
 $MINUTE$ or $MI$ for minute, $SECOND$ or $S$ for second,
 $PERIOD$ or $P$ for period, $WEEKDAY$ or $W$ for weekday,
 $DATE$ for date, $DATES$ for date seconds,
@@ -2842,7 +2842,7 @@ $GQ$ for golden quarks, $GQS$ for format golden quarks">
                 <p id="saveString" alt="saveString" label="saveString" class="tightText" title="Use $VERSION$ for full version, $VER$ for version number,
 $TIME$ for 24h time, $TIME12$ for 12h,
 $YEAR$ or $Y$ for year, $MONTH$ or $M$ for month,
-$DAY$ or $D$ for year, $HOUR$ or $H$ for hour,
+$DAY$ or $D$ for day, $HOUR$ or $H$ for hour,
 $MINUTE$ or $MI$ for minute, $SECOND$ or $S$ for second,
 $PERIOD$ or $P$ for period, $WEEKDAY$ or $W$ for weekday,
 $DATE$ for date, $DATES$ for date seconds,
@@ -2881,7 +2881,7 @@ $GQ$ for golden quarks, $GQS$ for format golden quarks"></p>
         <div id="versionnumber" alt="versionnumber" label="versionnumber">You're playing Synergism</div>
         <div id="event" alt="event" label="event" style="color: orchid">Event Status: <span id="eventCurrent" alt="eventCurrent" label="eventCurrent" style="color:orangered"></span></div>
         <div id="eventBuffs" alt="eventBuffs" label="eventBuffs" style="color: lime;">Buffs: </div>
-        <a href="https://www.youtube.com/watch?v=znxoba0k000" target="_blank" id="happyHolidays" alt="happyHolidays" label="happyHolidays" style="color: greenyellow"></a>
+        <a href="#" target="_blank" id="happyHolidays" alt="happyHolidays" label="happyHolidays" style="color: greenyellow"></a>
     </div>
     <div class="subtabContent" id="creditssubtab" alt="creditssubtab" label="creditssubtab">
         <h1>Coders</h1>
@@ -2982,6 +2982,7 @@ $GQ$ for golden quarks, $GQS$ for format golden quarks"></p>
             <p id="statOff26" alt="statOff26" label="statOff26" class="statPortion singularity">Offering Storm [GQ]: <span id="sOff26" alt="sOff26" label="sOff26" class="statNumber">0</span></p>
             <p id="statOff27" alt="statOff27" label="statOff27" class="statPortion singularity">Offering Tempest [GQ]: <span id="sOff27" alt="sOff27" label="sOff27" class="statNumber">0</span></p>
             <p id="statOff28" alt="statOff28" label="statOff28" class="statPortion singularity">Cube Upgrade Cx4: <span id="sOff28" alt="sOff28" label="sOff28" class="statNumber">0</span></p>
+            <p id="statOff29" alt="statOff29" label="statOff29" class="statPortion">Event: <span id="sOff29" alt="sOff29" label="sOff29" class="statNumber">0</span></p>
             <p id="statOffT" alt="statOffT" label="statOffT" class="statPortion statTotal" style='color: gold'>TOTAL OFFERING MULTIPLIER: <span id="sOffT" alt="sOffT" label="sOffT" class="statNumber statTotal">0</span></p>
         </div>
         <div id="globalQuarkMultiplierStats" alt="globalQuarkMultiplierStats" label="globalQuarkMultiplierStats" class="statContainer">

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1,4 +1,4 @@
-import { player, interval, clearInt, saveSynergy, format, resourceGain, updateAll } from './Synergism';
+import { player, interval, clearInt, saveSynergy, format, resourceGain, updateAll, loadingDate } from './Synergism';
 import { sumContents, productContents, getElementById } from './Utility';
 import { Globals as G } from './Variables';
 import { CalcECC } from './Challenges';
@@ -13,6 +13,7 @@ import { Alert, Prompt } from './UpdateHTML';
 import { quarkHandler } from './Quark';
 import { DOMCacheGetOrSet } from './Cache/DOM';
 import { calculateSingularityDebuff } from './singularity';
+import { calculateEventSourceBuff } from './Event';
 
 export const calculateTotalCoinOwned = () => {
     G['totalCoinOwned'] =
@@ -362,7 +363,8 @@ export function calculateOfferings(input: resetNames, calcMult = true, statistic
         +player.singularityUpgrades.singOfferings1.getEffect().bonus, // Offering Charge GQ Upgrade
         +player.singularityUpgrades.singOfferings2.getEffect().bonus, // Offering Storm GQ Upgrade
         +player.singularityUpgrades.singOfferings3.getEffect().bonus, // Offering Tempest GQ Upgrade
-        1 + player.cubeUpgrades[54] / 100 // Cube upgrade 6x4 (Cx4)
+        1 + player.cubeUpgrades[54] / 100, // Cube upgrade 6x4 (Cx4)
+        1 + calculateEventBuff('Offering') // Event
     ];
 
     if (calcMult) {
@@ -469,6 +471,7 @@ export const calculateObtainium = () => {
     G['obtainiumGain'] *= (1 + player.cubeUpgrades[55] / 100) // Cube Upgrade 6x5 (Cx5)
     G['obtainiumGain'] *= (1 + 1/200 * player.shopUpgrades.cashGrab2)
     G['obtainiumGain'] *= (1 + 1/100 * player.shopUpgrades.obtainiumEX2 * player.singularityCount)
+    G['obtainiumGain'] *= 1 + calculateEventBuff('Obtainium');
     if (player.currentChallenge.ascension === 15) {
         G['obtainiumGain'] += 1;
         G['obtainiumGain'] *= (1 + 7 * player.cubeUpgrades[62])
@@ -767,6 +770,7 @@ const calculateAntSacrificeMultipliers = () => {
     G['upgradeMultiplier'] *= (1 + 1 / 10 * player.upgrades[79]);
     G['upgradeMultiplier'] *= (1 + 0.09 * player.upgrades[40]);
     G['upgradeMultiplier'] *= G['cubeBonusMultiplier'][7];
+    G['upgradeMultiplier'] *= (1 + calculateEventBuff('Ant Sacrifice'));
 }
 
 interface IAntSacRewards {
@@ -1024,8 +1028,8 @@ export const calculateAllCubeMultiplier = () => {
         Math.pow(1.01, player.platonicUpgrades[15] * player.challengecompletions[9]),
         // Powder Bonus
         calculateCubeMultFromPowder(),
-        // Event (currently, +0%)
-        1,
+        // Event
+        1 + calculateEventBuff('Cubes'),
         // Singularity Factor
         1 / calculateSingularityDebuff('Cubes'),
         // Wow Pass Y
@@ -1229,7 +1233,7 @@ export const calculateHepteractMultiplier = (score = -1) => {
         // Achievement 265 Bonus [Max: 160T Asc]
         1 + Math.min(0.2, player.ascensionCount / 8e14) * player.achievements[265],
         // Achievement 270 Bonus
-        Math.min(2, (1 + 1/1_000_000 * Decimal.log(player.ascendShards.add(1), 10) * player.achievements[270]))
+        Math.min(2, (1 + 1/1000000 * Decimal.log(player.ascendShards.add(1), 10) * player.achievements[270]))
         // Total Hepteract Multipliers: 7
     ]
 
@@ -1296,7 +1300,7 @@ export const calculateTimeAcceleration = () => {
     }
     timeMult /= calculateSingularityDebuff('Global Speed');
     timeMult *= G['platonicBonusMultiplier'][7]
-    timeMult *= (1 + 2 * +G['isEvent'])
+    timeMult *= 1 + calculateEventBuff('Global Speed');
     timeMult *= 1 + (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0)
 
     if (player.usedCorruptions[3] >= 6 && player.achievements[241] < 1) {
@@ -1321,9 +1325,92 @@ export const calculateAscensionAcceleration = () => {
         G['challenge15Rewards'].ascensionSpeed,                                                         // C15
         1 + 1/400 * player.cubeUpgrades[59],                                                            // Cookie Upgrade 9
         1 + 0.5 * (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0),              // Intermediate Pack, Sing Shop
-        1 + 1/1000 * player.singularityCount * player.shopUpgrades.chronometerZ                         // Chronometer Z
+        1 + 1/1000 * player.singularityCount * player.shopUpgrades.chronometerZ,                        // Chronometer Z
+        1 + calculateEventBuff('Ascension Speed')                                                       // Event
     ]
     return productContents(arr) / calculateSingularityDebuff('Ascension Speed')
+}
+
+export const calculateQuarkMultiplier = () => {
+    let multiplier = 1;
+    if (player.achievementPoints > 0) { // Achievement Points
+        multiplier += player.achievementPoints / 25000; // Cap of +0.20 at 5,000 Pts
+    }
+    if (player.achievements[250] > 0) { // Max research 8x25
+        multiplier += 0.10;
+    }
+    if (player.achievements[251] > 0) { // Max Wow! Cube Upgrade 5x10
+        multiplier += 0.10;
+    }
+    if (player.platonicUpgrades[5] > 0) { // Platonic ALPHA upgrade
+        multiplier += 0.10;
+    }
+    if (player.platonicUpgrades[10] > 0) { // Platonic BETA Upgrade
+        multiplier += 0.15;
+    }
+    if (player.platonicUpgrades[15] > 0) { // Platonic OMEGA upgrade
+        multiplier += 0.20;
+    }
+    if (player.challenge15Exponent >= 1e11) { // Challenge 15: Exceed 1e11 exponent reward
+        multiplier += (G['challenge15Rewards'].quarks - 1);
+    }
+    if (player.shopUpgrades.infiniteAscent) { // Purchased Infinite Ascent Rune
+        multiplier *= (1.1 + 0.15 / 75 * calculateEffectiveIALevel());
+    }
+    if (player.challenge15Exponent >= 1e15) { // Challenge 15: Exceed 1e15 exponent reward
+        multiplier *= (1 + 5/10000 * hepteractEffective('quark'));
+    }
+    if (player.overfluxPowder > 0) { // Overflux Powder [Max: 10% at 10,000]
+        multiplier *= calculateQuarkMultFromPowder();
+    }
+    if (player.achievements[266] > 0) { // Achievement 266 [Max: 10% at 1Qa Ascensions]
+        multiplier *= (1 + Math.min(0.1, (player.ascensionCount) / 1e16))
+    }
+    if (player.singularityCount > 0) { // Singularity Modifier
+        multiplier *= (1 + player.singularityCount / 10)
+    }
+    if (G['isEvent']) {
+        multiplier *= 1 + calculateEventBuff('Quarks');
+    }
+    if (player.cubeUpgrades[53] > 0) { // Cube Upgrade 6x3 (Cx3)
+        multiplier *= (1 + 0.10 * player.cubeUpgrades[53] / 100)
+    }
+    if (player.cubeUpgrades[68] > 0) { // Cube Upgrade 7x8
+        multiplier *= (1 + 1/10000 * player.cubeUpgrades[68] + 0.05 * (Math.floor(player.cubeUpgrades[68] / 1000)))
+    }
+    if (player.singularityCount >= 5) { // Singularity Milestone (5 sing)
+        multiplier *= 1.05
+    }
+    if (player.singularityCount >= 20) { // Singularity Milestone (20 sing)
+        multiplier *= 1.05
+    }
+    multiplier *= (1 + 0.02 * player.singularityUpgrades.intermediatePack.level +               // 1.02
+                           0.04 * player.singularityUpgrades.advancedPack.level +               // 1.06
+                           0.06 * player.singularityUpgrades.expertPack.level +                 // 1.12
+                           0.08 * player.singularityUpgrades.masterPack.level +                 // 1.20
+                           0.10 * player.singularityUpgrades.expertPack.level)                  // 1.30
+    return multiplier
+}
+
+/**
+ *
+ * Calculate the number of Golden Quarks earned in current singularity
+ */
+export const calculateGoldenQuarkGain = ():number => {
+    const base = 2 * player.singularityCount + 10
+    const bonus = (player.singularityCount < 10) ? (100 - 10 * player.singularityCount) : 0;
+    const gainFromQuarks = player.quarksThisSingularity / 1e5;
+
+    const allGoldenQuarkMultiplier = productContents([
+        1 + Math.max(0, Math.log10(player.challenge15Exponent + 1) - 20) / 2,
+        1 + player.worlds.BONUS / 100,
+        (+player.singularityUpgrades.goldenQuarks1.getEffect().bonus) *
+        (+player.singularityUpgrades.goldenQuarks2.getEffect().bonus),
+        1 + 0.12 * player.cubeUpgrades[69],
+        1 + calculateEventBuff('Golden Quarks')
+    ]);
+
+    return (base + gainFromQuarks) * allGoldenQuarkMultiplier + bonus;
 }
 
 export const calculateCorruptionPoints = () => {
@@ -1488,6 +1575,9 @@ export const computeAscensionScoreBonusMultiplier = () => {
     if (player.achievements[259] > 0) {
         multiplier *= Math.max(1, Math.pow(1.01, Math.log2(player.hepteractCrafts.abyss.CAP)));
     }
+    if (G['isEvent']) {
+        multiplier *= 1 + calculateEventBuff('Ascension Score');
+    }
 
     return multiplier
 }
@@ -1641,7 +1731,7 @@ export const calculatePowderConversion = () => {
         (1 + player.achievements[256] / 20), // Achievement 256, 5%
         (1 + player.achievements[257] / 20), // Achievement 257, 5%
         1 + 0.01 * player.platonicUpgrades[16], // Platonic Upgrade 4x1
-        1 + .1337 * +G['isEvent'] // Event!
+        1 + calculateEventBuff('Powder Conversion') // Event
     ]
 
     return {
@@ -1675,30 +1765,22 @@ export const calculateQuarkMultFromPowder = () => {
 }
 
 export const dailyResetCheck = () => {
-    player.dayCheck ||= new Date();
-    if (typeof player.dayCheck === 'string') {
-        player.dayCheck = new Date(player.dayCheck);
+    if (!player.dayCheck) {
+        return;
     }
-
-    const d = new Date()
-    const h = d.getHours()
-    const m = d.getMinutes()
-    const s = d.getSeconds()
+    const now = new Date(loadingDate.getTime() + performance.now());
+    const day = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const h = now.getHours()
+    const m = now.getMinutes()
+    const s = now.getSeconds()
     player.dayTimer = (60 * 60 * 24) - (60 * 60 * h) - (60 * m) - s;
 
-    if (d.getDate() !== player.dayCheck.getDate() || d.getMonth() !== player.dayCheck.getMonth() || d.getFullYear() !== player.dayCheck.getFullYear()) {
-        player.dayCheck = new Date();
-        player.cubeQuarkDaily = 0;
-        player.tesseractQuarkDaily = 0;
-        player.hypercubeQuarkDaily = 0;
-        player.platonicCubeQuarkDaily = 0;
-        player.cubeOpenedDaily = 0;
-        player.tesseractOpenedDaily = 0;
-        player.hypercubeOpenedDaily = 0;
-        player.platonicCubeOpenedDaily = 0;
+    // Daily is not reset even if it is set to a past time.
+    // If the daily is not reset, the data may have been set to a future time.
+    if (day.getTime() - 3600000 > player.dayCheck.getTime()) {
+        player.dayCheck = new Date(day);
 
-        player.overfluxPowder += player.overfluxOrbs * calculatePowderConversion().mult;
-        player.overfluxOrbs = G['challenge15Rewards'].freeOrbs
+        forcedDailyReset(true);
         player.dailyPowderResetUses = 1;
         player.dailyCodeUsed = false;
 
@@ -1718,8 +1800,7 @@ export const dailyResetCheck = () => {
 /**
  * Resets Cube Counts and stuff. NOTE: It is intentional it does not award powder or expire orbs.
  */
-export const forcedDailyReset = (testing = false) => {
-    player.dayCheck = new Date();
+export const forcedDailyReset = (rewards = false) => {
     player.cubeQuarkDaily = 0;
     player.tesseractQuarkDaily = 0;
     player.hypercubeQuarkDaily = 0;
@@ -1729,32 +1810,15 @@ export const forcedDailyReset = (testing = false) => {
     player.hypercubeOpenedDaily = 0;
     player.platonicCubeOpenedDaily = 0;
 
-    if (testing) {
+    if (rewards) {
         player.overfluxPowder += player.overfluxOrbs * calculatePowderConversion().mult;
-        player.overfluxOrbs = 0;
+        player.overfluxOrbs = G['challenge15Rewards'].freeOrbs;
     }
 }
 
-const eventStart = '06/05/2022 00:00:00'
-const eventEnd = '06/12/2022 23:59:59'
-
-// current event: NONE
-
-export const eventCheck = () => {
-    const start = new Date(eventStart);
-    const end = new Date(eventEnd);
-    const now = new Date();
-
-    if (now.getTime() >= start.getTime() && now.getTime() <= end.getTime()){
-        G['isEvent'] = true
-        DOMCacheGetOrSet('eventCurrent').textContent = 'ACTIVE UNTIL ' + end
-        DOMCacheGetOrSet('eventBuffs').textContent = 'Current Buffs: +125% Quarks from all sources, +13.37% Powder Conversion, +200% Time Acceleration!'
-        DOMCacheGetOrSet('happyHolidays').innerHTML = '&#128151 2.9.7 Event! &#128151;'
-    } else {
-        G['isEvent'] = false
-        DOMCacheGetOrSet('eventCurrent').textContent = 'INACTIVE'
-        DOMCacheGetOrSet('eventBuffs').textContent = ''
-        DOMCacheGetOrSet('happyHolidays').innerHTML = ''
+export const calculateEventBuff = (buff: string) => {
+    if (!G['isEvent']) {
+        return 0;
     }
-
+    return calculateEventSourceBuff(buff);
 }

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1778,7 +1778,7 @@ export const dailyResetCheck = () => {
     // Daily is not reset even if it is set to a past time.
     // If the daily is not reset, the data may have been set to a future time.
     if (day.getTime() - 3600000 > player.dayCheck.getTime()) {
-        player.dayCheck = new Date(day);
+        player.dayCheck = day;
 
         forcedDailyReset(true);
         player.dailyPowderResetUses = 1;

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,0 +1,286 @@
+import { player, loadingDate } from './Synergism'
+import { Globals as G } from './Variables';
+import { DOMCacheGetOrSet } from './Cache/DOM';
+
+interface HolidayData {
+    name: string
+    color: string
+    url: string
+    everyYear: boolean
+    start: string
+    end: string
+    notice: number
+    event: boolean
+    buffs: {
+        quark?: number
+        goldenQuark?: number
+        cubes?: number
+        powderConversion?: number
+        ascensionSpeed?: number
+        globalSpeed?: number
+        ascensionScore?: number
+        antSacrifice?: number
+        offering?: number
+        obtainium?: number
+    }
+}
+
+// Editing the event is here
+// can change the basic game balance by setting default to event: true, but cannot stack events
+const events: Record<string, HolidayData> = {
+    default: {
+        name: 'Game Modified',
+        color: 'white',
+        url: '',
+        everyYear: true,
+        start: '1/1/2001 00:00:00',
+        end: '12/31/2099 23:59:59',
+        notice: 0,
+        event: false,
+        buffs: {
+            quark: -0.2,
+            goldenQuark: 0,
+            cubes: 0,
+            powderConversion: 0,
+            ascensionSpeed: 0,
+            globalSpeed: 0,
+            ascensionScore: 0,
+            antSacrifice: 0,
+            offering: 0,
+            obtainium: 0
+        }
+    },
+    // Last active event
+    last: {
+        name: '&#128151 2.9.7 Event! &#128151;',
+        color: 'greenyellow',
+        url: 'https://www.youtube.com/watch?v=znxoba0k000',
+        everyYear: false,
+        start: '06/05/2022 00:00:00',
+        end: '06/12/2022 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1.25,
+            powderConversion: 0.1337,
+            globalSpeed: 2
+        }
+    }
+    // Event example
+    /*
+    newyear: {
+        name: '&#127881; New Year Event! &#127881;',
+        color: 'yellow',
+        url: '',
+        everyYear: true,
+        start: '12/31/2001 00:00:00',
+        end: '01/02/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            ascensionSpeed: 2,
+            globalSpeed: 2
+        }
+    },
+    spring: {
+        name: '&#127800; Spring Event! &#127800;',
+        color: 'pink',
+        url: '',
+        everyYear: true,
+        start: '04/01/2001 00:00:00',
+        end: '04/02/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            ascensionScore: 0.5,
+            antSacrifice: 1
+        }
+    },
+    summer: {
+        name: '&#9728 Summer Event! &#9728',
+        color: 'lightgoldenrodyellow',
+        url: '',
+        everyYear: true,
+        start: '07/01/2001 00:00:00',
+        end: '07/02/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            ascensionSpeed: 1,
+            obtainium: 2
+        }
+    },
+    autumn: {
+        name: '&#127810; Autumn Event! &#127810;',
+        color: 'tomato',
+        url: '',
+        everyYear: true,
+        start: '10/01/2001 00:00:00',
+        end: '10/02/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            cubes: 1,
+            offering: 2
+        }
+    },
+    winter: {
+        name: '&#10052 Winter Event! &#10052',
+        color: 'lightblue',
+        url: '',
+        everyYear: true,
+        start: '02/01/2001 00:00:00',
+        end: '02/02/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            powderConversion: 2,
+            globalSpeed: 2
+        }
+    },
+    birthday: {
+        name: '&#127874; Synergism Birthday! &#127874;',
+        color: 'white',
+        url: '',
+        everyYear: true,
+        start: '01/05/2001 00:00:00',
+        end: '01/05/2001 23:59:59',
+        notice: 3,
+        event: true,
+        buffs: {
+            quark: 1,
+            goldenQuark: 1,
+            cubes: 1,
+            powderConversion: 1,
+            ascensionSpeed: 1,
+            globalSpeed: 1,
+            ascensionScore: 1,
+            antSacrifice: 1,
+            offering: 1,
+            obtainium: 1
+        }
+    }
+    */
+}
+
+let nowEvent = events.default;
+
+export const getEvent = (): HolidayData => {
+    return nowEvent;
+}
+
+export const eventCheck = () => {
+    if (!player.dayCheck) {
+        return;
+    }
+    const now = new Date(loadingDate.getTime() + performance.now());
+    let start: Date;
+    let end: Date;
+
+    // Disable the event if there is any fraud, such as setting a device clock in the past
+    nowEvent = events.default;
+    if (now.getTime() >= player.dayCheck.getTime() && now.getTime() > loadingDate.getTime()) {
+        // Update currently valid events
+        for (const e in events) {
+            const event = events[e];
+            if (event.name !== 'default' && event.event === true) {
+                start = new Date(event.start);
+                end = new Date(event.end);
+                if (event.everyYear === true) {
+                    const nowFullYear = now.getFullYear();
+                    start = new Date(event.start);
+                    end = new Date(event.end);
+                    start.setFullYear(nowFullYear);
+                    end.setFullYear(nowFullYear);
+                    if (start.getTime() > end.getTime()) {
+                        end.setFullYear(nowFullYear + 1);
+                    }
+                    if (now.getTime() >= start.getTime() - 31536000000 && now.getTime() <= end.getTime() - 31536000000) {
+                        start.setFullYear(start.getFullYear() - 1);
+                        end.setFullYear(end.getFullYear() - 1);
+                    }
+                    if (now.getTime() >= end.getTime() + 86400000) {
+                        continue;
+                    }
+                } else if (now.getTime() >= end.getTime() + 86400000) {
+                    continue;
+                }
+                if (now.getTime() >= start.getTime() - event.notice * 86400000 && now.getTime() <= end.getTime()) {
+                    nowEvent = event;
+                    if (now.getTime() >= start.getTime() && now.getTime() <= end.getTime()) {
+                        break;
+                    }
+                }
+            }
+        }
+    }
+    const happyHolidays = DOMCacheGetOrSet('happyHolidays') as HTMLAnchorElement;
+    const eventBuffs = DOMCacheGetOrSet('eventBuffs');
+    if (nowEvent.event === true) {
+        start = new Date(nowEvent.start);
+        end = new Date(nowEvent.end);
+        if (nowEvent.everyYear === true) {
+            const nowFullYear = now.getFullYear();
+            start.setFullYear(nowFullYear);
+            end.setFullYear(nowFullYear);
+            if (start.getTime() > end.getTime()) {
+                end.setFullYear(nowFullYear + 1);
+            }
+            if (now.getTime() >= start.getTime() - 31536000000 && now.getTime() <= end.getTime() - 31536000000) {
+                start.setFullYear(start.getFullYear() - 1);
+                end.setFullYear(end.getFullYear() - 1);
+            }
+        }
+        G['isEvent'] = now.getTime() >= start.getTime() && now.getTime() <= end.getTime();
+        let buffs = '';
+        for (let i = 0; i < eventBuffType.length; i++) {
+            const eventBuff = calculateEventSourceBuff(eventBuffType[i]);
+            if (eventBuff !== 0) {
+                buffs += `${eventBuff >= 0 ? '+' : '-'}${Math.round(Math.abs(eventBuff) * 100)}% ${eventBuffName[i]}, `;
+            }
+        }
+        if (buffs.length > 2) {
+            buffs = buffs.substring(0, buffs.length - 2);
+            buffs += '!';
+        }
+        DOMCacheGetOrSet('eventCurrent').textContent = G['isEvent'] ? 'ACTIVE UNTIL ' + end : 'START UNTIL ' + start;
+        eventBuffs.textContent = G['isEvent'] ? 'Current Buffs: ' + buffs : '';
+        eventBuffs.style.color = 'lime';
+        happyHolidays.innerHTML = nowEvent.name;
+        happyHolidays.style.color = nowEvent.color;
+        happyHolidays.href = nowEvent.url.length > 0 && G['isEvent'] ? nowEvent.url : '#';
+    } else {
+        G['isEvent'] = false;
+        DOMCacheGetOrSet('eventCurrent').textContent = 'INACTIVE';
+        eventBuffs.textContent = now.getTime() >= player.dayCheck.getTime() ? '' :
+            `You have set a date operation that is a prohibited act. To receive events and daily rewards, you need to proceed to ${player.dayCheck} or import normal save data.`;
+        eventBuffs.style.color = 'red';
+        happyHolidays.innerHTML = '';
+        happyHolidays.href = '';
+    }
+}
+
+const eventBuffType = ['Quarks', 'Golden Quarks', 'Cubes', 'Powder Conversion', 'Ascension Speed', 'Global Speed', 'Ascension Score', 'Ant Sacrifice', 'Offering', 'Obtainium'];
+const eventBuffName = ['Quarks', 'Golden Quarks', 'Cubes from all type', 'Powder Conversion', 'Ascension Speed', 'Global Speed', 'Ascension Score', 'Ant Sacrifice rewards', 'Offerings', 'Obtainiums'];
+
+export const calculateEventSourceBuff = (buff: string): number => {
+    const event = getEvent();
+    switch (buff) {
+        case 'Quarks': return event.buffs.quark || 0;
+        case 'Golden Quarks': return event.buffs.goldenQuark || 0;
+        case 'Cubes': return event.buffs.cubes || 0;
+        case 'Powder Conversion': return event.buffs.powderConversion || 0;
+        case 'Ascension Speed': return event.buffs.ascensionSpeed || 0;
+        case 'Global Speed': return event.buffs.globalSpeed || 0;
+        case 'Ascension Score': return event.buffs.ascensionScore || 0;
+        case 'Ant Sacrifice': return event.buffs.antSacrifice || 0;
+        case 'Offering': return event.buffs.offering || 0;
+        case 'Obtainium': return event.buffs.obtainium || 0;
+        default: return 0;
+    }
+}

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -16,6 +16,7 @@ import localforage from 'localforage';
 import { Globals as G } from './Variables';
 import { calculateAscensionAcceleration, calculateAscensionScore } from './Calculate';
 import { singularityData } from './singularity';
+import { getEvent } from './Event';
 
 const format24 = new Intl.DateTimeFormat('EN-GB', {
     year: 'numeric',
@@ -263,7 +264,7 @@ export const promocodes = async (input: string | null) => {
     if (input === null) {
         return Alert('Alright, come back soon!')
     }
-    if (input === '2.9.7' && !player.codes.get(40) && G['isEvent']) {
+    if (input === '2.9.7' && !player.codes.get(40) && G['isEvent'] && getEvent().name === '&#128151 2.9.7 Event! &#128151;') {
         player.codes.set(40, true);
         player.quarkstimer = quarkHandler().maxTime;
         player.goldenQuarksTimer = 3600 * 168;

--- a/src/Quark.ts
+++ b/src/Quark.ts
@@ -1,10 +1,8 @@
 /* Functions which Handle Quark Gains,  */
 
-import { calculateCubeQuarkMultiplier, calculateEffectiveIALevel, calculateQuarkMultFromPowder} from './Calculate';
-import { hepteractEffective } from './Hepteracts'
+import { calculateCubeQuarkMultiplier, calculateQuarkMultiplier} from './Calculate';
 import { format, player } from './Synergism'
 import { Alert } from './UpdateHTML';
-import { Globals as G } from './Variables'
 import { DOMCacheGetOrSet } from './Cache/DOM';
 
 const getBonus = async (): Promise<null | number> => {
@@ -42,67 +40,6 @@ const getBonus = async (): Promise<null | number> => {
     }
 
     return null;
-}
-
-export const getQuarkMultiplier = () => {
-    let multiplier = 1;
-    if (player.achievementPoints > 0) { // Achievement Points
-        multiplier += player.achievementPoints / 25000; // Cap of +0.20 at 5,000 Pts
-    }
-    if (player.achievements[250] > 0) { // Max research 8x25
-        multiplier += 0.10;
-    }
-    if (player.achievements[251] > 0) { // Max Wow! Cube Upgrade 5x10
-        multiplier += 0.10;
-    }
-    if (player.platonicUpgrades[5] > 0) { // Platonic ALPHA upgrade
-        multiplier += 0.10;
-    }
-    if (player.platonicUpgrades[10] > 0) { // Platonic BETA Upgrade
-        multiplier += 0.15;
-    }
-    if (player.platonicUpgrades[15] > 0) { // Platonic OMEGA upgrade
-        multiplier += 0.20;
-    }
-    if (player.challenge15Exponent >= 1e11) { // Challenge 15: Exceed 1e11 exponent reward
-        multiplier += (G['challenge15Rewards'].quarks - 1);
-    }
-    if (player.shopUpgrades.infiniteAscent) { // Purchased Infinite Ascent Rune
-        multiplier *= (1.1 + 0.15 / 75 * calculateEffectiveIALevel());
-    }
-    if (player.challenge15Exponent >= 1e15) { // Challenge 15: Exceed 1e15 exponent reward
-        multiplier *= (1 + 5/10000 * hepteractEffective('quark'));
-    }
-    if (player.overfluxPowder > 0) { // Overflux Powder [Max: 10% at 10,000]
-        multiplier *= calculateQuarkMultFromPowder();
-    }
-    if (player.achievements[266] > 0) { // Achievement 266 [Max: 10% at 1Qa Ascensions]
-        multiplier *= (1 + Math.min(0.1, (player.ascensionCount) / 1e16))
-    }
-    if (player.singularityCount > 0) { // Singularity Modifier
-        multiplier *= (1 + player.singularityCount / 10)
-    }
-    if (G['isEvent']) {
-        multiplier *= 2.25; // Jun06-Jun13
-    }
-    if (player.cubeUpgrades[53] > 0) { // Cube Upgrade 6x3 (Cx3)
-        multiplier *= (1 + 0.10 * player.cubeUpgrades[53] / 100)
-    }
-    if (player.cubeUpgrades[68] > 0) { // Cube Upgrade 7x8
-        multiplier *= (1 + 1/10000 * player.cubeUpgrades[68] + 0.05 * (Math.floor(player.cubeUpgrades[68] / 1000)))
-    }
-    if (player.singularityCount >= 5) { // Singularity Milestone (5 sing)
-        multiplier *= 1.05
-    }
-    if (player.singularityCount >= 20) { // Singularity Milestone (20 sing)
-        multiplier *= 1.05
-    }
-    multiplier *= (1 + 0.02 * player.singularityUpgrades.intermediatePack.level +           // 1.02
-                           0.04 * player.singularityUpgrades.advancedPack.level +               // 1.06
-                           0.06 * player.singularityUpgrades.expertPack.level +                 // 1.12
-                           0.08 * player.singularityUpgrades.masterPack.level +                 // 1.20
-                           0.10 * player.singularityUpgrades.expertPack.level)                  // 1.30
-    return multiplier
 }
 
 export const quarkHandler = () => {
@@ -163,7 +100,7 @@ export class QuarkHandler {
 
     /*** Calculates the number of quarks to give with the current bonus. */
     applyBonus(amount: number) {
-        const nonPatreon = getQuarkMultiplier();
+        const nonPatreon = calculateQuarkMultiplier();
         return amount * (1 + (this.BONUS / 100)) * nonPatreon;
     }
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -2,8 +2,7 @@ import { player, clearInt, interval, format, blankSave } from './Synergism';
 import {
     calculateOfferings, CalcCorruptionStuff, calculateCubeBlessings, calculateRuneLevels,
     calculateAnts, calculateObtainium, calculateTalismanEffects, calculateAntSacrificeELO,
-    calcAscensionCount
-} from './Calculate';
+    calcAscensionCount, calculateGoldenQuarkGain} from './Calculate';
 import { resetofferings } from './Runes';
 import { updateTalismanInventory, updateTalismanAppearance } from './Talismans';
 import { calculateTesseractBlessings } from './Tesseracts';
@@ -707,25 +706,6 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
 
 /**
  *
- * Calculate the number of Golden Quarks earned in current singularity
- */
-export const calculateGoldenQuarkGain = ():number => {
-    const base = 2 * player.singularityCount + 10
-    const bonus = (player.singularityCount < 10) ? (100 - 10 * player.singularityCount) : 0;
-    const gainFromQuarks = player.quarksThisSingularity / 1e5;
-    const c15Multiplier = 1 + Math.max(0, Math.log10(player.challenge15Exponent + 1) - 20) / 2
-    const patreonMultiplier = 1 + player.worlds.BONUS/100;
-
-    const singularityUpgrades = (+player.singularityUpgrades.goldenQuarks1.getEffect().bonus) *
-                                (+player.singularityUpgrades.goldenQuarks2.getEffect().bonus)
-
-    const cookieUpgradeMultiplier = 1 + 0.12 * player.cubeUpgrades[69];
-
-    return (base + gainFromQuarks) * c15Multiplier * patreonMultiplier * singularityUpgrades * cookieUpgradeMultiplier + bonus;
-}
-
-/**
- *
  * Computes which achievements in 274-280 are achievable given current singularity number
  */
 export const updateSingularityAchievements = (): void => {
@@ -951,10 +931,16 @@ export const singularity = async (): Promise<void> => {
     hold.autoAntSacrifice = player.autoAntSacrifice
     hold.autoAntSacrificeMode = player.autoAntSacrificeMode
     hold.autoAntSacTimer = player.autoAntSacTimer
+    hold.autoAscend = player.autoAscend
+    hold.autoAscendMode = player.autoAscendMode
+    hold.autoAscendThreshold = player.autoAscendThreshold
     hold.autoResearch = 0
     hold.autoTesseracts = player.autoTesseracts
     hold.tesseractAutoBuyerToggle = player.tesseractAutoBuyerToggle
+    hold.tesseractAutoBuyerAmount = player.tesseractAutoBuyerAmount
     hold.historyShowPerSecond = player.historyShowPerSecond
+    hold.dayTimer = player.dayTimer
+    hold.dayCheck = player.dayCheck
     hold.shopBuyMaxToggle = player.shopBuyMaxToggle
     hold.shopConfirmationToggle = player.shopConfirmationToggle
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -939,8 +939,11 @@ export const singularity = async (): Promise<void> => {
     hold.tesseractAutoBuyerToggle = player.tesseractAutoBuyerToggle
     hold.tesseractAutoBuyerAmount = player.tesseractAutoBuyerAmount
     hold.historyShowPerSecond = player.historyShowPerSecond
+    hold.exporttest = player.exporttest
     hold.dayTimer = player.dayTimer
     hold.dayCheck = player.dayCheck
+    hold.ascStatToggles = player.ascStatToggles
+    hold.hepteractAutoCraftPercentage = player.hepteractAutoCraftPercentage
     hold.shopBuyMaxToggle = player.shopBuyMaxToggle
     hold.shopConfirmationToggle = player.shopConfirmationToggle
 

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -1,8 +1,7 @@
 import { player, format } from './Synergism';
 import { Globals as G } from './Variables';
-import { getQuarkMultiplier} from './Quark';
 import { hepteractEffective } from './Hepteracts'
-import { calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier } from './Calculate';
+import {calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier, calculateQuarkMultiplier, calculateEventBuff } from './Calculate';
 import { challenge15ScoreMultiplier } from './Challenges';
 import type { GlobalVariables } from './types/Synergism';
 import { DOMCacheGetOrSet } from './Cache/DOM';
@@ -76,8 +75,8 @@ export const loadQuarkMultiplier = () => {
     DOMCacheGetOrSet('sGQM6').textContent = '+' + format(player.platonicUpgrades[10] > 0 ? 0.15 : 0, 3, true) //BETA
     DOMCacheGetOrSet('sGQM7').textContent = '+' + format(player.platonicUpgrades[15] > 0 ? 0.20 : 0, 3, true) //OMEGA
     DOMCacheGetOrSet('sGQM8').textContent = '+' + format(G.challenge15Rewards['quarks']-1, 3, true) //Challenge 15 Reward
-    DOMCacheGetOrSet('sGQM9').textContent = 'x' + format(player.worlds.applyBonus(1 / getQuarkMultiplier()), 3, true) //Patreon Bonus
-    DOMCacheGetOrSet('sGQM10').textContent = 'x' + format((G['isEvent'] ? 2.25 : 1), 3, true) //Event
+    DOMCacheGetOrSet('sGQM9').textContent = 'x' + format(player.worlds.applyBonus(1 / calculateQuarkMultiplier()), 3, true) //Patreon Bonus
+    DOMCacheGetOrSet('sGQM10').textContent = 'x' + format((G['isEvent'] ? 1 + calculateEventBuff('Quarks') : 1), 3, true) //Event
     DOMCacheGetOrSet('sGQM11').textContent = 'x' + format(1.1 + 0.15 / 75 * calculateEffectiveIALevel(), 3, true) //IA Rune
     DOMCacheGetOrSet('sGQM12').textContent = 'x' + format(player.challenge15Exponent >= 1e15 ? 1 + 5/10000 * hepteractEffective('quark') : 1, 3, true) //Quark Hepteract
     DOMCacheGetOrSet('sGQM13').textContent = 'x' + format(calculateQuarkMultFromPowder(), 3, true) //Powder
@@ -106,16 +105,16 @@ export const loadStatisticsCubeMultipliers = () => {
         6: {acc: 2, desc: 'Platonic Beta:'},
         7: {acc: 2, desc: 'Platonic Omega:'},
         8: {acc: 2, desc: 'Overflux Powder:'},
-        9: {acc: 2, desc: 'Event [Most Recent: June 28 - July 01]'},
+        9: {acc: 2, desc: 'Event:'},
         10: {acc: 2, desc: 'Singularity Factor:'},
         11: {acc: 2, desc: 'Wow Pass Y'},
         12: {acc: 2, desc: 'Starter Pack:'},
         13: {acc: 2, desc: 'Cube Flame [GQ]:'},
         14: {acc: 2, desc: 'Cube Blaze [GQ]:'},
         15: {acc: 2, desc: 'Cube Inferno [GQ]:'},
-        16: {acc: 2, desc: 'Wow Pass Z'},
-        17: {acc: 2, desc: 'Cookie Upgrade 16'},
-        18: {acc: 2, desc: 'Cookie Upgrade 8'}
+        16: {acc: 2, desc: 'Wow Pass Z:'},
+        17: {acc: 2, desc: 'Cookie Upgrade 16:'},
+        18: {acc: 2, desc: 'Cookie Upgrade 8:'}
     }
     for (let i = 0; i < arr0.length; i++) {
         const statGCMi = DOMCacheGetOrSet(`statGCM${i + 1}`);
@@ -287,7 +286,8 @@ export const loadStatisticsOfferingMultipliers = () => {
         25: {acc: 3, desc: 'Offering Charge [GQ]:'},
         26: {acc: 3, desc: 'Offering Storm [GQ]:'},
         27: {acc: 3, desc: 'Offering Tempest [GQ]:'},
-        28: {acc: 3, desc: 'Cube Upgrade Cx4'}
+        28: {acc: 3, desc: 'Cube Upgrade Cx4:'},
+        29: {acc: 3, desc: 'Event:'}
     }
     for (let i = 0; i < arr.length; i++) {
         const statOffi = DOMCacheGetOrSet(`statOff${i + 1}`);
@@ -305,8 +305,8 @@ export const loadPowderMultiplier = () => {
         3: {acc: 2, desc: 'Powder EX:'},
         4: {acc: 2, desc: 'Achievement 256:'},
         5: {acc: 2, desc: 'Achievement 257:'},
-        6: {acc: 2, desc: 'Platonic Upgrade 16 [4x1]'},
-        7: {acc: 2, desc: 'Event [Most Recent: June 6 - June 13 2022]:'}
+        6: {acc: 2, desc: 'Platonic Upgrade 16 [4x1]:'},
+        7: {acc: 2, desc: 'Event:'}
     }
     for (let i = 0; i < arr0.length; i++) {
         const statGCMi = DOMCacheGetOrSet(`statPoM${i + 1}`);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1236,13 +1236,11 @@ const loadSynergy = async () => {
 
 
         if (player.saveString === '' || player.saveString === 'Synergism-v1011Test.txt') {
-            player.singularityCount === 0 ?
-                player.saveString = 'Synergism-$VERSION$-$TIME$.txt':
-                player.saveString = 'Synergism-$VERSION$-$TIME$-$SING$.txt'
+            player.saveString = player.singularityCount === 0 ?
+                'Synergism-$VERSION$-$TIME$.txt' :
+                'Synergism-$VERSION$-$TIME$-$SING$.txt'
         }
         (DOMCacheGetOrSet('saveStringInput') as HTMLInputElement).value = player.saveString;
-
-        player.wowCubes = new WowCubes(Number(player.wowCubes) || 0);
 
         for (let j = 1; j < 126; j++) {
             upgradeupdate(j);


### PR DESCRIPTION
I created a dedicated file to make it easier to edit the event.
Can now set and execute multiple events.
The settings for the events that actually work are commented out, but enabling them should be discussed.
Can now set up an annual event. Can use it for the season and birthday.
Can notify the user of the time of the event. It is usually set 3 days in advance.
Added event buff types.
Changing the time during the game no longer affects the time of the event.
Can no longer start an event older than the date confirmed the daily.
Added one stats offering. Fixed a part of the page.

If it is set to a time earlier than the date of the last daily reward, will no longer receive daily rewards and events.
If the daily rewards and events do not occur, the data may have been set to a future time. This status can be confirmed by the message written on the setting.
The Daily Check Timer does not set the game update date or the time past 06/01/2022.
The Daily Check timer is no longer reset in Singularity.
The text has been hidden when the game update time is displayed as NaN.

Moved two compute functions to Calculate.ts.
Added the setting inherited by Singularity.

It is possible to protect the save data from the time change exploit.
We have debugged and verified the time for a week, but we cannot guarantee that there will be no problems.
But if don't take action, daily rewards and events will have unlimited access.
We accept discussions.