### PR TITLE
Roomba Post Sing fix

### DIFF
--- a/src/Research.ts
+++ b/src/Research.ts
@@ -30,7 +30,7 @@ export const updateAutoResearch = (index: number, auto: boolean) => {
         }
 
         // Checks against researches invalid or not unlocked.
-        while (!isResearchUnlocked(player.autoResearch) && player.autoResearch < 200 && player.autoResearch >= 1) {
+        while (!isResearchUnlocked(player.autoResearch) && player.autoResearch < 200 && player.autoResearch >= 76) {
             player.roombaResearchIndex += 1;
             player.autoResearch = G['researchOrderByCost'][player.roombaResearchIndex];
         }


### PR DESCRIPTION
Ignoring the unlock check for the first 75 should avoid roomba from breaking right after sing, without causing side effects to the rest of the game.