### PR TITLE
Load corruptions from Reset history

### DIFF
--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -273,7 +273,15 @@ export const corruptionLoadoutSaveLoad = (save = true, loadout = 1) => {
         } else {
             player.prototypeCorruptions = Array.from(player.corruptionLoadouts[loadout])
         }
-        corruptionLoadoutTableUpdate()
+        corruptionLoadoutTableUpdate();
+        corruptionStatsUpdate();
+    }
+}
+
+export const applyCorruptions = (corruptions: string) => {
+    if (corruptions && corruptions.indexOf('/') > -1 && corruptions.split('/').length === 13) {
+        // Converts the '/' separated string into a number[]
+        player.prototypeCorruptions = corruptions.split('/').map(x => +x);
         corruptionStatsUpdate();
     }
 }

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3583,10 +3583,10 @@ document.addEventListener('keydown', (event) => {
         }
         if (player.challengecompletions[11] > 0 && !isNaN(num)) {
             if (num >= 0 && num < player.corruptionLoadoutNames.length) {
-                void Notification(`${player.corruptionLoadoutNames[num]} (${num + 1}) used activation. This will take effect on the next ascension.`, 5000);
+                void Notification(`Corruption Loadout ${num + 1} "${player.corruptionLoadoutNames[num]}" has been applied. This will take effect on the next ascension.`, 5000);
                 corruptionLoadoutSaveLoad(false, num + 1);
             } else {
-                void Notification('All next Corruption Stats are now Zero. This will take effect on the next ascension.', 5000);
+                void Notification('All Corruptions have been set to Zero. This will take effect on the next ascension.', 5000);
                 corruptionLoadoutSaveLoad(false, 0);
             }
         }


### PR DESCRIPTION
Added a load button on each row of the Ascend history table. It behaves the same as manually loading a Loadout or using the Hotkeys.
Improved the notification messages related to loading Corruptions
![image](https://user-images.githubusercontent.com/9673110/176144137-843cdb5f-5ecb-4afd-b771-6b2c448a973a.png)
