### PR TITLE
Revert CSS chnage leftover from SIngularity tab update

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2908,13 +2908,13 @@ header .img {
 
 .subHeader {
     display: flex;
-    width: 80%;
+    max-width: 1250px
 }
 
 .currenciesContainer {
     display: flex;
     flex-direction: column;
-    width: 55%;
+    width: 50%;
     align-items: flex-start;
     min-width: 625px;
 }

--- a/Synergism.css
+++ b/Synergism.css
@@ -2908,7 +2908,7 @@ header .img {
 
 .subHeader {
     display: flex;
-    max-width: 1250px
+    max-width: 1250px;
 }
 
 .currenciesContainer {

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -787,7 +787,7 @@ export const updateSingularityPerks = (): void => {
     const singularityCount = player.singularityCount;
     const str = getSingularityOridnalText(singularityCount) +
                 `<br/><br/>Here is the list of Perks you have acquired to compensate the Penalties
-                (Perks in <span class="newPerk">gold text</span> were added or improved in this singularity)<br/>`
+                (Hover for more details. Perks in <span class="newPerk">gold text</span> were added or improved in this singularity)<br/>`
                 + getAvailablePerksDescription(singularityCount)
 
     DOMCacheGetOrSet('singularityPerksMultiline').innerHTML = str;


### PR DESCRIPTION
While working on the singularity Tab with 3 subtabs, I had tried to add Golden Quarks in the currencies container then reverted my changes, except CSS. Now it's back to normal