### PR TITLE
Prevents the daily refill timer from bugging out to a future date

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1,4 +1,4 @@
-import { player, interval, clearInt, saveSynergy, format, resourceGain, updateAll, loadingDate } from './Synergism';
+import { player, interval, clearInt, saveSynergy, format, resourceGain, updateAll, getTimePinnedToLoadDate } from './Synergism';
 import { sumContents, productContents, getElementById } from './Utility';
 import { Globals as G } from './Variables';
 import { CalcECC } from './Challenges';
@@ -1768,7 +1768,7 @@ export const dailyResetCheck = () => {
     if (!player.dayCheck) {
         return;
     }
-    const now = new Date(loadingDate.getTime() + performance.now());
+    const now = new Date(getTimePinnedToLoadDate());
     const day = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const h = now.getHours()
     const m = now.getMinutes()

--- a/src/Event.ts
+++ b/src/Event.ts
@@ -1,4 +1,4 @@
-import { player, loadingDate } from './Synergism'
+import { player, getTimePinnedToLoadDate } from './Synergism'
 import { Globals as G } from './Variables';
 import { DOMCacheGetOrSet } from './Cache/DOM';
 
@@ -183,7 +183,7 @@ export const eventCheck = () => {
     if (!player.dayCheck) {
         return;
     }
-    const now = new Date(loadingDate.getTime() + performance.now());
+    const now = new Date(getTimePinnedToLoadDate());
     let start: Date;
     let end: Date;
 
@@ -191,7 +191,7 @@ export const eventCheck = () => {
     /* TODO: Figure out why some people get tagged for cheating even when they are playing legitimately
              I have temporarily disabled the checks. */
     nowEvent = events.default;
-    //if (now.getTime() >= player.dayCheck.getTime() && now.getTime() > loadingDate.getTime()) {
+    //if (now.getTime() >= player.dayCheck.getTime()) {
     // Update currently valid events
     for (const e in events) {
         const event = events[e];

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3390,7 +3390,7 @@ const loadingBasePerfTick = performance.now();
 // The returned time is pinned to when the page itself was loaded to remain
 // resilient against changed system clocks
 export const getTimePinnedToLoadDate = () => {
-  return loadingDate.getTime() + (performance.now() - loadingBasePerfTick);
+    return loadingDate.getTime() + (performance.now() - loadingBasePerfTick);
 }
 
 const tick = () => {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3382,7 +3382,16 @@ const dt = 5;
 const filterStrength = 20;
 let deltaMean = 0;
 
-export const loadingDate = new Date();
+const loadingDate = new Date();
+const loadingBasePerfTick = performance.now();
+
+// performance.now() doesn't always reset on reload, so we capture a "base value"
+// to keep things stable
+// The returned time is pinned to when the page itself was loaded to remain
+// resilient against changed system clocks
+export const getTimePinnedToLoadDate = () => {
+  return loadingDate.getTime() + (performance.now() - loadingBasePerfTick);
+}
 
 const tick = () => {
     const now = performance.now();


### PR DESCRIPTION
`performance.now()` does not always return to 0 on a reload, but `loadingDate` does. By instead taking the difference between `performance.now()` measurements for getting time pinned to the loading date, we can prevent the time from getting pushed into the future and causing missed refill timers.

This was also what was causing people to report refill timer values converging on times other than their local midnight -  this misaligned time is a symptom of the perceived date being pushed into the future, with their `dayCheck` value coming along with it.