### PR TITLE
Fix being able to open fractions of Cubes

### DIFF
--- a/src/Ants.ts
+++ b/src/Ants.ts
@@ -340,7 +340,7 @@ export const sacrificeAnts = async (auto = false) => {
     let p = true
 
     if (player.antPoints.gte('1e40')) {
-        if (!auto && player.antSacrificePoints < 100 && player.toggles[32]) {
+        if (!auto && player.toggles[32]) {
             p = await Confirm('This resets your Crumbs, Ants and Ant Upgrades in exchange for some multiplier and resources. Continue?')
         }
         if (p) {

--- a/src/CubeExperimental.ts
+++ b/src/CubeExperimental.ts
@@ -116,7 +116,7 @@ export abstract class Cube {
 
         if (isPercentage) {
             return this.open(
-                thisInPlayer.value * (cubesToOpen / 100),
+                Math.floor(thisInPlayer.value * (cubesToOpen / 100)),
                 cubesToOpen === 100
             );
         }

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -456,26 +456,26 @@ export const generateEventHandlers = () => {
     //Part 2: Cube Opening Buttons
     //Wow Cubes
     DOMCacheGetOrSet('open1Cube').addEventListener('click', () => player.wowCubes.open(1, false))
-    DOMCacheGetOrSet('open20Cube').addEventListener('click', () => player.wowCubes.open(Number(player.wowCubes) / 10, false))
-    DOMCacheGetOrSet('open1000Cube').addEventListener('click', () => player.wowCubes.open(Number(player.wowCubes) / 2, false))
+    DOMCacheGetOrSet('open20Cube').addEventListener('click', () => player.wowCubes.open(Math.floor(Number(player.wowCubes) / 10), false))
+    DOMCacheGetOrSet('open1000Cube').addEventListener('click', () => player.wowCubes.open(Math.floor(Number(player.wowCubes) / 2), false))
     DOMCacheGetOrSet('openCustomCube').addEventListener('click', () => player.wowCubes.openCustom());
     DOMCacheGetOrSet('openMostCube').addEventListener('click', () => player.wowCubes.open(1, true))
     //Wow Tesseracts
     DOMCacheGetOrSet('open1Tesseract').addEventListener('click', () => player.wowTesseracts.open(1, false))
-    DOMCacheGetOrSet('open20Tesseract').addEventListener('click', () => player.wowTesseracts.open(Number(player.wowTesseracts) / 10, false))
-    DOMCacheGetOrSet('open1000Tesseract').addEventListener('click', () => player.wowTesseracts.open(Number(player.wowTesseracts) / 2, false))
+    DOMCacheGetOrSet('open20Tesseract').addEventListener('click', () => player.wowTesseracts.open(Math.floor(Number(player.wowTesseracts) / 10), false))
+    DOMCacheGetOrSet('open1000Tesseract').addEventListener('click', () => player.wowTesseracts.open(Math.floor(Number(player.wowTesseracts) / 2), false))
     DOMCacheGetOrSet('openCustomTesseract').addEventListener('click', () => player.wowTesseracts.openCustom());
     DOMCacheGetOrSet('openMostTesseract').addEventListener('click', () => player.wowTesseracts.open(1, true))
     //Wow Hypercubes
     DOMCacheGetOrSet('open1Hypercube').addEventListener('click', () => player.wowHypercubes.open(1, false))
-    DOMCacheGetOrSet('open20Hypercube').addEventListener('click', () => player.wowHypercubes.open(Number(player.wowHypercubes) / 10, false))
-    DOMCacheGetOrSet('open1000Hypercube').addEventListener('click', () => player.wowHypercubes.open(Number(player.wowHypercubes) / 2, false))
+    DOMCacheGetOrSet('open20Hypercube').addEventListener('click', () => player.wowHypercubes.open(Math.floor(Number(player.wowHypercubes) / 10), false))
+    DOMCacheGetOrSet('open1000Hypercube').addEventListener('click', () => player.wowHypercubes.open(Math.floor(Number(player.wowHypercubes) / 2), false))
     DOMCacheGetOrSet('openCustomHypercube').addEventListener('click', () => player.wowHypercubes.openCustom());
     DOMCacheGetOrSet('openMostHypercube').addEventListener('click', () => player.wowHypercubes.open(1, true))
     //Wow Platonic Cubes
     DOMCacheGetOrSet('open1PlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(1, false))
-    DOMCacheGetOrSet('open40kPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(Number(player.wowPlatonicCubes) / 10, false))
-    DOMCacheGetOrSet('open1mPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(Number(player.wowPlatonicCubes) / 2, false))
+    DOMCacheGetOrSet('open40kPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(Math.floor(Number(player.wowPlatonicCubes) / 10), false))
+    DOMCacheGetOrSet('open1mPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(Math.floor(Number(player.wowPlatonicCubes) / 2), false))
     DOMCacheGetOrSet('openCustomPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.openCustom());
     DOMCacheGetOrSet('openMostPlatonicCube').addEventListener('click', () => player.wowPlatonicCubes.open(1, true))
 

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -373,6 +373,11 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
         G['autoResetTimers'].transcension = 0;
     }
 
+    if (input == 'reincarnation' || input == 'reincarnationChallenge') {
+        if (player.usedCorruptions[6] > 10 && player.platonicUpgrades[11] > 0) {
+            player.prestigePoints = player.prestigePoints.add(G['reincarnationPointGain'])
+        }
+    }
 
     if (input === 'reincarnation' || input === 'reincarnationChallenge' || input === 'ascension' || input === 'ascensionChallenge' || input == 'singularity') {
         // Fail safe if for some reason ascension achievement isn't awarded. hacky solution but am too tired to fix right now
@@ -409,9 +414,6 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
 
         player.transcendPoints = new Decimal('0');
         player.reincarnationPoints = player.reincarnationPoints.add(G['reincarnationPointGain']);
-        if (player.usedCorruptions[6] > 10 && player.platonicUpgrades[11] > 0) {
-            player.prestigePoints = player.prestigePoints.add(G['reincarnationPointGain'])
-        }
         player.reincarnationShards = new Decimal('0');
         player.challengecompletions[1] = 0;
         player.challengecompletions[2] = 0;


### PR DESCRIPTION
You can open Cubes with 10%, 50% and custom amount (if %), that ends up being round up
Giving you free cubes openings (I was able to get 4k tess opened from only having 6)
This should fix it, but will decrease by ~0,6% amount of cubes you get from using these buttons

Also I didnt deleted previous PR, I only changed name of branch...