### PR TITLE
Add ability to buy multiples of potions

### DIFF
--- a/index.html
+++ b/index.html
@@ -3203,13 +3203,13 @@ $GQ$ for golden quarks, $GQS$ for format golden quarks"></p>
                         <div>
                             <img id="offeringPotions" alt="offeringPotions" label="offeringPotions" src="Pictures/offering potion.png" loading="lazy">
                             <p id="offeringpotionowned" alt="offeringpotionowned" label="offeringpotionowned">Own: 2222</p>
-                            <button class="consumablebutton" id="buyofferingpotion" alt="buyofferingpotion" label="buyofferingpotion" style="border: 2px solid white">Buy 1 for 100 Quarks</button>
+                            <button class="consumablebutton" id="buyofferingpotion" alt="buyofferingpotion" label="buyofferingpotion" style="border: 2px solid white">Buy: 100 Quarks Each</button>
                             <button class="consumablebutton" id="useofferingpotion" alt="useofferingpotion" label="useofferingpotion" style="border: 2px solid orange">CONSUME</button>
                         </div>
                         <div>
                             <img id="obtainiumPotions" alt="obtainiumPotions" label="obtainiumPotions" src="Pictures/obtainium potion.png" loading="lazy">
                             <p id="obtainiumpotionowned" alt="obtainiumpotionowned" label="obtainiumpotionowned">Own: 0</p>
-                            <button class="consumablebutton" id="buyobtainiumpotion" alt="buyobtainiumpotion" label="buyobtainiumpotion" style="border: 2px solid white">Buy 1 for 100 Quarks</button>
+                            <button class="consumablebutton" id="buyobtainiumpotion" alt="buyobtainiumpotion" label="buyobtainiumpotion" style="border: 2px solid white">Buy: 100 Quarks Each</button>
                             <button class="consumablebutton" id="useobtainiumpotion" alt="useobtainiumpotion" label="useobtainiumpotion" style="border: 2px solid blue">CONSUME</button>
                         </div>
                     </div>

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -16,7 +16,7 @@ import { buyPlatonicUpgrades, createPlatonicDescription } from './Platonic'
 import { corruptionCleanseConfirm, corruptionDisplay } from './Corruptions'
 import { exportSynergism, updateSaveString, promocodes, promocodesPrompt, promocodesInfo, importSynergism, resetGame } from './ImportExport'
 import { resetHistoryTogglePerSecond } from './History'
-import { resetShopUpgrades, shopDescriptions, buyShopUpgrades, useConsumable, shopData, shopUpgradeTypes } from './Shop'
+import { resetShopUpgrades, shopDescriptions, buyShopUpgrades, buyConsumable, useConsumable, shopData, shopUpgradeTypes } from './Shop'
 import { Globals as G, Upgrade } from './Variables';
 import { changeTabColor } from './UpdateHTML'
 import { hepteractDescriptions, hepteractToOverfluxOrbDescription, tradeHepteractToOverfluxOrb, overfluxPowderDescription, overfluxPowderWarp } from './Hepteracts'
@@ -602,7 +602,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('offeringpotionowned').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('buyofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('useofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
-    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', () => buyShopUpgrades('offeringPotion'))
+    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', () => buyConsumable('offeringPotion'))
     //DOMCacheGetOrSet('offeringPotions').addEventListener('click', () => buyShopUpgrades("offeringPotion"))  //Allow clicking of image to buy also
     DOMCacheGetOrSet('useofferingpotion').addEventListener('click', () => useConsumable('offeringPotion'))
     /*Obtainium Potion*/
@@ -610,7 +610,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('obtainiumpotionowned').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
-    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', () => buyShopUpgrades('obtainiumPotion'))
+    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', () => buyConsumable('obtainiumPotion'))
     //DOMCacheGetOrSet('obtainiumPotions').addEventListener('click', () => buyShopUpgrades("obtainiumPotion"))  //Allow clicking of image to buy also
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('click', () => useConsumable('obtainiumPotion'))
     /* Permanent Upgrade Images */

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -1,5 +1,5 @@
 import { player, format } from './Synergism';
-import { Alert, Confirm, revealStuff } from './UpdateHTML';
+import { Alert, Confirm, Prompt, revealStuff } from './UpdateHTML';
 import { calculatePowderConversion, calculateTimeAcceleration } from './Calculate';
 import type { Player } from './types/Synergism';
 import { DOMCacheGetOrSet } from './Cache/DOM';
@@ -626,6 +626,34 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
         }
     }
     revealStuff();
+}
+
+export const buyConsumable = async (input: ShopUpgradeNames) => {
+
+    const maxBuyablePotions = Math.min(Math.floor(Number(player.worlds)/100),shopData[input].maxLevel-player.shopUpgrades[input]);
+    const potionKind = input === 'offeringPotion' ? 'Offering Potions' : 'Obtainium Potions';
+
+    if (shopData[input].maxLevel === player.shopUpgrades[input]) {
+        return Alert(`You can't purchase ${potionKind} because you already have the max level!`);
+    }
+    if (maxBuyablePotions === 0) {
+        return Alert(`You can't purchase ${potionKind} because you don't have enough Quarks!`);
+    }
+
+    const potionsAmount = await Prompt(`How many ${potionKind} would you like?\nYou can buy up to ${format(maxBuyablePotions, 0, true)} for 100 Quarks each.`);
+    const potionsToBuy = Math.floor(Number(potionsAmount));
+
+    if (potionsToBuy === 0) {
+        return Alert('Ok. No potions purchased.');
+    } else if (Number.isNaN(potionsToBuy) || !Number.isFinite(potionsToBuy) || potionsToBuy < 0) {
+        return Alert('Value must be a finite, positive integer.');
+    } else if (potionsToBuy > maxBuyablePotions) {
+        player.worlds.sub(100*maxBuyablePotions);
+        player.shopUpgrades[input] += maxBuyablePotions;
+    } else {
+        player.worlds.sub(100*potionsToBuy);
+        player.shopUpgrades[input] += potionsToBuy;
+    }
 }
 
 export const useConsumable = async (input: ShopUpgradeNames) => {


### PR DESCRIPTION
I often see users requesting the ability to buy a set amount of potions, but that may be because I've spent most of my last few months in the channel before singularity. This may be too niche of a request considering how often I've bought potions, but it's a little less clunky (from the user's perspective) than spending half your Quarks and using shop BUYMAX, resetting and repeat.