### PR TITLE
Heteract craft keep auto settings on sing

### DIFF
--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -13,7 +13,6 @@ import { Alert } from './UpdateHTML';
 import { getQuarkInvestment, shopData} from './Shop';
 import type { ISingularityData} from './singularity';
 import { singularityData, SingularityUpgrade } from './singularity';
-import { Globals as G } from './Variables';
 
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
 

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -462,8 +462,6 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
             if (data.hepteractCrafts[k]) {
                 player.hepteractCrafts[k] = createHepteract({...player.hepteractCrafts[k], ...data.hepteractCrafts[k]});
             }
-
-            G['autoHepteractCount'] += +player.hepteractCrafts[k].AUTO
         }
     }
 

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -257,24 +257,16 @@ export class HepteractCraft {
         return this;
     }
 
-    toggleAutomatic(bool?: boolean): Promise<void> | HepteractCraft {
+    toggleAutomatic(newValue?: boolean): Promise<void> | HepteractCraft {
+        const HTML = DOMCacheGetOrSet(`${this.HTML_STRING}HepteractAuto`);
 
-        if (!this.UNLOCKED && bool === undefined) {
-            return Alert('You do not have this as an unlocked craft. Automation is therefore not possible.')
-        }
-        const HTML = DOMCacheGetOrSet(`${this.HTML_STRING}HepteractAuto`)
+        // When newValue is empty, current value is toggled
+        this.AUTO = newValue ?? !this.AUTO;
 
-        this.AUTO = bool ?? !this.AUTO
+        HTML.textContent = `Auto ${this.AUTO ? 'ON' : 'OFF'}`;
+        HTML.style.border = `2px solid ${this.AUTO ? 'green' : 'red'}`;
 
-        HTML.textContent = `Auto ${this.AUTO ? 'ON' : 'OFF'}`
-        HTML.style.border = `2px solid ${this.AUTO ? 'green' : 'red'}`
-
-        if (bool === undefined) {
-            G['autoHepteractCount'] += (this.AUTO ? 1 : -1)
-        }
-        // Math.pow(-1, bool) also works here, but c'mon. - Platonic
-
-        return this
+        return this;
     }
 
     autoCraft(heptAmount: number): HepteractCraft {
@@ -570,6 +562,21 @@ export const overfluxPowderWarp = async () => {
             return Alert('Upon using the machine, your cubes feel just a little more rewarding. Daily cube opening counts have been reset! [-25 Powder]')
         }
     }
+}
+
+/**
+ * Get the HepteractCrafts which are unlocked and auto = ON
+ * @returns Array of HepteractCraft
+ */
+export const getAutoHepteractCrafts = () => {
+    const autoHepteracts: HepteractCraft[] = [];
+    for (const craft in player.hepteractCrafts) {
+        const k = craft as keyof Player['hepteractCrafts'];
+        if (player.hepteractCrafts[k].AUTO && player.hepteractCrafts[k].UNLOCKED) {
+            autoHepteracts.push(player.hepteractCrafts[k]);
+        }
+    }
+    return autoHepteracts;
 }
 
 // Hepteract of Chronos [UNLOCKED]

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -569,10 +569,10 @@ export const overfluxPowderWarp = async () => {
  */
 export const getAutoHepteractCrafts = () => {
     const autoHepteracts: HepteractCraft[] = [];
-    for (const craft in player.hepteractCrafts) {
-        const k = craft as keyof Player['hepteractCrafts'];
-        if (player.hepteractCrafts[k].AUTO && player.hepteractCrafts[k].UNLOCKED) {
-            autoHepteracts.push(player.hepteractCrafts[k]);
+    for (const craftName of Object.keys(player.hepteractCrafts)) {
+        const craftKey = craftName as keyof Player['hepteractCrafts'];
+        if (player.hepteractCrafts[craftKey].AUTO && player.hepteractCrafts[craftKey].UNLOCKED) {
+            autoHepteracts.push(player.hepteractCrafts[craftKey]);
         }
     }
     return autoHepteracts;

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -5,7 +5,6 @@ import { format, player } from './Synergism';
 import type { Player } from './types/Synergism';
 import { Alert, Confirm, Prompt } from './UpdateHTML';
 import { DOMCacheGetOrSet } from './Cache/DOM';
-import { Globals as G } from './Variables';
 
 export interface IHepteractCraft {
     BASE_CAP: number

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -34,6 +34,7 @@ import { QuarkHandler } from './Quark';
 import { calculateSingularityDebuff } from './singularity';
 import { updateCubeUpgradeBG } from './Cubes';
 import { calculateTessBuildingsInBudget, buyTesseractBuilding } from './Buy'
+import { getAutoHepteractCrafts } from './Hepteracts'
 import type { TesseractBuildings } from './Buy';
 
 let repeatreset: ReturnType<typeof setTimeout>;
@@ -616,14 +617,12 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
     }
 
     if (input === 'ascension' || input === 'ascensionChallenge') {
-        if (G['autoHepteractCount'] > 0) {
-            const heptAutoSpend = Math.floor((player.wowAbyssals / G['autoHepteractCount']) * (player.hepteractAutoCraftPercentage / 100))
-
-            for (const craft in player.hepteractCrafts) {
-                const k = craft as keyof Player['hepteractCrafts'];
-                if (player.hepteractCrafts[k].AUTO) {
-                    player.hepteractCrafts[k].autoCraft(heptAutoSpend)
-                }
+        const autoHepteractCrafts = getAutoHepteractCrafts();
+        if (autoHepteractCrafts.length > 0) {
+            // Computes the max number of Hepteracts to spend on each auto Hepteract craft
+            const heptAutoSpend = Math.floor((player.wowAbyssals / autoHepteractCrafts.length) * (player.hepteractAutoCraftPercentage / 100))
+            for (const craft of autoHepteractCrafts) {
+                craft.autoCraft(heptAutoSpend);
             }
         }
 
@@ -895,7 +894,6 @@ export const singularity = async (): Promise<void> => {
     hold.goldenQuarks = player.goldenQuarks;
     hold.shopUpgrades = player.shopUpgrades;
     hold.worlds = new QuarkHandler({ quarks: 0, bonus: 0 })
-    hold.hepteractCrafts.quark = player.hepteractCrafts.quark
     hold.singularityUpgrades = player.singularityUpgrades
     hold.autoChallengeToggles = player.autoChallengeToggles
     hold.autoChallengeTimer = player.autoChallengeTimer
@@ -955,6 +953,15 @@ export const singularity = async (): Promise<void> => {
     hold.shopConfirmationToggle = player.shopConfirmationToggle
     hold.researchBuyMaxToggle = player.researchBuyMaxToggle
     hold.cubeUpgradesBuyMaxToggle = player.cubeUpgradesBuyMaxToggle
+
+    // Quark Hepteract craft is saved entirely. For other crafts we only save their auto setting
+    hold.hepteractCrafts.quark = player.hepteractCrafts.quark;
+    for (const craftName in player.hepteractCrafts) {
+        if (craftName !== 'quark' ) {
+            const craftKey = craftName as keyof Player['hepteractCrafts'];
+            hold.hepteractCrafts[craftKey].AUTO = player.hepteractCrafts[craftKey].AUTO;
+        }
+    }
 
     //Import Game
     await importSynergism(btoa(JSON.stringify(hold)), true);

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -956,8 +956,8 @@ export const singularity = async (): Promise<void> => {
 
     // Quark Hepteract craft is saved entirely. For other crafts we only save their auto setting
     hold.hepteractCrafts.quark = player.hepteractCrafts.quark;
-    for (const craftName in player.hepteractCrafts) {
-        if (craftName !== 'quark' ) {
+    for (const craftName of Object.keys(player.hepteractCrafts)) {
+        if (craftName !== 'quark') {
             const craftKey = craftName as keyof Player['hepteractCrafts'];
             hold.hepteractCrafts[craftKey].AUTO = player.hepteractCrafts[craftKey].AUTO;
         }

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -430,26 +430,34 @@ export const visualUpdateCubes = () => {
 }
 
 const UpdateHeptGridValues = (type: hepteractTypes) => {
-    const text = type + 'ProgressBarText'
-    const bar = type + 'ProgressBar'
-    const textEl = document.getElementById(text)!
-    const barEl = document.getElementById(bar)!
-    const balance = player.hepteractCrafts[type].BAL
-    const cap = player.hepteractCrafts[type].CAP
-    const barWidth = Math.round((balance / cap) * 100)
+    const text = type + 'ProgressBarText';
+    const bar = type + 'ProgressBar';
+    const textEl = document.getElementById(text)!;
+    const barEl = document.getElementById(bar)!;
+    const unlocked = player.hepteractCrafts[type].UNLOCKED;
 
-    let barColor = '';
-    if (barWidth < 34) {
-        barColor = 'red';
-    } else if (barWidth >= 34 && barWidth < 68) {
-        barColor = '#cca300';
+    if (!unlocked) {
+        textEl.textContent = 'LOCKED';
+        barEl.style.width = '100%';
+        barEl.style.backgroundColor = 'red';
     } else {
-        barColor = 'green';
-    }
+        const balance = player.hepteractCrafts[type].BAL;
+        const cap = player.hepteractCrafts[type].CAP;
+        const barWidth = Math.round((balance / cap) * 100);
 
-    textEl.textContent = format(balance) + ' / ' + format(cap)
-    barEl.style.width = barWidth + '%'
-    barEl.style.backgroundColor = barColor
+        let barColor = '';
+        if (barWidth < 34) {
+            barColor = 'red';
+        } else if (barWidth >= 34 && barWidth < 68) {
+            barColor = '#cca300';
+        } else {
+            barColor = 'green';
+        }
+
+        textEl.textContent = format(balance) + ' / ' + format(cap);
+        barEl.style.width = barWidth + '%';
+        barEl.style.backgroundColor = barColor;
+    }
 }
 
 export const visualUpdateCorruptions = () => {

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -432,8 +432,8 @@ export const visualUpdateCubes = () => {
 const UpdateHeptGridValues = (type: hepteractTypes) => {
     const text = type + 'ProgressBarText';
     const bar = type + 'ProgressBar';
-    const textEl = document.getElementById(text)!;
-    const barEl = document.getElementById(bar)!;
+    const textEl = DOMCacheGetOrSet(text);
+    const barEl = DOMCacheGetOrSet(bar);
     const unlocked = player.hepteractCrafts[type].UNLOCKED;
 
     if (!unlocked) {

--- a/src/Variables.ts
+++ b/src/Variables.ts
@@ -424,7 +424,7 @@ export const Globals: GlobalVariables = {
 
     historyCountMax: 20,
 
-    isEvent: false,
+    isEvent: false
 
     // talismanResourceObtainiumCosts: [1e13, 1e14, 1e16, 1e18, 1e20, 1e22, 1e24]
     // talismanResourceOfferingCosts: [0, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9]

--- a/src/Variables.ts
+++ b/src/Variables.ts
@@ -428,8 +428,6 @@ export const Globals: GlobalVariables = {
 
     // talismanResourceObtainiumCosts: [1e13, 1e14, 1e16, 1e18, 1e20, 1e22, 1e24]
     // talismanResourceOfferingCosts: [0, 1e4, 1e5, 1e6, 1e7, 1e8, 1e9]
-
-    autoHepteractCount: 0
 }
 
 export const blankGlobals = { ...Globals };

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -881,8 +881,6 @@ export interface GlobalVariables {
     historyCountMax: number
 
     isEvent: boolean
-
-    autoHepteractCount: number
 }
 
 export interface SynergismEvents {


### PR DESCRIPTION
Auto settings are kept on Singularity.
Auto can be set ON/OFF even when craft is not unlocked but it triggers only when unlocked.
Display that a craft is locked in the colored progress bar.
Removed autoHepteractCount global variable because it created unnecessary complexity: it was updated in several parts of the game but used only once -> replaced by function getAutoHepteractCrafts()
![image](https://user-images.githubusercontent.com/9673110/178484879-bb394f11-ecdc-43ca-b21c-b8652bd824b8.png)

![image](https://user-images.githubusercontent.com/9673110/178484856-4826c512-8954-48b6-a50b-a857b0dda5bb.png)
