### PR TITLE
New mode for Auto Ascension

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -384,6 +384,7 @@ button:focus {
     text-align: left; /* Keeps text from bouncing around */
     font-size: 15px;
     font-variant-numeric: tabular-nums;
+    white-space: pre-line;
 }
 
 #resetrewards > div {

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -648,4 +648,8 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
     if (data.cubeUpgradesBuyMaxToggle === undefined) {
         player.cubeUpgradesBuyMaxToggle = false;
     }
+
+    if (data.ascensionCounterRealReal === undefined) {
+        player.ascensionCounterRealReal = 0;
+    }
 }

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -556,7 +556,8 @@ export const generateEventHandlers = () => {
     DOMCacheGetOrSet('corruptionCleanseConfirm').addEventListener('click', () => toggleCorruptionLevel(10, 999))
 
     //Extra toggle
-    DOMCacheGetOrSet('ascensionAutoEnable').addEventListener('click', () => toggleAutoAscend())
+    DOMCacheGetOrSet('ascensionAutoEnable').addEventListener('click', () => toggleAutoAscend(0))
+    DOMCacheGetOrSet('ascensionAutoToggle').addEventListener('click', () => toggleAutoAscend(1))
 
     // SETTNGS TAB
     // Part 0: Subtabs

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -31,12 +31,13 @@ export const addTimers = (input: TimerInput, time = 0) => {
             player.reincarnationcounter += time * timeMultiplier;
             break;
         }
-        case 'ascension': {
+        case 'ascension': { //Anything in here is affected by add code
             player.ascensionCounter += time * timeMultiplier * calculateAscensionAcceleration();
             player.ascensionCounterReal += time * timeMultiplier
             break;
         }
         case 'singularity': {
+            player.ascensionCounterRealReal += time;
             player.singularityCounter += time * timeMultiplier;
             break;
         }

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -135,7 +135,7 @@ export const resetdetails = (input: resetNames) => {
         case 'ascension':
             currencyImage1.style.display = 'none'
             resetCurrencyGain.textContent = '';
-            resetInfo.textContent = 'Ascend, C-10 is required! +' + format(CalcCorruptionStuff()[4], 0, true) + ' Wow! Cubes for doing it! Time: ' + format(player.ascensionCounter, 0, false) + ' Seconds.';
+            resetInfo.textContent = 'Ascend, C-10 is required! +' + format(CalcCorruptionStuff()[4], 0, true) + ' Wow! Cubes for doing it! Time: ' + format(player.ascensionCounter, 0, false) + ' Seconds.\n(Real-time ' + format(player.ascensionCounterRealReal, 0, false) + ' Seconds)';
             resetInfo.style.color = 'gold';
             break;
         case 'singularity':
@@ -558,6 +558,7 @@ export const reset = (input: resetNames, fast = false, from = 'unknown') => {
 
         player.ascensionCounter = 0;
         player.ascensionCounterReal = 0;
+        player.ascensionCounterRealReal = 0;
 
         updateTalismanInventory();
         updateTalismanAppearance(0);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -14,7 +14,7 @@ import { calculateHypercubeBlessings } from './Hypercubes';
 import { calculateTesseractBlessings } from './Tesseracts';
 import { calculateCubeBlessings, calculateObtainium, calculateAnts, calculateRuneLevels, calculateOffline, calculateSigmoidExponential, calculateCorruptionPoints, calculateTotalCoinOwned, calculateTotalAcceleratorBoost, dailyResetCheck, calculateOfferings, calculateAcceleratorMultiplier, calculateTimeAcceleration, exitOffline, calculateGoldenQuarkGain } from './Calculate';
 import { updateTalismanAppearance, toggleTalismanBuy, updateTalismanInventory, buyTalismanEnhance, buyTalismanLevels } from './Talismans';
-import { toggleAscStatPerSecond, toggleChallenges, toggleauto, toggleAutoChallengeModeText, toggleShops, toggleTabs, toggleSubTab, toggleAntMaxBuy, toggleAntAutoSacrifice, updateAutoChallenge, updateRuneBlessingBuyAmount } from './Toggles';
+import { toggleAscStatPerSecond, toggleChallenges, toggleauto, toggleAutoChallengeModeText, toggleShops, toggleTabs, toggleSubTab, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleAutoAscend, updateAutoChallenge, updateRuneBlessingBuyAmount } from './Toggles';
 import { c15RewardUpdate } from './Statistics';
 import { resetHistoryRenderAllTables } from './History';
 import { calculatePlatonicBlessings } from './PlatonicCubes';
@@ -521,6 +521,7 @@ export const player: Player = {
     ascensionCount: 0,
     ascensionCounter: 0,
     ascensionCounterReal: 0,
+    ascensionCounterRealReal: 0,
     cubeUpgrades: [null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
         0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -1583,6 +1584,11 @@ const loadSynergy = async () => {
             toggleAntMaxBuy();
             toggleAntAutoSacrifice(0);
             toggleAntAutoSacrifice(1);
+        }
+
+        for (let i = 1; i <= 2; i++) {
+            toggleAutoAscend(0);
+            toggleAutoAscend(1);
         }
 
         DOMCacheGetOrSet('historyTogglePerSecondButton').textContent = 'Per second: ' + (player.historyShowPerSecond ? 'ON' : 'OFF');
@@ -3352,8 +3358,11 @@ export const updateAll = (): void => {
     G['optimalObtainiumTimer'] = 3600 + 120 * player.shopUpgrades.obtainiumEX;
     autoBuyAnts()
 
-    if (player.autoAscend && player.challengecompletions[11] > 0 && player.cubeUpgrades[10] > 0) {
+    if (player.autoAscend && player.challengecompletions[11] > 0 && player.cubeUpgrades[10] > 0 && !player.currentChallenge.ascension) {
         if (player.autoAscendMode === 'c10Completions' && player.challengecompletions[10] >= Math.max(1, player.autoAscendThreshold)) {
+            reset('ascension', true)
+        }
+        if (player.autoAscendMode === 'realAscensionTime' && player.challengecompletions[10] >= 1 && player.ascensionCounterRealReal >= Math.max(1, player.autoAscendThreshold)) {
             reset('ascension', true)
         }
     }

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -887,17 +887,28 @@ export const toggleAutoChallengeModeText = (i: string) => {
     a.textContent = 'MODE: ' + i
 }
 
-export const toggleAutoAscend = () => {
-    const a = DOMCacheGetOrSet('ascensionAutoEnable');
-    if (player.autoAscend) {
-        a.style.border = '2px solid red'
-        a.textContent = 'Auto Ascend [OFF]';
-    } else {
-        a.style.border = '2px solid green'
-        a.textContent = 'Auto Ascend [ON]';
-    }
+export const toggleAutoAscend = (mode = 0) => {
+    if (mode === 0) {
+        const a = DOMCacheGetOrSet('ascensionAutoEnable');
+        if (player.autoAscend) {
+            a.style.border = '2px solid red'
+            a.textContent = 'Auto Ascend [OFF]'
+        } else {
+            a.style.border = '2px solid green'
+            a.textContent = 'Auto Ascend [ON]'
+        }
 
-    player.autoAscend = !player.autoAscend;
+        player.autoAscend = !player.autoAscend;
+    } else if (mode === 1 && player.singularityCount >= 25) {
+        const a = DOMCacheGetOrSet('ascensionAutoToggle');
+        if (player.autoAscendMode === 'c10Completions') {
+            player.autoAscendMode = 'realAscensionTime'
+            a.textContent = 'Mode: Real time'
+        } else {
+            player.autoAscendMode = 'c10Completions'
+            a.textContent = 'Mode: C10 Completions'
+        }
+    }
 }
 
 export const updateRuneBlessingBuyAmount = (i: number) => {

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -628,7 +628,7 @@ export const buttoncolorchange = () => {
         DOMCacheGetOrSet('ascendChallengeBtn').style.backgroundColor = '#171717' :
         DOMCacheGetOrSet('ascendChallengeBtn').style.backgroundColor = 'purple';
 
-    (player.autoAscend && player.cubeUpgrades[10] > 0.5) ?
+    (player.autoAscend && player.cubeUpgrades[10] > 0.5 && !player.currentChallenge.ascension) ?
         DOMCacheGetOrSet('ascendbtn').style.backgroundColor = 'green' :
         DOMCacheGetOrSet('ascendbtn').style.backgroundColor = '#171717';
 

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -461,6 +461,10 @@ export const visualUpdateCorruptions = () => {
     const metaData = CalcCorruptionStuff();
     const ascCount = calcAscensionCount();
 
+    const mode = player.autoAscendMode === 'c10Completions' ? 'you\'ve completed Sadistic Challenge I a total of' : 'the timer is at least';
+    const mode2 = player.autoAscendMode === 'c10Completions' ? 'times' : 'seconds (Real-time)';
+    const count = player.autoAscendMode === 'c10Completions' ? player.challengecompletions[10] : format(player.ascensionCounterRealReal, 0);
+    DOMCacheGetOrSet('autoAscend').textContent = `Ascend when ${mode} ${player.autoAscendThreshold} ${mode2}, Currently: ${count}.`
     DOMCacheGetOrSet('corruptionBankValue').textContent = format(metaData[0]);
     DOMCacheGetOrSet('corruptionScoreValue').textContent = format(metaData[1], 0, true);
     DOMCacheGetOrSet('corruptionMultiplierValue').textContent = format(metaData[2], 1, true);

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -407,6 +407,7 @@ export interface Player {
     ascensionCount: number
     ascensionCounter: number
     ascensionCounterReal: number
+    ascensionCounterRealReal: number
     cubeUpgrades: [null, ...number[]]
     cubeUpgradesBuyMaxToggle: boolean
     platonicUpgrades: number[]


### PR DESCRIPTION
New mode for Auto Ascension - Real-time (Not affected by adds)
To make this one more usefull (Can still be used with MD14, with "Time before entering challenge"), need to add better w3x8 (I liked idea of rewarding it with aschievement)
Auto Ascension no longer possible if inside Asc Challenge (Since it will only hurt to Auto Ascend inside)

(Pushed to fix, because Github auto removed const that had nothing to do with this PR)