### PR TITLE
Import corruption loadout from text

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2885,8 +2885,17 @@ img.small {
     margin-bottom: 1px;
 }
 
+.corrImport {
+    border: 1px solid green;
+    padding: 2px 5px;
+    transition-duration: 0.15s;
+    width: 100%;
+    margin-bottom: 1px;
+}
+
 .corrSave:hover,
-.corrLoad:hover {
+.corrLoad:hover,
+.corrImport:hover {
     background-color: #333;
 }
 

--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -213,28 +213,40 @@ export const corruptionLoadoutTableCreate = () => {
         for (let j = 0; j <= corrCount; j++) {
             const cell = row.insertCell();
             cell.className = `test${j}`
-            if (j === 0) {
-                if (i === 0) {
+            if (j === 0) { // First column
+                if (i === 0) { // First row
                     cell.textContent = 'Next:'
+                } else {
+                    // Custom loadout names are loaded later, via updateCorruptionLoadoutNames()
+                    cell.title = `Click to rename. Hotkey: SHIFT+${i}`
                 }
-                // Other loadout names are updated after player load in Synergism.ts > loadSynergy
+
             } else if (j <= corrCount) {
-                // start two-indexed (WTF!)
-                cell.textContent = ((i === 0) ? player.prototypeCorruptions[j+1] : player.corruptionLoadouts[i][j+1]).toString();
+                if (i === 0) { // Next Ascension Corruption values
+                    cell.textContent = player.prototypeCorruptions[j+1].toString()
+                } else { // Loadout Corruption values
+                    cell.textContent = player.corruptionLoadouts[i][j+1].toString()
+                }
                 cell.style.textAlign = 'center'
             }
         }
         if (i === 0) {
+            // First line is special : "Import" and "Zero" buttons
             let cell = row.insertCell();
-            //empty
+            let btn: HTMLButtonElement= document.createElement('button');
+            btn.className = 'corrImport'
+            btn.textContent = 'Import'
+            btn.onclick = () => importCorruptionsPrompt();
+            cell.appendChild(btn);
+            cell.title = 'Import Corruption Loadout in text format'
 
             cell = row.insertCell();
-            const btn = document.createElement('button');
+            btn = document.createElement('button');
             btn.className = 'corrLoad'
             btn.textContent = 'Zero'
             btn.onclick = () => corruptionLoadoutSaveLoad(false, i);
             cell.appendChild(btn);
-            cell.title = 'Reset corruptions to zero on your next ascension'
+            cell.title = 'Reset Corruptions to zero on your next Ascension. Hotkey: SHIFT+9'
         } else {
             let cell = row.insertCell();
             let btn = document.createElement('button');
@@ -242,6 +254,7 @@ export const corruptionLoadoutTableCreate = () => {
             btn.textContent = 'Save'
             btn.onclick = () => corruptionLoadoutSaveLoad(true, i);
             cell.appendChild(btn);
+            cell.title = 'Save current Corruptions to this Loadout'
 
             cell = row.insertCell();
             btn = document.createElement('button');
@@ -282,7 +295,19 @@ export const applyCorruptions = (corruptions: string) => {
     if (corruptions && corruptions.indexOf('/') > -1 && corruptions.split('/').length === 13) {
         // Converts the '/' separated string into a number[]
         player.prototypeCorruptions = corruptions.split('/').map(x => +x);
+        corruptionLoadoutTableUpdate();
         corruptionStatsUpdate();
+        return true;
+    }
+
+    return false;
+}
+
+async function importCorruptionsPrompt() {
+    const input = await Prompt('Enter a Corruption Loadout to import for next Ascension. It must be in the following text format: 1/2/3/4/5/6/7/8');
+
+    if (!applyCorruptions('0/0/' + input + '/0/0/0')) {
+        void Alert('Your input was not in the correct format, try again.');
     }
 }
 

--- a/src/History.ts
+++ b/src/History.ts
@@ -372,7 +372,7 @@ function clickHandlerForLoadCorruptionsButton(btn: HTMLElement) {
     const corruptions = btn.getAttribute('data-corr');
     if (corruptions) {
         applyCorruptions(corruptions);
-        void Notification('Corruption Loadout from previous run has been applied. This will take effect on the next ascension.', 5000);
+        void Notification('Corruption Loadout from previous run has been applied. This will take effect on the next Ascension.', 5000);
     }
 }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3624,10 +3624,10 @@ document.addEventListener('keydown', (event) => {
         }
         if (player.challengecompletions[11] > 0 && !isNaN(num)) {
             if (num >= 0 && num < player.corruptionLoadoutNames.length) {
-                void Notification(`Corruption Loadout ${num + 1} "${player.corruptionLoadoutNames[num]}" has been applied. This will take effect on the next ascension.`, 5000);
+                void Notification(`Corruption Loadout ${num + 1} "${player.corruptionLoadoutNames[num]}" has been applied. This will take effect on the next Ascension.`, 5000);
                 corruptionLoadoutSaveLoad(false, num + 1);
             } else {
-                void Notification('All Corruptions have been set to Zero. This will take effect on the next ascension.', 5000);
+                void Notification('All Corruptions have been set to Zero. This will take effect on the next Ascension.', 5000);
                 corruptionLoadoutSaveLoad(false, 0);
             }
         }


### PR DESCRIPTION
New button allows to import a loadout from its text representation. Makes it easy for players to follow guides or copy/paste a loadout from Discord
Added hover text to indicate that loadouts can be renamed and have a Hotkey (several players don't know)
![image](https://user-images.githubusercontent.com/9673110/178759780-f758f39c-478b-49ab-8b1a-cee56f1afe9d.png)
![image](https://user-images.githubusercontent.com/9673110/178759900-38d9fdef-b58f-49be-a3d6-485983e2ea4e.png)
