### PR TITLE
Auto-reincarnation bug at reincarnationPoints == 0

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3588,7 +3588,7 @@ function tack(dt: number) {
             }
         }
         if (player.resettoggle3 === 1 || player.resettoggle3 === 0) {
-            if (player.toggles[27] === true && player.researches[46] > 0.5 && G['reincarnationPointGain'].gte(player.reincarnationPoints.times(Decimal.pow(10, player.reincarnationamount))) && player.transcendShards.gte(1e300) && player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0) {
+            if (player.toggles[27] === true && player.researches[46] > 0.5 && G['reincarnationPointGain'].gte(player.reincarnationPoints.add(1).times(Decimal.pow(10, player.reincarnationamount))) && player.transcendShards.gte(1e300) && player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0) {
                 resetachievementcheck(3);
                 reset('reincarnation', true)
             }


### PR DESCRIPTION
In the beginning of an Ascension/Singularity, the auto-reincarnation buyer when set to amount will reset as soon as you hit 1e300 mythos shards for 0 particles, and continue to reset for 0 * 10e(amount) = 0 particles.

Break_infinity.js prioritizes speed over accuracy, and i think the issue comes from
`    G['reincarnationPointGain'] = Decimal.floor(Decimal.pow(player.transcendShards.dividedBy(1e300), 0.01));
`

I can bypass the unintended behavior if I change the line to
`    G['reincarnationPointGain'] = Decimal.max(1,Decimal.floor(Decimal.pow(player.transcendShards.dividedBy(1e300), 0.01)));
`

The auto-reincarnation buyer is probably the only time you'll see that edge case of flooring to 0, and that code gets called every currency update. Meanwhile, auto-reincarnation is soon supplanted by C3x8, and after that our change does not impact the game.
