### PR TITLE
added real TQE and changed name of quarks this sing

### DIFF
--- a/index.html
+++ b/index.html
@@ -2934,6 +2934,7 @@ $GQ$ for golden quarks, $GQS$ for format golden quarks"></p>
             <p class="reincarnationunlock statPortion" id="obtainiumPerSecondStatistic" alt="obtainiumPerSecondStatistic" label="obtainiumPerSecondStatistic" style="color: crimson;">Current Obtainium/sec: <span id="sMisc11" alt="sMisc11" label="sMisc11" class="statNumber">0</span></p>
             <p class="ascendunlock statPortion" id="ascensionCountStatistic" alt="ascensionCountStatistic" label="ascensionCountStatistic" style="color: orange">Ascension Count: <span id="sMisc12" alt="sMisc12" label="sMisc12" class="statNumber">0</span></p>
             <p class="ascendunlock statPortion" id="totalQuarkCountStatistic" alt="totalQuarkCountStatistic" label="totalQuarkCountStatistic" style="color: white">Total Quarks Ever (TQE): <span id="sMisc13" alt="sMisc13" label="sMisc13" class="statNumber">0</span></p>
+            <p class="ascendunlock statPortion" id="totalQuarkCountStatisticSing" alt="totalQuarkCountStatisticSing" label="totalQuarkCountStatisticSing" style="color: white">Total Quarks This Singularity: <span id="sMisc14" alt="sMisc14" label="sMisc14" class="statNumber">0</span></p>
         </div>
         <div id="acceleratorStats" alt="acceleratorStats" label="acceleratorStats" class="statContainer">
             <p id="acceleratorStatTitle" alt="acceleratorStatTitle" label="acceleratorStatTitle" class="statPortion" style="color: goldenrod; font-size: 1.2em">Free Accelerators</p>

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -539,6 +539,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         }
     }
 
+    if (data.totalQuarksEver === undefined){
+        player.totalQuarksEver = 0;
+    }
+
     // Update (read: check) for undefined shop upgrades. Also checks above max level.
     const shopKeys = Object.keys(blankSave['shopUpgrades']) as (keyof Player['shopUpgrades'])[];
     for (const shopUpgrade of shopKeys) {

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -880,6 +880,7 @@ export const singularity = async (): Promise<void> => {
     player.runelevels[6] = 0;
     player.goldenQuarks += calculateGoldenQuarkGain();
     player.singularityCount += 1;
+    player.totalQuarksEver += player.quarksThisSingularity;
     await resetShopUpgrades(true);
     const hold = Object.assign({}, blankSave, {
         codes: Array.from(blankSave.codes)
@@ -892,6 +893,7 @@ export const singularity = async (): Promise<void> => {
     toggleSubTab(9, 0); // set 'corruption main'
     toggleSubTab(-1, 0); // set 'statistics main'
 
+    hold.totalQuarksEver = player.totalQuarksEver
     hold.singularityCount = player.singularityCount;
     hold.goldenQuarks = player.goldenQuarks;
     hold.shopUpgrades = player.shopUpgrades;

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -684,6 +684,7 @@ export const player: Player = {
     singularityCounter: 0,
     goldenQuarks: 0,
     quarksThisSingularity: 0,
+    totalQuarksEver: 0,
 
     singularityUpgrades: {
         goldenQuarks1: new SingularityUpgrade(singularityData['goldenQuarks1']),

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -398,6 +398,9 @@ export const revealStuff = () => {
         (DOMCacheGetOrSet('singularitybtn').style.display = 'block') :
         (DOMCacheGetOrSet('singularitybtn').style.display = 'none');
 
+    player.singularityCount > 0 && player.ascensionCount >= 1 ?
+        (DOMCacheGetOrSet('totalQuarkCountStatisticSing').style.display = 'block') :
+        (DOMCacheGetOrSet('totalQuarkCountStatisticSing').style.display = 'none') ;
 
 
     DOMCacheGetOrSet('ascensionStats').style.visibility = (player.achievements[197] > 0 || player.singularityCount > 0) ? 'visible' : 'hidden';

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -509,7 +509,8 @@ export const visualUpdateSettings = () => {
     DOMCacheGetOrSet('runeSumStatistic').childNodes[1].textContent = format(G['runeSum'])
     DOMCacheGetOrSet('obtainiumPerSecondStatistic').childNodes[1].textContent = format(player.obtainiumpersecond, 2, true)
     DOMCacheGetOrSet('ascensionCountStatistic').childNodes[1].textContent = format(player.ascensionCount, 0, true)
-    DOMCacheGetOrSet('totalQuarkCountStatistic').childNodes[1].textContent = format(player.quarksThisSingularity, 0, true)
+    DOMCacheGetOrSet('totalQuarkCountStatistic').childNodes[1].textContent = format(player.totalQuarksEver + player.quarksThisSingularity, 0, true)
+    DOMCacheGetOrSet('totalQuarkCountStatisticSing').childNodes[1].textContent = format(player.quarksThisSingularity, 0, true)
 
     DOMCacheGetOrSet('saveString').textContent =
         `Currently: ${player.saveString.replace('$VERSION$', 'v' + version)}`;

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -539,6 +539,7 @@ export interface Player {
     singularityCounter: number
     goldenQuarks: number
     quarksThisSingularity: number
+    totalQuarksEver: number
 
     singularityUpgrades: Record<keyof typeof singularityData, SingularityUpgrade>
     dailyCodeUsed: boolean


### PR DESCRIPTION
Changed TQE stat to actually track total quarks rather than total quarks this sing, added a stat for total quarks this sing that shows up in sing 1. Please when this gets merged pin a message in singularity to octeracts that says it will only count from the current sing onward, I don't want to have to answer so many questions about why it's equal to Total Quarks this singularity.