### PR TITLE
Small css changes

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -532,19 +532,28 @@ nav li:hover {
 }
 
 #buyamountcoin {
-    position: absolute;
-    top: 0;
-    left: 80%;
+    display: none;
 }
 
-#togglecoinbuy {
+.buyamountbuildings {
+    position: relative;
+    left: 558px;
+    margin-bottom: -42px;
+}
+
+.buyamountbuildingsText {
+    position: relative;
+    top: -12px;
+    left: 30px;
+    margin-bottom: -26px;
     color: white;
-    position: absolute;
     font-size: 11px;
     width: 220px;
-    left: 80%;
-    top: 30px;
-    margin-left: -87px;
+}
+
+#toggleofferingbuy {
+    left: -60px;
+    width: 250px;
 }
 
 #buildingtext {
@@ -918,21 +927,6 @@ nav li:hover {
 #achievementcolorcode3 { color: crimson; }
 #achievementcolorcode4 { color: gray; }
 
-#buyamountcrystal {
-    position: absolute;
-    top: 0;
-    left: 80%;
-}
-
-#buyamountoffering {
-    position: absolute;
-    font-size: 11px;
-    width: 220px;
-    left: 86%;
-    top: 32px;
-    margin-left: -173px;
-}
-
 .talismanBuyAmountContainer {
     display: flex;
     flex-direction: column;
@@ -947,24 +941,6 @@ nav li:hover {
     align-items: center;
 }
 
-#buyamountmythos {
-    position: absolute;
-    top: 0;
-    left: 80%;
-}
-
-#buyamountparticle {
-    position: absolute;
-    top: 0;
-    left: 80%;
-}
-
-#buyAmountTesseract {
-    position: absolute;
-    top: 0;
-    left: 80%;
-}
-
 .buyAmountBtn {
     background-color: black;
     cursor: pointer;
@@ -975,59 +951,9 @@ nav li:hover {
     background-color: var(--hover-color);
 }
 
-#togglecrystalbuy {
-    color: white;
-    position: absolute;
-    font-size: 11px;
-    width: 220px;
-    left: 80%;
-    top: 30px;
-    margin-left: -87px;
-}
-
-#toggleofferingbuy {
-    color: white;
-    position: absolute;
-    font-size: 11px;
-    width: 250px;
-    left: 85%;
-    top: 25px;
-    margin-left: -183px;
-}
-
 #toggletalismanbuy {
     font-size: 11px;
     margin: -4px 0 5px;
-}
-
-#togglemythosbuy {
-    color: white;
-    position: absolute;
-    font-size: 11px;
-    width: 220px;
-    left: 80%;
-    top: 30px;
-    margin-left: -87px;
-}
-
-#toggleparticlebuy {
-    color: white;
-    position: absolute;
-    font-size: 11px;
-    width: 220px;
-    left: 80%;
-    top: 30px;
-    margin-left: -87px;
-}
-
-#toggleTesseractBuy {
-    color: white;
-    position: absolute;
-    font-size: 11px;
-    width: 220px;
-    left: 80%;
-    top: 30px;
-    margin-left: -87px;
 }
 
 #coinBuildings {
@@ -1103,6 +1029,9 @@ nav li:hover {
 
 #runeContainer2 {
     margin-top: 20px;
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 1800px;
 }
 
 #runesToggle {
@@ -1278,7 +1207,6 @@ nav li:hover {
 
 .talismanContainer {
     flex-direction: column;
-    width: 11%;
     min-width: 102px;
     align-items: center;
     white-space: nowrap;
@@ -1300,94 +1228,74 @@ nav li:hover {
     margin-bottom: 3px;
 }
 
-#respecAllTalismans {
+.talismanWindows {
     position: absolute;
+    left: 50%;
+    top: 290px;
+}
+
+#respecAllTalismans {
+    position: relative;
+    right: 296px;
+    top: 50px;
     height: 30px;
     width: 80px;
     color: plum;
     border: 2px solid white;
-    left: 70px;
-    top: 290px;
 }
 
 #talismanEffect {
-    position: absolute;
-    left: 50%;
+    position: relative;
     width: 600px;
-    margin-left: -300px;
-    top: 290px;
+    right: 155px;
+    top: 3px;
+}
+
+#talismanSummary {
     text-align: center;
+    margin-left: -300px;
 }
 
-#talismanBonus {
-    position: absolute;
-    top: 20px;
-    left: 145px;
-}
-
-#talismanRune1Effect {
-    position: absolute;
-    top: 40px;
-    left: 145px;
-}
-
-#talismanRune2Effect {
-    position: absolute;
-    top: 60px;
-    left: 145px;
-}
-
-#talismanRune3Effect {
-    position: absolute;
-    top: 80px;
-    left: 145px;
-}
-
-#talismanRune4Effect {
-    position: absolute;
-    top: 100px;
-    left: 145px;
-}
-
-#talismanRune5Effect {
-    position: absolute;
-    top: 120px;
-    left: 145px;
-}
-
-#talismanMythicEffect {
-    position: absolute;
-    top: 140px;
-    left: 145px;
+.taliEff {
+    margin-top: -17px;
 }
 
 #talismanlevelup {
-    position: absolute;
-    left: 50%;
+    position: relative;
     width: 600px;
+    top: -48px;
     margin-left: -200px;
-    top: 327px;
     text-align: center;
 }
 
 #talismanLevelUpSummary {
-    position: absolute;
-    top: -40px;
+    position: relative;
     left: 50px;
+    margin-top: 31px;
+    margin-bottom: 1px;
+    text-align: left;
 }
 
 #talismanrespec {
-    position: absolute;
-    left: 50%;
+    position: relative;
+    top: -48px;
     width: 600px;
     margin-left: -300px;
-    top: 290px;
     text-align: center;
 }
 
+#talismanRespecSummary {
+    margin-top: 34px;
+    margin-bottom: 12px;
+}
+
 .talismanRespecBtn {
+    position: relative;
+    display: block;
     height: 30px;
     width: 200px;
+    left: 200px;
+    margin-top: 1px;
     text-align: center;
     transition-duration: 0.15s;
 }
@@ -1396,46 +1304,15 @@ nav li:hover {
     background-color: var(--hover-color);
 }
 
-#talismanRespecButton1 {
-    position: absolute;
-    top: 50px;
-    left: 200px;
-}
-
-#talismanRespecButton2 {
-    position: absolute;
-    top: 81px;
-    left: 200px;
-}
-
-#talismanRespecButton3 {
-    position: absolute;
-    top: 112px;
-    left: 200px;
-}
-
-#talismanRespecButton4 {
-    position: absolute;
-    top: 143px;
-    left: 200px;
-}
-
-#talismanRespecButton5 {
-    position: absolute;
-    top: 174px;
-    left: 200px;
-}
-
 #confirmTalismanRespec {
-    position: absolute;
-    top: 112px;
     left: 430px;
+    bottom: 93px;
+    margin-bottom: -31px;
 }
 
 #cancelTalismanRespec {
-    position: absolute;
-    top: 143px;
     left: 430px;
+    bottom: 62px;
 }
 
 #transcension {
@@ -3002,6 +2879,7 @@ header #obtainiumDisplay { color: pink; }
     gap: 10px;
     padding-top: 10px;
     margin-bottom: 15px;
+    max-width: 1600px;
     line-height: 20px;
     width: 60%;
     justify-content: space-evenly;
@@ -3111,16 +2989,20 @@ header #obtainiumDisplay { color: pink; }
     margin-bottom: 50px;
 }
 
-#saveOffToggle {
+.platonicTogglesContainer {
+    position: relative;
+    top: 2px;
+    right: 233px;
+}
+
+.platonicToggles {
+    margin-top: 4px;
     width: 130px;
     height: 32px;
-    position: absolute;
-    margin-top: 6px;
-    margin-left: 193px;
     transition-duration: 0.15s;
 }
 
-#saveOffToggle:hover {
+.platonicToggles:hover {
     background-color: var(--hover-color);
 }
 

--- a/index.html
+++ b/index.html
@@ -243,8 +243,8 @@
             <button class="ascendunlock" id="switchToTesseractBuilding" alt="switchToTesseractBuilding" label="switchToTesseractBuilding" style="border: 2px solid orange">Tesseract Buildings</button>
         </div>
         <div id="coinBuildings" alt="coinBuildings" label="coinBuildings">
-        <div id="buyamountcoin" alt="buyamountcoin" label="buyamountcoin">
-            <table class="coinunlock3" id="coinbuyamount" alt="coinbuyamount" label="coinbuyamount">
+        <div class="buyamountbuildings coinunlock3" id="buyamountcoin" alt="buyamountcoin" label="buyamountcoin">
+            <table id="coinbuyamount" alt="coinbuyamount" label="coinbuyamount">
                 <tr>
                 <td><img id="coinone" alt="coinone" label="coinone" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinOne.png" style="background-color: green;" loading="lazy"></td>
                 <td><img id="cointen" alt="cointen" label="cointen" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinTen.png" loading="lazy"></td>
@@ -252,7 +252,7 @@
                 <td><img id="cointhousand" alt="cointhousand" label="cointhousand" class="buyAmountBtn" src="Pictures/Transparent Pics/CoinThousand.png" loading="lazy"></td>
                 </tr>
             </table>
-            <p class="coinunlock3" id="togglecoinbuy" alt="togglecoinbuy" label="togglecoinbuy">Toggle amount to buy</p>
+            <p class="buyamountbuildingsText" id="togglecoinbuy" alt="togglecoinbuy" label="togglecoinbuy">Toggle amount to buy</p>
         </div>
 
         <!--
@@ -328,7 +328,7 @@
         </div>
     </div>
     <div id="prestige" alt="prestige" label="prestige" style="display: none;">
-        <div id="buyamountcrystal" alt="buyamountcrystal" label="buyamountcrystal">
+        <div class="buyamountbuildings" id="buyamountcrystal" alt="buyamountcrystal" label="buyamountcrystal">
             <table id="crystalbuyamount" alt="crystalbuyamount" label="crystalbuyamount">
                 <tr>
                 <td><img id="crystalone" alt="crystalone" label="crystalone" class="buyAmountBtn" src="Pictures/Transparent Pics/CrystalOne.png" style="background-color: green;" loading="lazy"></td>
@@ -338,7 +338,7 @@
 
                 </tr>
             </table>
-            <p id="togglecrystalbuy" alt="togglecrystalbuy" label="togglecrystalbuy">Toggle amount to buy</p>
+            <p class="buyamountbuildingsText" id="togglecrystalbuy" alt="togglecrystalbuy" label="togglecrystalbuy">Toggle amount to buy</p>
         </div>
 
         <div class="buttonRow">
@@ -406,7 +406,7 @@
         </div>
     </div>
     <div id="transcension" alt="transcension" label="transcension" style="display: none;">
-        <div id="buyamountmythos" alt="buyamountmythos" label="buyamountmythos">
+        <div class="buyamountbuildings" id="buyamountmythos" alt="buyamountmythos" label="buyamountmythos">
             <table id="mythosbuyamount" alt="mythosbuyamount" label="mythosbuyamount">
                 <tr>
                 <td><img id="mythosone" alt="mythosone" label="mythosone" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosOne.png" style="background-color: green;" loading="lazy"></td>
@@ -415,7 +415,7 @@
                 <td><img id="mythosthousand" alt="mythosthousand" label="mythosthousand" class="buyAmountBtn" src="Pictures/Transparent Pics/MythosThousand.png" loading="lazy"></td>
                 </tr>
             </table>
-            <p id="togglemythosbuy" alt="togglemythosbuy" label="togglemythosbuy">Toggle amount to buy</p>
+            <p class="buyamountbuildingsText" id="togglemythosbuy" alt="togglemythosbuy" label="togglemythosbuy">Toggle amount to buy</p>
         </div>
 
         <div class="buttonRow">
@@ -468,7 +468,7 @@
         <p id="transcendhotkeys" alt="transcendhotkeys" label="transcendhotkeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer.</p>
     </div>
     <div id="reincarnation" alt="reincarnation" label="reincarnation" style="display: none;">
-        <div id="buyamountparticle" alt="buyamountparticle" label="buyamountparticle">
+        <div class="buyamountbuildings" id="buyamountparticle" alt="buyamountparticle" label="buyamountparticle">
             <table id="particlebuyamount" alt="particlebuyamount" label="particlebuyamount">
                 <tr>
                 <td><img id="particleone" alt="particleone" label="particleone" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleOne.png" style="background-color: green;" loading="lazy"></td>
@@ -477,7 +477,7 @@
                 <td><img id="particlethousand" alt="particlethousand" label="particlethousand" class="buyAmountBtn" src="Pictures/Transparent Pics/ParticleThousand.png" loading="lazy"></td>
                 </tr>
             </table>
-            <p id="toggleparticlebuy" alt="toggleparticlebuy" label="toggleparticlebuy">Toggle amount to buy</p>
+            <p class="buyamountbuildingsText" id="toggleparticlebuy" alt="toggleparticlebuy" label="toggleparticlebuy">Toggle amount to buy</p>
         </div>
 
         <div class="buttonRow">
@@ -535,7 +535,7 @@
         <p id="reincarnatehotkeys" alt="reincarnatehotkeys" label="reincarnatehotkeys">Press [1], [2], [3], [4], or [5] to buy the respective tiered producer.</p>
     </div>
     <div id="ascension" alt="ascension" label="ascension" style="display: none">
-        <div id="buyAmountTesseract" alt="buyAmountTesseract" label="buyAmountTesseract">
+        <div class="buyamountbuildings" id="buyAmountTesseract" alt="buyAmountTesseract" label="buyAmountTesseract">
             <table id="buyTesseractToggles" alt="buyTesseractToggles" label="buyTesseractToggles">
                 <tr>
                     <td><img id="tesseractone" alt="tesseractone" label="tesseractone" class="buyAmountBtn" src="Pictures/Transparent Pics/TesseractOne.png" style="background-color: green;" loading="lazy"></td>
@@ -544,7 +544,7 @@
                     <td><img id="tesseractthousand" alt="tesseractthousand" label="tesseractthousand" class="buyAmountBtn"src="Pictures/Transparent Pics/TesseractThousand.png" loading="lazy"></td>
                 </tr>
             </table>
-            <p id="toggleTesseractBuy" alt="toggleTesseractBuy" label="toggleTesseractBuy">Toggle amount to buy</p>
+            <p class="buyamountbuildingsText" id="toggleTesseractBuy" alt="toggleTesseractBuy" label="toggleTesseractBuy">Toggle amount to buy</p>
         </div>
 
         <div class="buttonRow">
@@ -1204,7 +1204,7 @@
 
             <div id="runeContainer1" alt="runeContainer1" label="runeContainer1">
 
-                <div id="buyamountoffering" alt="buyamountoffering" label="buyamountoffering">
+                <div class="buyamountbuildings" id="buyamountoffering" alt="buyamountoffering" label="buyamountoffering">
                     <table id="offeringbuyamount" alt="offeringbuyamount" label="offeringbuyamount">
                         <tr>
                         <td><img id="offeringone" alt="offeringone" label="offeringone" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingOne.png" style="background-color: green;" loading="lazy"></td>
@@ -1213,7 +1213,7 @@
                         <td><img id="offeringthousand" alt="offeringthousand" label="offeringthousand" class="buyAmountBtn" src="Pictures/Transparent Pics/OfferingThousand.png" loading="lazy"></td>
                         </tr>
                     </table>
-                    <p id="toggleofferingbuy" alt="toggleofferingbuy" label="toggleofferingbuy">Toggle the number of levels to buy per sacrifice</p>
+                    <p class="buyamountbuildingsText" id="toggleofferingbuy" alt="toggleofferingbuy" label="toggleofferingbuy">Toggle the number of levels to buy per sacrifice</p>
                 </div>
 
                 <div id="offeringDetails" alt="offeringDetails" label="offeringDetails">
@@ -1347,7 +1347,6 @@
                     <span id="talismanFragmentCost" alt="talismanFragmentCost" label="talismanFragmentCost">Cost for 1: 1e6 Obtainium</span>
                 </div>
                 <div class="talismansContainer">
-                    <button class="talismanBtn" id="respecAllTalismans" alt="respecAllTalismans" label="respecAllTalismans">RESPEC ALL</button>
                     <div class="talismanContainer" id="talisman1area" alt="talisman1area" label="talisman1area">
                         <span class="talismanName" style="color: limegreen;">Exemption</span>
                         <img class="talismanIcon" id="talisman1" alt="talisman1" label="talisman1" src="Pictures/taxtalisman.png" loading="lazy">
@@ -1422,50 +1421,53 @@
                     </div>
                 </div>
 
-                <div id="talismanEffect" alt="talismanEffect" label="talismanEffect">
-                    <p id="talismanSummary" alt="talismanSummary" label="talismanSummary" style="color: silver"></p>
-                    <p id="talismanBonus" alt="talismanBonus" label="talismanBonus" style="color: white"></p>
-                    <p id="talismanRune1Effect" alt="talismanRune1Effect" label="talismanRune1Effect" style="color: cyan"></p>
-                    <p id="talismanRune2Effect" alt="talismanRune2Effect" label="talismanRune2Effect" style="color: plum"></p>
-                    <p id="talismanRune3Effect" alt="talismanRune3Effect" label="talismanRune3Effect" style="color: lightblue"></p>
-                    <p id="talismanRune4Effect" alt="talismanRune4Effect" label="talismanRune4Effect" style="color: limegreen"></p>
-                    <p id="talismanRune5Effect" alt="talismanRune5Effect" label="talismanRune5Effect" style="color: crimson"></p>
-                    <p id="talismanMythicEffect" alt="talismanMythicEffect" label="talismanMythicEffect" style="color: gold"></p>
-                </div>
+                <div class="talismanWindows">
+                    <button class="talismanBtn" id="respecAllTalismans" alt="respecAllTalismans" label="respecAllTalismans">RESPEC ALL</button>
+                    <div id="talismanEffect" alt="talismanEffect" label="talismanEffect">
+                        <p class="taliEff" id="talismanSummary" alt="talismanSummary" label="talismanSummary" style="color: silver"></p>
+                        <p class="taliEff" id="talismanBonus" alt="talismanBonus" label="talismanBonus" style="color: white"></p>
+                        <p class="taliEff" id="talismanRune1Effect" alt="talismanRune1Effect" label="talismanRune1Effect" style="color: cyan"></p>
+                        <p class="taliEff" id="talismanRune2Effect" alt="talismanRune2Effect" label="talismanRune2Effect" style="color: plum"></p>
+                        <p class="taliEff" id="talismanRune3Effect" alt="talismanRune3Effect" label="talismanRune3Effect" style="color: lightblue"></p>
+                        <p class="taliEff" id="talismanRune4Effect" alt="talismanRune4Effect" label="talismanRune4Effect" style="color: limegreen"></p>
+                        <p class="taliEff" id="talismanRune5Effect" alt="talismanRune5Effect" label="talismanRune5Effect" style="color: crimson"></p>
+                        <p class="taliEff" id="talismanMythicEffect" alt="talismanMythicEffect" label="talismanMythicEffect" style="color: gold"></p>
+                    </div>
 
-                <div id="talismanlevelup" alt="talismanlevelup" label="talismanlevelup" style="table-layout: fixed; display: none">
-                    <p id="talismanLevelUpSummary" alt="talismanLevelUpSummary" label="talismanLevelUpSummary" style="color: silver">-=-=- Resources Required to Level Up -=-=-</p>
-                    <table>
-                        <tr>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/TalismanShard.png" loading="lazy"></td>
-                            <td style="width: 68px; color: yellow"><p id="talismanShardCost" alt="talismanShardCost" label="talismanShardCost"></p></td>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/CommonTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: white"><p id="talismanCommonFragmentCost" alt="talismanCommonFragmentCost" label="talismanCommonFragmentCost"></p></td>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/UncommonTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: limegreen"><p id="talismanUncommonFragmentCost" alt="talismanUncommonFragmentCost" label="talismanUncommonFragmentCost"></p></td>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/RareTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: darkcyan"><p id="talismanRareFragmentCost" alt="talismanRareFragmentCost" label="talismanRareFragmentCost"></p></td>
-                        </tr>
-                        <tr>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/EpicTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: plum"><p id="talismanEpicFragmentCost" alt="talismanEpicFragmentCost" label="talismanEpicFragmentCost"></p></td>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/LegendaryTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: orange"><p id="talismanLegendaryFragmentCost" alt="talismanLegendaryFragmentCost" label="talismanLegendaryFragmentCost"></p></td>
-                            <td style="font-size: 0; width: 32px"><img src="Pictures/MythicalTalisman.png" loading="lazy"></td>
-                            <td style="width: 68px; color: crimson"><p id="talismanMythicalFragmentCost" alt="talismanMythicalFragmentCost" label="talismanMythicalFragmentCost"></p></td>
-                        </tr>
-                    </table>
-                </div>
+                    <div id="talismanlevelup" alt="talismanlevelup" label="talismanlevelup" style="table-layout: fixed; display: none">
+                        <p id="talismanLevelUpSummary" alt="talismanLevelUpSummary" label="talismanLevelUpSummary" style="color: silver">-=-=- Resources Required to Level Up -=-=-</p>
+                        <table>
+                            <tr>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/TalismanShard.png" loading="lazy"></td>
+                                <td style="width: 68px; color: yellow"><p id="talismanShardCost" alt="talismanShardCost" label="talismanShardCost"></p></td>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/CommonTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: white"><p id="talismanCommonFragmentCost" alt="talismanCommonFragmentCost" label="talismanCommonFragmentCost"></p></td>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/UncommonTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: limegreen"><p id="talismanUncommonFragmentCost" alt="talismanUncommonFragmentCost" label="talismanUncommonFragmentCost"></p></td>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/RareTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: darkcyan"><p id="talismanRareFragmentCost" alt="talismanRareFragmentCost" label="talismanRareFragmentCost"></p></td>
+                            </tr>
+                            <tr>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/EpicTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: plum"><p id="talismanEpicFragmentCost" alt="talismanEpicFragmentCost" label="talismanEpicFragmentCost"></p></td>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/LegendaryTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: orange"><p id="talismanLegendaryFragmentCost" alt="talismanLegendaryFragmentCost" label="talismanLegendaryFragmentCost"></p></td>
+                                <td style="font-size: 0; width: 32px"><img src="Pictures/MythicalTalisman.png" loading="lazy"></td>
+                                <td style="width: 68px; color: crimson"><p id="talismanMythicalFragmentCost" alt="talismanMythicalFragmentCost" label="talismanMythicalFragmentCost"></p></td>
+                            </tr>
+                        </table>
+                    </div>
 
-                <div id="talismanrespec" alt="talismanrespec" label="talismanrespec" style="display: none">
-                    <p id="talismanRespecSummary" alt="talismanRespecSummary" label="talismanRespecSummary" style="color: orchid">+-==-+ Select for 3 GREEN Runes, for Respec! +-==-+</p>
-                    <button class="talismanRespecBtn" id="talismanRespecButton1" alt="talismanRespecButton1" label="talismanRespecButton1">Speed Rune: POSITIVE</button>
-                    <button class="talismanRespecBtn" id="talismanRespecButton2" alt="talismanRespecButton2" label="talismanRespecButton2">Duplication Rune: POSITIVE</button>
-                    <button class="talismanRespecBtn" id="talismanRespecButton3" alt="talismanRespecButton3" label="talismanRespecButton3">Prism Rune: POSITIVE</button>
-                    <button class="talismanRespecBtn" id="talismanRespecButton4" alt="talismanRespecButton4" label="talismanRespecButton4">Thrift Rune: POSITIVE</button>
-                    <button class="talismanRespecBtn" id="talismanRespecButton5" alt="talismanRespecButton5" label="talismanRespecButton5">SI Rune: POSITIVE</button>
-                    <button class="talismanRespecBtn" id="confirmTalismanRespec" alt="confirmTalismanRespec" label="confirmTalismanRespec" style="border: 2px solid plum">Confirm for 100,000 Offerings.</button>
-                    <button class="talismanRespecBtn" id="cancelTalismanRespec" alt="cancelTalismanRespec" label="cancelTalismanRespec" style="border: 2px solid red">Cancel respec changes</button>
+                    <div id="talismanrespec" alt="talismanrespec" label="talismanrespec" style="display: none">
+                        <p id="talismanRespecSummary" alt="talismanRespecSummary" label="talismanRespecSummary" style="color: orchid">+-==-+ Select for 3 GREEN Runes, for Respec! +-==-+</p>
+                        <button class="talismanRespecBtn" id="talismanRespecButton1" alt="talismanRespecButton1" label="talismanRespecButton1">Speed Rune: POSITIVE</button>
+                        <button class="talismanRespecBtn" id="talismanRespecButton2" alt="talismanRespecButton2" label="talismanRespecButton2">Duplication Rune: POSITIVE</button>
+                        <button class="talismanRespecBtn" id="talismanRespecButton3" alt="talismanRespecButton3" label="talismanRespecButton3">Prism Rune: POSITIVE</button>
+                        <button class="talismanRespecBtn" id="talismanRespecButton4" alt="talismanRespecButton4" label="talismanRespecButton4">Thrift Rune: POSITIVE</button>
+                        <button class="talismanRespecBtn" id="talismanRespecButton5" alt="talismanRespecButton5" label="talismanRespecButton5">SI Rune: POSITIVE</button>
+                        <button class="talismanRespecBtn" id="confirmTalismanRespec" alt="confirmTalismanRespec" label="confirmTalismanRespec" style="border: 2px solid plum">Confirm for 100,000 Offerings.</button>
+                        <button class="talismanRespecBtn" id="cancelTalismanRespec" alt="cancelTalismanRespec" label="cancelTalismanRespec" style="border: 2px solid red">Cancel respec changes</button>
+                    </div>
                 </div>
             </div>
             <div id="runeContainer3" alt="runeContainer3" label="runeContainer3" style="display: none">
@@ -2479,9 +2481,6 @@
                     </div>
                     <div class="platonicUpgradesContainer">
                         <div id="platonicUpgrades" alt="platonicUpgrades" label="platonicUpgrades">
-                            <div style="display: inline">
-                                <button id="saveOffToggle" alt="saveOffToggle" label="saveOffToggle" style="border: 2px solid gold" title="If ON, then it will turn OFF Auto Runes toggle">Save Offerings [OFF]</button>
-                            </div>
                             <table class="boxColor" id="platonicUpgradePics" alt="platonicUpgradePics" label="platonicUpgradePics">
                                 <tr>
                                     <td style="font-size: 0;"><img id="platUpg1" alt="platUpg1" label="platUpg1" src="Pictures/Transparent%20Pics/PlatonicUpgrade1.png" class="platonicUpgradeImage" loading="lazy"></td>
@@ -2527,6 +2526,9 @@
                             <p id="platonicHepteractCost" alt="platonicHepteractCost" label="platonicHepteractCost" class="platonicPortion">---</p>
                             <p id="platonicCanBuy" alt="platonicCanBuy" label="platonicCanBuy" class="platonicPortion">---</p>
                         </div>
+                    </div>
+                    <div class="platonicTogglesContainer">
+                        <button class="platonicToggles" id="saveOffToggle" alt="saveOffToggle" label="saveOffToggle" style="border: 2px solid gold" title="If ON, then it will turn OFF Auto Runes toggle">Save Offerings [OFF]</button>
                     </div>
                 </div>
                 <div id="cubeTab7" alt="cubeTab7" label="cubeTab7" class="cubeTab" style="display: none">


### PR DESCRIPTION
I'm not 100% sure it wont break everything (as I cant truly test different ratios)
Maybe that will make Khafra happy and not attack me about absolute positions...

Buy 1-1000 now doesnt clip into text and doesnt move with zoom
Rune 1-max now doesnt move with zoom (or leaves orbit if you really zoom out)
Talisman tab now wont grow too much with zoom out (text doesnt overlap on small screens)
Stats on top now wont grow too much with zoom out
Removed a lot of Absolute positions (including my saveOffToggle)