### PR TITLE
Add and settings bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -2820,14 +2820,14 @@
                     <div class="center"></div>
                 </div>
                 <p class="prestigeunlock" id="confirmationdisclaimer" alt="confirmationdisclaimer" label="confirmationdisclaimer" style="color: plum">These do not work with hotkeys. Too bad!</p>
-                <p class="prestigeunlock" id="specialActionsTitle" alt="specialActionsTitle" label="specialActionsTitle" style="color: pink">Special Actions</p>
+                <p id="specialActionsTitle" alt="specialActionsTitle" label="specialActionsTitle" style="color: pink">Special Actions</p>
                 <button id="dailyCode" alt="dailyCode" label="dailyCode" class="promocodeButton" style="border:2px solid green">Daily</button>
                 <button id="addCode" alt="addCode" label="addCode" class="promocodeButton" style="min-width:40%; border:2px solid green">Add</button>
                 <button id="addCodeOne" alt="addCodeOne" label="addCodeOne" class="promocodeButton" style="min-width:24%;border:2px solid green">Add x1</button>
                 <button id="timeCode" alt="timeCode" label="timeCode" class="promocodeButton" style="border:2px solid green">Time</button>
                 <button id="promocodes" alt="promocodes" label="promocodes" class="promocodeButton" style="border:2px solid goldenrod">Enter a promotion code here!</button>
                 <p id="promocodeinfo" alt="promocodeinfo" label="promocodeinfo" style="color: goldenrod"></p>
-                <p class="prestigeunlock" id="themesTitle" alt="themesTitle" label="themesTitle" style="color: pink">Current Theme</p>
+                <p id="themesTitle" alt="themesTitle" label="themesTitle" style="color: pink">Current Theme</p>
                 <button id="theme" alt="theme" label="theme" class="promocodeButton" style="border: 2px solid white">Dark Mode</button>
             </div>
             <div id="exportButtons" alt="exportButtons" label="exportButtons">

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -166,24 +166,24 @@ export function calculateRuneExpGiven(runeIndex: number, all = false, runeLevel 
         G['challenge15Rewards'].runeExp
     ]);
         // Corruption Divisor
-    const droughEffect = 1 / Math.pow(G['droughtMultiplier'][player.usedCorruptions[8]], 1 - 1 / 2 * player.platonicUpgrades[13]);
+    const droughtEffect = 1 / Math.pow(G['droughtMultiplier'][player.usedCorruptions[8]], 1 - 1 / 2 * player.platonicUpgrades[13]);
 
     // Rune multiplier that gets applied to specific runes
     const runeExpMultiplier = [
         productContents([
-            1 + (player.researches[78] / 50), 1 + (player.researches[111] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[7]) / 10), droughEffect
+            1 + (player.researches[78] / 50), 1 + (player.researches[111] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[7]) / 10), droughtEffect
         ]),
         productContents([
-            1 + (player.researches[80] / 50), 1 + (player.researches[112] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[7]) / 10), droughEffect
+            1 + (player.researches[80] / 50), 1 + (player.researches[112] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[7]) / 10), droughtEffect
         ]),
         productContents([
-            1 + (player.researches[79] / 50), 1 + (player.researches[113] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[8]) / 5), droughEffect
+            1 + (player.researches[79] / 50), 1 + (player.researches[113] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[8]) / 5), droughtEffect
         ]),
         productContents([
-            1 + (player.researches[77] / 50), 1 + (player.researches[114] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[6]) / 10), droughEffect
+            1 + (player.researches[77] / 50), 1 + (player.researches[114] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[6]) / 10), droughtEffect
         ]),
         productContents([
-            1 + (player.researches[83] / 20), 1 + (player.researches[115] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[9]) / 5), droughEffect
+            1 + (player.researches[83] / 20), 1 + (player.researches[115] / 100), 1 + (CalcECC('reincarnation', player.challengecompletions[9]) / 5), droughtEffect
         ]),
         productContents([1]),
         productContents([1])

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -399,7 +399,7 @@ export const promocodes = async (input: string | null, amount?: number) => {
         const ascMult = (player.singularityUpgrades.expertPack.level > 0) ? 1.2 : 1;
         const ascensionTimer = 60 * player.shopUpgrades.calculator3 * realAttemptsUsed * ascMult;
         const ascensionTimerText = (player.shopUpgrades.calculator3 > 0)
-            ? 'Thanks to PL-AT Ω you have also gained ' + format(ascensionTimer) + ' real-life seconds to your Ascension Timer!'
+            ? `Thanks to PL-AT Ω you have also gained ${format(ascensionTimer)} real-life seconds to your Ascension Timer!`
             : '';
 
         // Calculator Maxed: you don't need to insert anything!
@@ -412,8 +412,8 @@ export const promocodes = async (input: string | null, amount?: number) => {
                 void promocodesInfo('add')
                 return
             } else {
-                return Alert(`Your calculator figured out that ${first} + ${second} = ${first + second} on its own, so you were awarded ${player.worlds.toString(actualQuarks)} quarks ` +
-                    `${ ascensionTimer } You have ${ remaining } uses of Add. You will gain 1 in ${ timeToNext.toLocaleString(navigator.language) } seconds.`);
+                return Alert(`Your calculator figured out that ${first} + ${second} = ${first + second} on its own, so you were awarded ${player.worlds.toString(actualQuarks)} Quarks! ` +
+                    `${ ascensionTimerText } You have ${ remaining } uses of Add. You will gain 1 in ${ timeToNext.toLocaleString(navigator.language) } seconds.`);
             }
         }
 


### PR DESCRIPTION
A couple small bug fixes. Headers for special actions and theme are hidden until first prestige while the buttons are always available. I made them always visible.

Renamed droughEffect to the most likely intended droughtEffect. A pedantic clean-up... No logic changed.

And a re-fix of the Add alert for a maxed calculator that was partially reverted with the new 'Add 1' feature. Additionally, changed the alert text so that the maxed and unmaxed calculators are more consistent.