### PR TITLE
Fix Pass Y buff not affecting octs

### DIFF
--- a/src/Octeracts.ts
+++ b/src/Octeracts.ts
@@ -351,7 +351,7 @@ export const octeractGainPerSecond = () => {
 
     const valueMultipliers = [
         1 + 1.5 * player.shopUpgrades.seasonPass3 / 100,
-        1 + player.shopUpgrades.seasonPassY / 200,
+        1 + 1.5 * player.shopUpgrades.seasonPassY / 200,
         1 + player.shopUpgrades.seasonPassZ * player.singularityCount / 100,
         1 + player.shopUpgrades.seasonPassLost / 1000,
         1 + +(corruptionLevelSum >= 14 * 8) * player.cubeUpgrades[70] / 10000,


### PR DESCRIPTION
Looks like Pass3 got its multiplier for octs when the cap was reduced back to 100, but not PassY