### PR TITLE
fix sing history text placement

### DIFF
--- a/index.html
+++ b/index.html
@@ -3266,11 +3266,11 @@ $STAGE$ for synergism stage" style="color: white"></p>
         <div id="historySingularity" alt="historySingularity" label="historySingularity">
             <div>
                 <p style="float: left">Your last singularities got you the following:</p>
-            </div>
-            <div class="historyTableWrap" style="clear: both">
-                <table id="historySingularityTable" alt="historySingularityTable" label="historySingularityTable">
-                    <tbody></tbody>
-                </table>
+                <div class="historyTableWrap" style="clear: both">
+                    <table id="historySingularityTable" alt="historySingularityTable" label="historySingularityTable">
+                        <tbody></tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Moved "Your last singularities got you the following:" to be above history table. It was this way originally but changed with the big PR.