### PR TITLE
Enhance Quark Shop: Buy {1 | 10 | Max | Any}

### DIFF
--- a/index.html
+++ b/index.html
@@ -3363,12 +3363,12 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="instantChallenge2Level" alt="instantChallenge2Level" label="instantChallenge2Level"></p>
                             <button class="permshopbutton" id="instantChallenge2Button" alt="instantChallenge2Button" label="instantChallenge2Button" style="border: 2px solid darkviolet"></button>
                         </div>
-                        <div class="chal8Shop" id="antSpeedHide">
+                        <div class="chal8" id="antSpeedHide">
                             <img id="antSpeed" alt="antSpeed" label="antSpeed" src="Pictures/antspeed.png" loading="lazy">
                             <p id="antSpeedLevel" alt="antSpeedLevel" label="antSpeedLevel">Level: 0/3</p>
                             <button class="permshopbutton" id="antSpeedButton" alt="antSpeedButton" label="antSpeedButton" style="border: 2px solid maroon">Upgrade for 200 Quarks</button>
                         </div>
-                        <div class="chal8Shop" id="cashGrabHide">
+                        <div class="chal8" id="cashGrabHide">
                             <img id="cashGrab" alt="cashGrab" label="cashGrab" src="Pictures/cashgrab.png" loading="lazy">
                             <p id="cashGrabLevel" alt="cashGrabLevel" label="cashGrabLevel">Level: 0/5</p>
                             <button class="permshopbutton" id="cashGrabButton" alt="cashGrabButton" label="cashGrabButton" style="border: 2px solid limegreen">Upgrade for 100 Quarks</button>
@@ -3378,27 +3378,27 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="cashGrab2Level"></p>
                             <button class="permshopbutton" id="cashGrab2Button" style="border: 2px solid cyan"></button>
                         </div>
-                        <div class="chal9Shop" id="shopTalismanHide">
+                        <div class="chal9" id="shopTalismanHide">
                             <img id="shopTalisman" alt="shopTalisman" label="shopTalisman" src="Pictures/shoptalisman.png" loading="lazy">
                             <p id="shopTalismanLevel" alt="shopTalismanLevel" label="shopTalismanLevel">Not Bought</p>
                             <button class="permshopbutton" id="shopTalismanButton" alt="shopTalismanButton" label="shopTalismanButton" style="border: 2px solid chartreuse">Buy for 1,500 Quarks</button>
                         </div>
-                        <div class="ascendunlockShop" id="seasonPassHide">
+                        <div class="ascendunlock" id="seasonPassHide">
                             <img id="seasonPass" alt="seasonPass" label="seasonPass" src="Pictures/VIP Pass Upgrade.png" loading="lazy">
                             <p id="seasonPassLevel" alt="seasonPassLevel" label="seasonPassLevel">Level: 0/5</p>
                             <button class="permshopbutton" id="seasonPassButton" alt="seasonPassButton" label="seasonPassButton" style="border: 2px solid orange"></button>
                         </div>
-                        <div class="chal14Shop" id="seasonPass2Hide">
+                        <div class="chal14" id="seasonPass2Hide">
                             <img id="seasonPass2" alt="seasonPass2" label="seasonPass2" src="Pictures/VIP Pass Upgrade 2.png" loading="lazy">
                             <p id="seasonPass2Level" alt="seasonPass2Level" label="seasonPass2Level">Level: 0/100</p>
                             <button class="permshopbutton" id="seasonPass2Button" alt="seasonPass2Button" label="seasonPass2Button" style="border: 2px solid orange"></button>
                         </div>
-                        <div class="chal14Shop" id="seasonPass3Hide">
+                        <div class="chal14" id="seasonPass3Hide">
                             <img id="seasonPass3" alt="seasonPass3" label="seasonPass3" src="Pictures/VIP Pass Upgrade 3.png" loading="lazy">
                             <p id="seasonPass3Level" alt="seasonPass3Level" label="seasonPass3Level">Level: 0/100</p>
                             <button class="permshopbutton" id="seasonPass3Button" alt="seasonPass3Button" label="seasonPass3Button" style="border: 2px solid orange"></button>
                         </div>
-                        <div class="hepteractsShop" id="seasonPassYHide">
+                        <div class="hepteracts" id="seasonPassYHide">
                             <img id="seasonPassY" alt="seasonPassY" label="seasonPassY" src="Pictures/VIP Pass Upgrade Y.png" loading="lazy">
                             <p id="seasonPassYLevel" alt="seasonPassYLevel" label="seasonPassYLevel"></p>
                             <button class="permshopbutton" id="seasonPassYButton" alt="seasonPassYButton" label="seasonPassYButton" style="border: 2px solid red"></button>
@@ -3413,12 +3413,12 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="seasonPassLostLevel"></p>
                             <button class="permshopbutton" id="seasonPassLostButton" style="border: 2px solid blue"></button>
                         </div>
-                        <div class="ascendunlockShop" id="challengeExtensionHide">
+                        <div class="ascendunlock" id="challengeExtensionHide">
                             <img id="challengeExtension" alt="challengeExtension" label="challengeExtension" src="Pictures/Challenge Upgrade.png" loading="lazy">
                             <p id="challengeExtensionLevel" alt="challengeExtensionLevel" label="challengeExtensionLevel">Level: 0/5</p>
                             <button class="permshopbutton" id="challengeExtensionButton" alt="challengeExtensionButton" label="challengeExtensionButton" style="border: 2px solid gray"></button>
                         </div>
-                        <div class="ascendunlockShop" id="challengeTomeHide">
+                        <div class="ascendunlock" id="challengeTomeHide">
                             <img id="challengeTome" alt="challengeTome" label="challengeTome" src="Pictures/Challenge 10 Tome Upgrade.png" loading="lazy">
                             <p id="challengeTomeLevel" alt="challengeTomeLevel" label="challengeTomeLevel">Level: 0/5</p>
                             <button class="permshopbutton" id="challengeTomeButton" alt="challengeTomeButton" label="challengeTomeButton" style="border: 2px solid gold"></button>
@@ -3428,17 +3428,17 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="challengeTome2Level" alt="challengeTome2Level" label="challengeTome2Level"></p>
                             <button class="permshopbutton" id="challengeTome2Button" alt="challengeTome2Button" label="challengeTome2Button" style="border: 2px solid red"></button>
                         </div>
-                        <div class="ascendunlockShop" id="cubeToQuarkHide">
+                        <div class="ascendunlock" id="cubeToQuarkHide">
                             <img id="cubeToQuark" alt="cubeToQuark" label="cubeToQuark" src="Pictures/Cube Quark Upgrade.png" loading="lazy">
                             <p id="cubeToQuarkLevel" alt="cubeToQuarkLevel" label="cubeToQuarkLevel">Not Bought</p>
                             <button class="permshopbutton" id="cubeToQuarkButton" alt="cubeToQuarkButton" label="cubeToQuarkButton" style="border: 2px solid yellow"></button>
                         </div>
-                        <div class="chal11Shop" id="tesseractToQuarkHide">
+                        <div class="chal11" id="tesseractToQuarkHide">
                             <img id="tesseractToQuark" alt="tesseractToQuark" label="tesseractToQuark" src="Pictures/Tesseract Quark Upgrade.png" loading="lazy">
                             <p id="tesseractToQuarkLevel" alt="tesseractToQuarkLevel" label="tesseractToQuarkLevel">Not Bought</p>
                             <button class="permshopbutton" id="tesseractToQuarkButton" alt="tesseractToQuarkButton" label="tesseractToQuarkButton" style="border: 2px solid darkorchid"></button>
                         </div>
-                        <div class="chal13Shop" id="hypercubeToQuarkHide">
+                        <div class="chal13" id="hypercubeToQuarkHide">
                             <img id="hypercubeToQuark" alt="hypercubeToQuark" label="hypercubeToQuark" src="Pictures/Hypercube Quark Upgrade.png" loading="lazy">
                             <p id="hypercubeToQuarkLevel" alt="hypercubeToQuarkLevel" label="hypercubeToQuarkLevel">Not Bought</p>
                             <button class="permshopbutton" id="hypercubeToQuarkButton" alt="hypercubeToQuarkButton" label="hypercubeToQuarkButton" style="border: 2px solid red"></button>
@@ -3448,12 +3448,12 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="cubeToQuarkAllLevel"></p>
                             <button class="permshopbutton" id="cubeToQuarkAllButton" style="border: 2px solid purple"></button>
                         </div>
-                        <div class="chal12Shop" id="chronometerHide">
+                        <div class="chal12" id="chronometerHide">
                             <img id="chronometer" alt="chronometer" label="chronometer" src="Pictures/Chronometer.png" loading="lazy">
                             <p id="chronometerLevel" alt="chronometerLevel" label="chronometerLevel">Level: 0/100</p>
                             <button class="permshopbutton" id="chronometerButton" alt="chronometerButton" label="chronometerButton" style="border: 2px solid red"></button>
                         </div>
-                        <div class="hepteractsShop" id="chronometer2Hide">
+                        <div class="hepteracts" id="chronometer2Hide">
                             <img id="chronometer2" alt="chronometer2" label="chronometer2" src="Pictures/Chronometer2.png" loading="lazy">
                             <p id="chronometer2Level" alt="chronometer2Level" label="chronometer2Level"></p>
                             <button class="permshopbutton" id="chronometer2Button" alt="chronometer2Button" label="chronometer2Button" style="border: 2px solid red"></button>
@@ -3468,7 +3468,7 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="chronometerZLevel"></p>
                             <button class="permshopbutton" id="chronometerZButton" style="border: 2px solid lime"></button>
                         </div>
-                        <div class="chal14Shop" id="infiniteAscentHide">
+                        <div class="chal14" id="infiniteAscentHide">
                             <img id="infiniteAscent" alt="infiniteAscent" label="infiniteAscent" src="Pictures/Shop Rune.png" loading="lazy">
                             <p id="infiniteAscentLevel" alt="infiniteAscentLevel" label="infiniteAscentLevel">Not Bought</p>
                             <button class="permshopbutton" id="infiniteAscentButton" alt="infiniteAscentButton" label="infiniteAscentButton" style="border: 2px solid cyan"></button>
@@ -3478,12 +3478,12 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="calculatorLevel" alt="calculatorLevel" label="calculatorLevel">Not Bought</p>
                             <button class="permshopbutton" id="calculatorButton" alt="calculatorButton" label="calculatorButton" style="border: 2px solid purple"></button>
                         </div>
-                        <div class="chal11Shop" id="calculator2Hide">
+                        <div class="chal11" id="calculator2Hide">
                             <img id="calculator2" alt="calculator2" label="calculator2" src="Pictures/Calculator2.png" loading="lazy">
                             <p id="calculator2Level" alt="calculator2Level" label="calculator2Level"></p>
                             <button class="permshopbutton" id="calculator2Button" alt="calculator2Button" label="calculator2Button" style="border: 2px solid purple"></button>
                         </div>
-                        <div class="chal13Shop" id="calculator3Hide">
+                        <div class="chal13" id="calculator3Hide">
                             <img id="calculator3" alt="calculator3" label="calculator3" src="Pictures/Calculator3.png" loading="lazy">
                             <p id="calculator3Level" alt="calculator3Level" label="calculator3Level"></p>
                             <button class="permshopbutton" id="calculator3Button" alt="calculator3Button" label="calculator3Button" style="border: 2px solid purple;"></button>
@@ -3503,17 +3503,17 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="calculator6Level" alt="calculator6Level" label="calculator6Level"></p>
                             <button class="permshopbutton" id="calculator6Button" alt="calculator6Button" label="calculator6Button" style="border: 2px solid black;"></button>
                         </div>
-                        <div class="chal14Shop" id="constantEXHide">
+                        <div class="chal14" id="constantEXHide">
                             <img id="constantEX" alt="constantEX" label="constantEX" src="Pictures/ConstantExtension.png" loading="lazy">
                             <p id="constantEXLevel" alt="constantEXLevel" label="constantEXLevel"></p>
                             <button class="permshopbutton" id="constantEXButton" alt="constantEXButton" label="constantEXButton" style="border: 2px solid gray;"></button>
                         </div>
-                        <div class="hepteractsShop" id="powderEXHide">
+                        <div class="hepteracts" id="powderEXHide">
                             <img id="powderEX" alt="powderEX" label="powderEX" src="Pictures/Powder Gain Upgrade.png" loading="lazy">
                             <p id="powderEXLevel" alt="powderEXLevel" label="powderEXLevel"></p>
                             <button class="permshopbutton" id="powderEXButton" alt="powderEXButton" label="powderEXButton" style="border: 2px solid red;"></button>
                         </div>
-                        <div class="hepteractsShop" id="improveQuarkHeptHide">
+                        <div class="hepteracts" id="improveQuarkHeptHide">
                             <img id="improveQuarkHept" alt="improveQuarkHept" label="improveQuarkHept" src="Pictures/Improved Quark Hepteract Shop 0.png">
                             <p id="improveQuarkHeptLevel" alt="improveQuarkHeptLevel" label="improveQuarkHeptLevel"></p>
                             <button class="permshopbutton" id="improveQuarkHeptButton" alt="improveQuarkHeptButton" label="improveQuarkHeptButton" style="border: 2px solid cyan;"></button>
@@ -3533,7 +3533,7 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="improveQuarkHept4Level" alt="improveQuarkHept4Level" label="improveQuarkHept4Level"></p>
                             <button class="permshopbutton" id="improveQuarkHept4Button" alt="improveQuarkHept4Button" label="improveQuarkHept4Button" style="border: 2px solid grey;"></button>
                         </div>
-                        <div class="chal14Shop" id="shopImprovedDailyHide">
+                        <div class="chal14" id="shopImprovedDailyHide">
                             <img id="shopImprovedDaily" alt="shopImprovedDaily" src="Pictures/Shop Improved Daily0.png">
                             <p id="shopImprovedDailyLevel"></p>
                             <button class="permshopbutton" id="shopImprovedDailyButton" style="border: 2px solid gold"></button>

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -594,7 +594,7 @@ TODO: Fix this entire tab it's utter shit
     // Part 1: The Settings
     /*Respec The Upgrades*/ DOMCacheGetOrSet('resetShopUpgrades').addEventListener('click', () => resetShopUpgrades())
     /*Toggle Shop Confirmations*/ DOMCacheGetOrSet('toggleConfirmShop').addEventListener('click', () => toggleShopConfirmation())
-    /*Toggle Shop Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxShop').addEventListener('click', () => toggleBuyMaxShop())
+    /*Toggle Shop Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxShop').addEventListener('click', (event) => toggleBuyMaxShop(event))
     /*Toggle Hide Permanent Maxed*/ DOMCacheGetOrSet('toggleHideShop').addEventListener('click', () => toggleHideShop())
 
     // Part 2: Potions

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -14,7 +14,7 @@ import { buyPlatonicUpgrades, createPlatonicDescription } from './Platonic'
 import { corruptionCleanseConfirm, corruptionDisplay } from './Corruptions'
 import { exportSynergism, updateSaveString, promocodes, promocodesPrompt, promocodesInfo, importSynergism, resetGame, reloadDeleteGame, handleLastModified } from './ImportExport'
 import { resetHistoryTogglePerSecond } from './History'
-import { resetShopUpgrades, shopDescriptions, buyShopUpgrades, buyConsumable, useConsumable, shopData, shopUpgradeTypes } from './Shop'
+import { resetShopUpgrades, shopDescriptions, buyShopUpgrades, useConsumable, shopData, shopUpgradeTypes } from './Shop'
 import { Globals as G } from './Variables';
 import { changeTabColor, Confirm } from './UpdateHTML'
 import { hepteractDescriptions, hepteractToOverfluxOrbDescription, tradeHepteractToOverfluxOrb, overfluxPowderDescription, overfluxPowderWarp, toggleAutoBuyOrbs } from './Hepteracts'
@@ -603,7 +603,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('offeringpotionowned').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('buyofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('useofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
-    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', () => buyConsumable('offeringPotion'))
+    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', () => buyShopUpgrades('offeringPotion'))
     //DOMCacheGetOrSet('offeringPotions').addEventListener('click', () => buyShopUpgrades("offeringPotion"))  //Allow clicking of image to buy also
     DOMCacheGetOrSet('useofferingpotion').addEventListener('click', () => useConsumable('offeringPotion'))
     /*Obtainium Potion*/
@@ -611,7 +611,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('obtainiumpotionowned').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
-    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', () => buyConsumable('obtainiumPotion'))
+    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', () => buyShopUpgrades('obtainiumPotion'))
     //DOMCacheGetOrSet('obtainiumPotions').addEventListener('click', () => buyShopUpgrades("obtainiumPotion"))  //Allow clicking of image to buy also
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('click', () => useConsumable('obtainiumPotion'))
     /* Permanent Upgrade Images */

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -874,15 +874,17 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         player.highestchallengecompletions[6] = 1;
         achievementaward(113);
     }
-    if (player.achievements[278] > 0 && singularityReset) { // Singularity 5
-        player.shopUpgrades.offeringAuto = 10
-        player.shopUpgrades.offeringEX = 10
-        player.shopUpgrades.obtainiumAuto = 10
-        player.shopUpgrades.obtainiumEX = 10
-        player.shopUpgrades.antSpeed = 10
-        player.shopUpgrades.cashGrab = 10
+    const shopItemPerk_5 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
+    const perk_5: boolean = player.achievements[278] > 0;
+    if (perk_5 && singularityReset) { // Singularity 5
+        shopItemPerk_5.forEach(k => {
+            player.shopUpgrades[k] = 10;
+        });
         player.cubeUpgrades[7] = 1;
     }
+    shopItemPerk_5.forEach(k => {
+        shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;
+    });
     if (player.achievements[279] > 0) { // Singularity 7
         player.challengecompletions[7] = 1;
         player.highestchallengecompletions[7] = 1;
@@ -917,19 +919,21 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         player.fifthOwnedAnts = 1;
         player.cubeUpgrades[20] = 1;
     }
-    if (player.singularityCount >= 20) {
+    const perk_20: boolean = player.singularityCount >= 20;
+    const shopItemPerk_20 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
+    if (perk_20) {
         player.challengecompletions[9] = 1;
         player.highestchallengecompletions[9] = 1;
         achievementaward(134);
         player.antPoints = new Decimal('1e100');
         player.antUpgrades[11] = 1;
-        player.shopUpgrades.offeringAuto = shopData.offeringAuto.maxLevel
-        player.shopUpgrades.offeringEX = shopData.offeringEX.maxLevel
-        player.shopUpgrades.obtainiumAuto = shopData.obtainiumAuto.maxLevel
-        player.shopUpgrades.obtainiumEX = shopData.obtainiumEX.maxLevel
-        player.shopUpgrades.antSpeed = shopData.antSpeed.maxLevel
-        player.shopUpgrades.cashGrab = shopData.cashGrab.maxLevel
+        shopItemPerk_20.forEach(k => {
+            player.shopUpgrades[k] = shopData[k].maxLevel;
+        });
     }
+    shopItemPerk_20.forEach(k => {
+        shopData[k].refundable = perk_20 ? false : true;
+    });
     if (player.singularityCount >= 25) {
         player.eighthOwnedAnts = 1;
     }
@@ -938,6 +942,12 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         player.researches[135] = 1;
         player.researches[145] = 1;
     }
+    const perk_51 = player.singularityCount >= 51;
+    const shopItemPerk_51 = ['seasonPass', 'seasonPass2', 'seasonPass3', 'seasonPassY', 'chronometer', 'chronometer2'] as const;
+    shopItemPerk_51.forEach(k => {
+        shopData[k].refundable = perk_51 ? false : true;
+    });
+
     if (player.singularityCount >= 101 && singularityReset) {
         player.cubeUpgrades[51] = 1;
         awardAutosCookieUpgrade();

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -798,11 +798,8 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
         return Alert(`You can't purchase ${friendlyShopName(input)} because you don't have enough Quarks!`);
     }
     // Actually lock for HTML exploit
-    if ((shopItem.tier === 'Ascension' && player.ascensionCount <= 0) ||
-        (shopItem.tier === 'Singularity' && !player.singularityUpgrades.wowPass.getEffect().bonus) ||
-        (shopItem.tier === 'SingularityVol2' && !player.singularityUpgrades.wowPass2.getEffect().bonus) ||
-        (shopItem.tier === 'SingularityVol3' && !player.singularityUpgrades.wowPass3.getEffect().bonus)) {
-        return Alert('You do not have the right to purchase ' + friendlyShopName(input) + '!');
+    if (!isShopUpgradeUnlocked(input)) {
+        return Alert(`You do not have the right to purchase ${friendlyShopName(input)}!`);
     }
 
     let buyData:IMultiBuy;

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -901,26 +901,27 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
         let refunds = false;
         for (const shopItem in shopData){
             const key = shopItem as keyof typeof shopData;
-            if (shopData[key].refundable && player.shopUpgrades[key] > shopData[key].refundMinimumLevel){
+            const item = shopData[key];
+            if (item.refundable && player.shopUpgrades[key] > item.refundMinimumLevel){
                 refunds = true;
                 // Determines how many quarks one would not be refunded, based on minimum refund level
-                const doNotRefund = shopData[key].price * shopData[key].refundMinimumLevel +
-                                shopData[key].priceIncrease * (shopData[key].refundMinimumLevel) * (shopData[key].refundMinimumLevel - 1) / 2;
+                const doNotRefund = item.price * item.refundMinimumLevel +
+                                item.priceIncrease * (item.refundMinimumLevel) * (item.refundMinimumLevel - 1) / 2;
 
                 //Refunds Quarks based on the shop level and price vals
                 player.worlds.add(
-                    shopData[key].price * player.shopUpgrades[key] +
-                    shopData[key].priceIncrease * (player.shopUpgrades[key]) * (player.shopUpgrades[key] - 1) / 2
+                    item.price * player.shopUpgrades[key] +
+                    item.priceIncrease * (player.shopUpgrades[key]) * (player.shopUpgrades[key] - 1) / 2
                     - doNotRefund,
                     false
                 );
 
-                player.shopUpgrades[key] = shopData[key].refundMinimumLevel;
+                player.shopUpgrades[key] = item.refundMinimumLevel;
             }
         }
         if (refunds) {
             player.worlds.sub(15);
-        } else {
+        } else if (!ignoreBoolean && player.shopConfirmationToggle) {
             void Alert('Nothing to Refund!');
         }
         player.quarksThisSingularity = singularityQuarks;

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -897,14 +897,6 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
             const key = shopItem as keyof typeof shopData;
             if (shopData[key].refundable && player.shopUpgrades[key] > shopData[key].refundMinimumLevel){
 
-                if (shopData[key].tier === 'Reincarnation' && player.singularityCount >= 20) {
-                    continue;
-                }
-
-                if (shopData[key].tier === 'Ascension' && player.singularityCount >= 51) {
-                    continue;
-                }
-
                 // Determines how many quarks one would not be refunded, based on minimum refund level
                 const doNotRefund = shopData[key].price * shopData[key].refundMinimumLevel +
                                 shopData[key].priceIncrease * (shopData[key].refundMinimumLevel) * (shopData[key].refundMinimumLevel - 1) / 2;
@@ -922,11 +914,6 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
         }
         player.quarksThisSingularity = singularityQuarks;
     }
-    /*if (p && player.worlds >= 15) {
-        player.worlds -= 15;
-        Object.keys(shopData).forEach(function)
-        revealStuff();
-    }*/
 }
 
 export const getQuarkInvestment = (upgrade: ShopUpgradeNames) => {

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -888,12 +888,11 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
 
     if (p || ignoreBoolean) {
         const singularityQuarks = player.quarksThisSingularity;
-        player.worlds.sub(15);
-
+        let refunds = false;
         for (const shopItem in shopData){
             const key = shopItem as keyof typeof shopData;
             if (shopData[key].refundable && player.shopUpgrades[key] > shopData[key].refundMinimumLevel){
-
+                refunds = true;
                 // Determines how many quarks one would not be refunded, based on minimum refund level
                 const doNotRefund = shopData[key].price * shopData[key].refundMinimumLevel +
                                 shopData[key].priceIncrease * (shopData[key].refundMinimumLevel) * (shopData[key].refundMinimumLevel - 1) / 2;
@@ -908,6 +907,11 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
 
                 player.shopUpgrades[key] = shopData[key].refundMinimumLevel;
             }
+        }
+        if (refunds) {
+            player.worlds.sub(15);
+        } else {
+            void Alert('Nothing to Refund!');
         }
         player.quarksThisSingularity = singularityQuarks;
     }

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -825,9 +825,9 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
             buyCost = buyData.cost;
     }
 
-    const noRefunds = shopItem.refundable ? '' : ' REMINDER: No refunds!';
     const singular = shopItem.maxLevel === 1;
     const merch = buyAmount.toLocaleString() + (shopItem.type === shopUpgradeTypes.UPGRADE ? ' level' : ' vial') + (buyAmount === 1 ? '' : 's');
+    const noRefunds = shopItem.refundable ? '' : '\n\n\u26A0\uFE0F !! No Refunds !! \u26A0\uFE0F';
 
     if (player.shopBuyMaxToggle === 'ANY' && !singular) {
         const buyInput = await Prompt(`You can afford to purchase up to ${merch} of ${friendlyShopName(input)} for ${buyCost.toLocaleString()} Quarks. How many would you like to buy?${noRefunds}`);

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -1710,10 +1710,18 @@ const loadSynergy = async () => {
         } else {
             DOMCacheGetOrSet('toggleConfirmShop').textContent = 'Shop Confirmations: OFF'
         }
-        if (player.shopBuyMaxToggle) {
-            DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy Max: ON'
-        } else {
-            DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy Max: OFF'
+        switch (player.shopBuyMaxToggle) {
+            case false:
+                DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy: 1';
+                break;
+            case 'TEN':
+                DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy: 10';
+                break;
+            case true:
+                DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy: MAX';
+                break;
+            case 'ANY':
+                DOMCacheGetOrSet('toggleBuyMaxShop').textContent = 'Buy: ANY';
         }
         if (player.shopHideToggle) {
             DOMCacheGetOrSet('toggleHideShop').textContent = 'Hide Maxed: ON'

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -21,7 +21,7 @@ import { calculatePlatonicBlessings } from './PlatonicCubes';
 import { antSacrificePointsToMultiplier, autoBuyAnts, calculateCrumbToCoinExp } from './Ants';
 import { calculatetax } from './Tax';
 import { ascensionAchievementCheck, challengeachievementcheck, achievementaward, resetachievementcheck, buildingAchievementCheck } from './Achievements';
-import { reset, resetrepeat, singularity, updateSingularityAchievements, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens } from './Reset';
+import { reset, resetrepeat, singularity, updateSingularityAchievements, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens, updateSingularityMilestoneAwards } from './Reset';
 import type { TesseractBuildings} from './Buy';
 import { buyMax, buyAccelerator, buyMultiplier, boostAccelerator, buyCrystalUpgrades, buyParticleBuilding, getReductionValue, getCost, buyRuneBonusLevels, buyTesseractBuilding, calculateTessBuildingsInBudget } from './Buy';
 import { autoUpgrades } from './Automation';
@@ -1782,6 +1782,7 @@ const loadSynergy = async () => {
         calculateRuneLevels();
         resetHistoryRenderAllTables();
         updateSingularityAchievements();
+        updateSingularityMilestoneAwards(false);
     }
 
     updateAchievementBG();

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -732,11 +732,23 @@ export const toggleShopConfirmation = () => {
 
 export const toggleBuyMaxShop = () => {
     const el = DOMCacheGetOrSet('toggleBuyMaxShop')
-    el.textContent = player.shopBuyMaxToggle
-        ? 'Buy Max: OFF'
-        : 'Buy Max: ON';
-
-    player.shopBuyMaxToggle = !player.shopBuyMaxToggle;
+    switch (player.shopBuyMaxToggle) {
+        case false:
+            el.textContent = 'Buy: 10';
+            player.shopBuyMaxToggle = 'TEN';
+            break;
+        case 'TEN':
+            el.textContent = 'Buy: MAX';
+            player.shopBuyMaxToggle = true;
+            break;
+        case true:
+            el.textContent = 'Buy: ANY';
+            player.shopBuyMaxToggle = 'ANY';
+            break;
+        case 'ANY':
+            el.textContent = 'Buy: 1';
+            player.shopBuyMaxToggle = false;
+    }
 }
 
 export const toggleHideShop = () => {

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -730,23 +730,25 @@ export const toggleShopConfirmation = () => {
     player.shopConfirmationToggle = !player.shopConfirmationToggle;
 }
 
-export const toggleBuyMaxShop = () => {
+export const toggleBuyMaxShop = (event: MouseEvent) => {
     const el = DOMCacheGetOrSet('toggleBuyMaxShop')
+    if (event.shiftKey) {
+        el.textContent = 'Buy: ANY';
+        player.shopBuyMaxToggle = 'ANY';
+        return;
+    }
+    const suf = '<br><span style=\'color: gold; font-size:75%;\'>Shift-Click for Buy: Any</span>';
     switch (player.shopBuyMaxToggle) {
         case false:
-            el.textContent = 'Buy: 10';
+            el.innerHTML = `Buy: 10${suf}`;
             player.shopBuyMaxToggle = 'TEN';
             break;
         case 'TEN':
-            el.textContent = 'Buy: MAX';
+            el.innerHTML = `Buy: MAX${suf}`;
             player.shopBuyMaxToggle = true;
             break;
-        case true:
-            el.textContent = 'Buy: ANY';
-            player.shopBuyMaxToggle = 'ANY';
-            break;
-        case 'ANY':
-            el.textContent = 'Buy: 1';
+        default:
+            el.innerHTML = `Buy: 1${suf}`;
             player.shopBuyMaxToggle = false;
     }
 }

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -644,21 +644,6 @@ export const visualUpdateShop = () => {
             const singularityShopItems3 = document.getElementsByClassName('singularityShopUnlock3') as HTMLCollectionOf<HTMLElement>;
 
             if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopData[key].refundable) {
-                if (player.singularityCount >= 20) {
-                    shopData.offeringAuto.refundable = false;
-                    shopData.offeringEX.refundable = false;
-                    shopData.obtainiumAuto.refundable = false;
-                    shopData.obtainiumEX.refundable = false;
-                    shopData.antSpeed.refundable = false;
-                    shopData.cashGrab.refundable = false;
-                } else {
-                    shopData.offeringAuto.refundable = true;
-                    shopData.offeringEX.refundable = true;
-                    shopData.obtainiumAuto.refundable = true;
-                    shopData.obtainiumEX.refundable = true;
-                    shopData.antSpeed.refundable = true;
-                    shopData.cashGrab.refundable = true;
-                }
                 DOMCacheGetOrSet(`${key}Hide`).style.display = 'none';
             } else if (player.shopHideToggle && (player.shopUpgrades[key] < shopItem.maxLevel || shopData[key].refundable)) {
                 DOMCacheGetOrSet(`${key}Hide`).style.display = 'block'; //This checks if you have something you are not supposed to have or supposed to.

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -7,7 +7,7 @@ import { calculateSigmoidExponential, calculateMaxRunes, calculateRuneExpToLevel
 import { displayRuneInformation } from './Runes';
 import { showSacrifice } from './Ants';
 import { sumContents } from './Utility';
-import { getShopCosts, shopData, shopUpgradeTypes } from './Shop';
+import { getShopCosts, isShopUpgradeUnlocked, shopData, shopUpgradeTypes } from './Shop';
 import { quarkHandler } from './Quark';
 import type { Player, ZeroToFour } from './types/Synergism';
 import type { hepteractTypes } from './Hepteracts';
@@ -604,8 +604,14 @@ export const visualUpdateShop = () => {
                     el.textContent = `+${maxBuyablePotions} for ${format(getShopCosts(key)*maxBuyablePotions)} Quarks`;
             }
         }
-        // Ignore all consumables, to be handled above, since they're different.
+
         if (shopItem.type === shopUpgradeTypes.UPGRADE) {
+            if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopData[key].refundable) {
+                DOMCacheGetOrSet(`${key}Hide`).style.display = 'none';
+                continue;
+            } else {
+                DOMCacheGetOrSet(`${key}Hide`).style.display = isShopUpgradeUnlocked(key) ? 'block' : 'none';
+            }
             // Case: If max level is 1, then it can be considered a boolean "bought" or "not bought" item
             if (shopItem.maxLevel === 1) {
                 DOMCacheGetOrSet(`${key}Level`).textContent = player.shopUpgrades[key] >= shopItem.maxLevel ? 'Bought!' : 'Not Bought!';
@@ -629,123 +635,6 @@ export const visualUpdateShop = () => {
                 default:
                     buyData = calculateSummationNonLinear(player.shopUpgrades[key], shopData[key].price, +player.worlds, shopData[key].priceIncrease / shopData[key].price, buyMaxAmount);
                     DOMCacheGetOrSet(`${key}Button`).textContent = player.shopUpgrades[key] >= shopItem.maxLevel ? 'Maxed!' : `+ ${format(buyData.levelCanBuy - player.shopUpgrades[key], 0, true)} for ${format(buyData.cost)} Quarks`;
-            }
-
-            const shopUnlock1 = document.getElementsByClassName('chal8Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock2 = document.getElementsByClassName('chal9Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock3 = document.getElementsByClassName('ascendunlockShop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock4 = document.getElementsByClassName('chal11Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock5 = document.getElementsByClassName('chal12Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock6 = document.getElementsByClassName('chal13Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock7 = document.getElementsByClassName('chal14Shop') as HTMLCollectionOf<HTMLElement>;
-            const shopUnlock8 = document.getElementsByClassName('hepteractsShop') as HTMLCollectionOf<HTMLElement>;
-            const singularityShopItems = document.getElementsByClassName('singularityShopUnlock') as HTMLCollectionOf<HTMLElement>;
-            const singularityShopItems2 = document.getElementsByClassName('singularityShopUnlock2') as HTMLCollectionOf<HTMLElement>;
-            const singularityShopItems3 = document.getElementsByClassName('singularityShopUnlock3') as HTMLCollectionOf<HTMLElement>;
-
-            if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopData[key].refundable) {
-                DOMCacheGetOrSet(`${key}Hide`).style.display = 'none';
-            } else if (player.shopHideToggle && (player.shopUpgrades[key] < shopItem.maxLevel || shopData[key].refundable)) {
-                DOMCacheGetOrSet(`${key}Hide`).style.display = 'block'; //This checks if you have something you are not supposed to have or supposed to.
-                for (const i of Array.from(shopUnlock1)) {
-                    if (i.style.display === 'block' && player.achievements[127] != 1) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock2)) {
-                    if (i.style.display === 'block' && player.achievements[134] != 1) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock3)) {
-                    if (i.style.display === 'block' && player.ascensionCount === 0) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock4)) {
-                    if (i.style.display === 'block' && player.challengecompletions[11] === 0) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock5)) {
-                    if (i.style.display === 'block' && player.challengecompletions[12] === 0) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock6)) {
-                    if (i.style.display === 'block' && player.challengecompletions[13] === 0) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock7)) {
-                    if (i.style.display === 'block' && player.challengecompletions[14] === 0) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(shopUnlock8)) {
-                    if (i.style.display === 'block' && player.challenge15Exponent < 1e15) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(singularityShopItems)) {
-                    if (i.style.display === 'block' && !player.singularityUpgrades.wowPass.getEffect().bonus) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(singularityShopItems2)) {
-                    if (i.style.display === 'block' && !player.singularityUpgrades.wowPass2.getEffect().bonus) {
-                        i.style.display = 'none';
-                    }
-                }
-                for (const i of Array.from(singularityShopItems3)) {
-                    if (i.style.display === 'block' && !player.singularityUpgrades.wowPass3.getEffect().bonus) {
-                        i.style.display = 'none';
-                    }
-                }
-            } else if (!player.shopHideToggle) {
-                DOMCacheGetOrSet('instantChallengeHide').style.display = 'block';
-                DOMCacheGetOrSet('calculatorHide').style.display = 'block';
-                if (shopData.offeringAuto.refundable === false) {
-                    DOMCacheGetOrSet('offeringAutoHide').style.display = 'block';
-                    DOMCacheGetOrSet('offeringEXHide').style.display = 'block';
-                    DOMCacheGetOrSet('obtainiumAutoHide').style.display = 'block';
-                    DOMCacheGetOrSet('obtainiumEXHide').style.display = 'block';
-                    DOMCacheGetOrSet('antSpeedHide').style.display = 'block';
-                    DOMCacheGetOrSet('cashGrabHide').style.display = 'block';
-                }
-                for (const i of Array.from(shopUnlock1)) {
-                    i.style.display = player.achievements[127] === 1 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock2)) {
-                    i.style.display = player.achievements[134] === 1 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock3)) {
-                    i.style.display = player.ascensionCount > 0 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock4)) {
-                    i.style.display = player.challengecompletions[11] > 0 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock5)) {
-                    i.style.display = player.challengecompletions[12] > 0 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock6)) {
-                    i.style.display = player.challengecompletions[13] > 0 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock7)) {
-                    i.style.display = player.challengecompletions[14] > 0 ? 'block' : 'none';
-                }
-                for (const i of Array.from(shopUnlock8)) {
-                    i.style.display = player.challenge15Exponent >= 1e15 ? 'block' : 'none';
-                }
-                for (const i of Array.from(singularityShopItems)) {
-                    i.style.display = player.singularityUpgrades.wowPass.getEffect().bonus ? 'block' : 'none';
-                }
-                for (const i of Array.from(singularityShopItems2)) {
-                    i.style.display = player.singularityUpgrades.wowPass2.getEffect().bonus ? 'block' : 'none';
-                }
-                for (const i of Array.from(singularityShopItems3)) {
-                    i.style.display = player.singularityUpgrades.wowPass3.getEffect().bonus ? 'block' : 'none';
-                }
             }
         }
     }

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -591,7 +591,7 @@ export const visualUpdateShop = () => {
         const shopItem = shopData[key]
 
         if (shopItem.type === shopUpgradeTypes.CONSUMABLE) {
-            const maxBuyablePotions = Math.min(Math.floor(Number(player.worlds)/getShopCosts(key)),shopData[key].maxLevel-player.shopUpgrades[key]);
+            const maxBuyablePotions = Math.min(Math.floor(Number(player.worlds)/getShopCosts(key)),shopItem.maxLevel-player.shopUpgrades[key]);
             const el = DOMCacheGetOrSet(`buy${key.toLowerCase()}`);
             switch (player.shopBuyMaxToggle) {
                 case false:
@@ -606,7 +606,7 @@ export const visualUpdateShop = () => {
         }
 
         if (shopItem.type === shopUpgradeTypes.UPGRADE) {
-            if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopData[key].refundable) {
+            if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopItem.refundable) {
                 DOMCacheGetOrSet(`${key}Hide`).style.display = 'none';
                 continue;
             } else {
@@ -621,7 +621,7 @@ export const visualUpdateShop = () => {
             }
             // Handles Button - max level needs no price indicator, otherwise it's necessary
 
-            const buyMaxAmount = shopData[key].maxLevel - player.shopUpgrades[key];
+            const buyMaxAmount = shopItem.maxLevel - player.shopUpgrades[key];
             let buyData:IMultiBuy;
 
             switch (player.shopBuyMaxToggle) {
@@ -629,11 +629,11 @@ export const visualUpdateShop = () => {
                     DOMCacheGetOrSet(`${key}Button`).textContent = player.shopUpgrades[key] >= shopItem.maxLevel ? 'Maxed!' : `Upgrade for ${format(getShopCosts(key))}  Quarks`;
                     break;
                 case 'TEN':
-                    buyData = calculateSummationNonLinear(player.shopUpgrades[key], shopData[key].price, +player.worlds, shopData[key].priceIncrease / shopData[key].price, Math.min(10,buyMaxAmount));
+                    buyData = calculateSummationNonLinear(player.shopUpgrades[key], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, Math.min(10,buyMaxAmount));
                     DOMCacheGetOrSet(`${key}Button`).textContent = player.shopUpgrades[key] >= shopItem.maxLevel ? 'Maxed!' : `+ ${format(buyData.levelCanBuy - player.shopUpgrades[key], 0, true)} for ${format(buyData.cost)} Quarks`;
                     break;
                 default:
-                    buyData = calculateSummationNonLinear(player.shopUpgrades[key], shopData[key].price, +player.worlds, shopData[key].priceIncrease / shopData[key].price, buyMaxAmount);
+                    buyData = calculateSummationNonLinear(player.shopUpgrades[key], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, buyMaxAmount);
                     DOMCacheGetOrSet(`${key}Button`).textContent = player.shopUpgrades[key] >= shopItem.maxLevel ? 'Maxed!' : `+ ${format(buyData.levelCanBuy - player.shopUpgrades[key], 0, true)} for ${format(buyData.cost)} Quarks`;
             }
         }

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -373,7 +373,7 @@ export interface Player {
         shopImprovedDaily4: number
     },
     shopConfirmationToggle: boolean,
-    shopBuyMaxToggle: boolean,
+    shopBuyMaxToggle: boolean | 'TEN' | 'ANY',
     shopHideToggle: boolean,
 
     autoSacrificeToggle: boolean,


### PR DESCRIPTION
Quark Shop Enhancement:
Took the idea from buy-many-potions and applied it to the Quark Shop in whole.
Changed Buy Max toggle to Buy: {1 | 10 | Max | Any} on all upgrades/potions
Buy 10 feels very nice; Buy ANY is maybe for the more compulsive among us.
Keeps httpsnet's change disabling warning on nonrefundable AND buy 1.

Room for improvement:
Does not honor the singularity perk change to nonrefundable of the various Reincarnation/Ascension level purchases, but they are so cheap at that point that it's meaningless.

It's possible that it's too annoying to click 4 times to cycle through the toggle; but at least clicking 2 times gets you from 1 to Max and Max to 1, which mirrors the old behavior. If there's enough demand it might be enough to drop the cycle to {1 | 10 | Max} when clicking on the left 80% of the button, and have to click on the text indicated ANY section to enter that mode. Mock-up below.
```
___________________
|             | A |
|  Buy: 10    | N |
|_____________| Y |

```
Honestly don't think we spend enough time respecing shop to make the clicks an issue, especially with how much Buy 10 saves. My slight level of annoyance could just be from the amount of time I spent testing in shop at various quark levels.

Changed 'no refund' shop alert to be a little more obvious, as a separate commit in case you want to cherry pick. Although it's been in Unicode since 2010, supported by javascript, and fails gracefully.
⚠️!! No Refunds !!⚠️