### PR TITLE
Fix autoTess amount incorrectly showing

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -173,6 +173,9 @@ export const updateAutoReset = (i: number) => {
 export const updateTesseractAutoBuyAmount = () => {
     let value = Math.floor(parseFloat((DOMCacheGetOrSet('tesseractAmount') as HTMLInputElement).value)) || 0;
     if (player.resettoggle4 === 2) { // Auto mode: PERCENTAGE
+        if (value > 100) {
+            (DOMCacheGetOrSet('tesseractAmount') as HTMLInputElement).value = '100';
+        }
         value = Math.min(value, 100);
     }
     player.tesseractAutoBuyerAmount = Math.max(value, 0);


### PR DESCRIPTION
This PR prevents the text box from showing a different value than the text in percent mode. Currently, when you enter a number > 100 the text below the box corrects to 100% while the text in the box stays at the entered value. This PR will set the text in the box to 100 if the text entered is >100 and it is toggled to % mode. This will help prevent confusion when people swap between % and amount modes.
This image shows the text as 100% but the box shows 1e3.
![image](https://user-images.githubusercontent.com/78285417/184552451-aebc54e9-3ee0-4342-b154-c1b083aa80b2.png)
