### PR TITLE
Reopening old PR for hide toggle

### DIFF
--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -231,6 +231,31 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.shopUpgrades.tesseractToQuark = 0;
         player.shopUpgrades.hypercubeToQuark = 0;
     }
+    for (const i in shopData) { //Since you cant increase SingularityCount without calling it
+        if (shopData[i as keyof typeof shopData].tier === 'Reincarnation') {
+            if (player.singularityCount >= 20) {
+                shopData[i as keyof typeof shopData].refundable = false;
+            } else {
+                shopData.offeringAuto.refundable = true;
+                shopData.offeringEX.refundable = true;
+                shopData.obtainiumAuto.refundable = true;
+                shopData.obtainiumEX.refundable = true;
+                shopData.antSpeed.refundable = true;
+                shopData.cashGrab.refundable = true;
+            }
+        } else if (shopData[i as keyof typeof shopData].tier === 'Ascension') {
+            if (player.singularityCount >= 51) {
+                shopData[i as keyof typeof shopData].refundable = false;
+            } else {
+                shopData.seasonPass.refundable = true;
+                shopData.seasonPass2.refundable = true;
+                shopData.seasonPass3.refundable = true;
+                shopData.seasonPassY.refundable = true;
+                shopData.chronometer.refundable = true;
+                shopData.chronometer2.refundable = true;
+            }
+        }
+    }
     if (data.cubeUpgrades == null || data.cubeUpgrades[19] === 0 || player.cubeUpgrades[19] === 0) {
         for (let i = 121; i <= 125; i++) {
             player.upgrades[i] = 0

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -900,15 +900,6 @@ export const resetShopUpgrades = async (ignoreBoolean = false) => {
         for (const shopItem in shopData){
             const key = shopItem as keyof typeof shopData;
             if (shopData[key].refundable && player.shopUpgrades[key] > shopData[key].refundMinimumLevel){
-
-                if (shopData[key].tier === 'Reincarnation' && player.singularityCount >= 20) {
-                    continue;
-                }
-
-                if (shopData[key].tier === 'Ascension' && player.singularityCount >= 51) {
-                    continue;
-                }
-
                 // Determines how many quarks one would not be refunded, based on minimum refund level
                 const doNotRefund = shopData[key].price * shopData[key].refundMinimumLevel +
                                 shopData[key].priceIncrease * (shopData[key].refundMinimumLevel) * (shopData[key].refundMinimumLevel - 1) / 2;

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -621,25 +621,9 @@ export const visualUpdateShop = () => {
             const singularityShopItems = document.getElementsByClassName('singularityShopUnlock') as HTMLCollectionOf<HTMLElement>;
             const singularityShopItems2 = document.getElementsByClassName('singularityShopUnlock2') as HTMLCollectionOf<HTMLElement>;
             const singularityShopItems3 = document.getElementsByClassName('singularityShopUnlock3') as HTMLCollectionOf<HTMLElement>;
-
-            if (player.shopHideToggle && player.shopUpgrades[key] >= shopItem.maxLevel && !shopData[key].refundable) {
-                if (player.singularityCount >= 20) {
-                    shopData.offeringAuto.refundable = false;
-                    shopData.offeringEX.refundable = false;
-                    shopData.obtainiumAuto.refundable = false;
-                    shopData.obtainiumEX.refundable = false;
-                    shopData.antSpeed.refundable = false;
-                    shopData.cashGrab.refundable = false;
-                } else {
-                    shopData.offeringAuto.refundable = true;
-                    shopData.offeringEX.refundable = true;
-                    shopData.obtainiumAuto.refundable = true;
-                    shopData.obtainiumEX.refundable = true;
-                    shopData.antSpeed.refundable = true;
-                    shopData.cashGrab.refundable = true;
-                }
+            if (player.shopHideToggle && player.shopUpgrades[key] === shopItem.maxLevel && !shopItem.refundable) {
                 DOMCacheGetOrSet(`${key}Hide`).style.display = 'none';
-            } else if (player.shopHideToggle && (player.shopUpgrades[key] < shopItem.maxLevel || shopData[key].refundable)) {
+            } else if (player.shopHideToggle && (player.shopUpgrades[key] !== shopItem.maxLevel || shopItem.refundable)) {
                 DOMCacheGetOrSet(`${key}Hide`).style.display = 'block'; //This checks if you have something you are not supposed to have or supposed to.
                 for (const i of Array.from(shopUnlock1)) {
                     if (i.style.display === 'block' && player.achievements[127] != 1) {
@@ -704,8 +688,6 @@ export const visualUpdateShop = () => {
                     DOMCacheGetOrSet('offeringEXHide').style.display = 'block';
                     DOMCacheGetOrSet('obtainiumAutoHide').style.display = 'block';
                     DOMCacheGetOrSet('obtainiumEXHide').style.display = 'block';
-                    DOMCacheGetOrSet('antSpeedHide').style.display = 'block';
-                    DOMCacheGetOrSet('cashGrabHide').style.display = 'block';
                 }
                 for (const i of Array.from(shopUnlock1)) {
                     i.style.display = player.achievements[127] === 1 ? 'block' : 'none';


### PR DESCRIPTION
Small optimization, remove no longer usefull check
Better perfomance will be if to just write for each key: refundable = false; But this way is easier to add extra's
4x 'as keyof typeof shopData' is auto removed when converted to js, so doesn't matter if ugly