### PR TITLE
Fix for Singularity History

### DIFF
--- a/index.html
+++ b/index.html
@@ -3267,15 +3267,17 @@ $STAGE$ for synergism stage" style="color: white"></p>
         </div>
     </div>
     <div class="subtabContent subtabDisplayFlex historySubTab" id="singularityHistorySubTab" alt="singularityHistorySubTab" label="singularityHistorySubTab">
-        <div id="historySingularity" alt="historySingularity" label="historySingularity">
-            <div>
+        <div class="scrollbarX">
+            <div id="historySingularity" alt="historySingularity" label="historySingularity">
+                <div>
                 <p style="float: left">Your last singularities got you the following:</p>
-            </div>
-            <div class="historyTableWrap" style="clear: both">
-                <table id="historySingularityTable" alt="historySingularityTable" label="historySingularityTable">
-                    <tbody></tbody>
-                </table>
-            </div>
+                 </div>
+                 <div class="historyTableWrap" style="clear: both">
+                    <table id="historySingularityTable" alt="historySingularityTable" label="historySingularityTable">
+                        <tbody></tbody>
+                    </table>
+                </div>
+             </div>
         </div>
     </div>
     <div class="subtabContent subtabDisplayFlex" id="hotkeys" alt="hotkeys" label="hotkeys">


### PR DESCRIPTION
The scrollbarX Div class was forgotten about on the Singularity History page. 
Adding it back in in fixes the misalignment issue that page has had since its inclusion. 
This is a very minor change to the HTML file, I believe merge conflicts should be the only primary concern here?
Hopefully so anyways.