### PR TITLE
Penalty Difficulty Indicators

### DIFF
--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -1475,7 +1475,7 @@ export const calculateEffectiveSingularities = (singularityCount: number = playe
 export const calculateNextSpike = (singularityCount: number = player.singularityCount): number => {
     const singularityPenaltyThreshold = [11, 26, 37, 51, 101, 151, 250];
     for (const sing of singularityPenaltyThreshold) {
-        if (sing >= singularityCount) {
+        if (sing > singularityCount) {
             return sing;
         }
     }

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -21,7 +21,7 @@ export const updateSingularityPenalties = (): void => {
                  Cube Upgrade Costs (Excluding Cookies) are multiplied by ${format(calculateSingularityDebuff('Cube Upgrades', singularityCount), 2, true)}.
                  ${platonic}
                  ${hepteract}
-                 Your penalties will sharply increase in <span style="color: red"> Singularity ${format(calculateNextSpike(player.singularityCount), 0, true)}</span>.
+                 Your penalties will ${singularityCount >= 250 ? 'now smoothly increase forever.' : `sharply increase in <span style="color: red"> Singularity ${format(calculateNextSpike(player.singularityCount), 0, true)}</span>.`}
                  <span style='color: ${color}'>Antiquities of Ant God is ${(player.runelevels[6] > 0) ? '' : 'NOT'} purchased. Penalties are ${(player.runelevels[6] > 0) ? '' : 'NOT'} dispelled!</span>`
 
     DOMCacheGetOrSet('singularityPenaltiesMultiline').innerHTML = str;
@@ -1473,30 +1473,13 @@ export const calculateEffectiveSingularities = (singularityCount: number = playe
     return effectiveSingularities
 }
 export const calculateNextSpike = (singularityCount: number = player.singularityCount): number => {
-    let PenaltyArray = 11;
-    if (singularityCount > 10) {
-        PenaltyArray = 26
+    const singularityPenaltyThreshold = [11, 26, 37, 51, 101, 151, 250];
+    for (const sing of singularityPenaltyThreshold) {
+        if (sing >= singularityCount) {
+            return sing;
+        }
     }
-    if (singularityCount > 25) {
-        PenaltyArray = 37
-    }
-    if (singularityCount > 36) {
-        PenaltyArray = 51
-    }
-    if (singularityCount > 50) {
-        PenaltyArray = 101
-    }
-    if (singularityCount > 100) {
-        PenaltyArray = 151
-    }
-    if (singularityCount > 150) {
-        PenaltyArray = 250
-    }
-    if (singularityCount === 250) {
-        PenaltyArray = 1337
-    }
-
-    return PenaltyArray
+    return -1;
 }
 export const calculateSingularityDebuff = (debuff: SingularityDebuffs, singularityCount: number=player.singularityCount) => {
     if (singularityCount === 0) {

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -9,8 +9,8 @@ import { toOrdinal } from './Utility'
 export const updateSingularityPenalties = (): void => {
     const singularityCount = player.singularityCount;
     const color = player.runelevels[6] > 0 ? 'green' : 'red';
-    const platonic = (singularityCount > 36) ? `Platonic Upgrade costs are multiplied by ${format(calculateSingularityDebuff('Platonic Costs', singularityCount), 2, true)}.` : '';
-    const hepteract = (singularityCount > 50) ? `Hepteract Forge costs are multiplied by ${format(calculateSingularityDebuff('Hepteract Costs', singularityCount), 2, true)}.` : '';
+    const platonic = (singularityCount > 36) ? `Platonic Upgrade costs are multiplied by ${format(calculateSingularityDebuff('Platonic Costs', singularityCount), 2, true)}.` : '<span style="color: grey">???????? ??????? ????? ??? ?????????? ?? ???</span> <span style="color: red">(Sing 37)</span>';
+    const hepteract = (singularityCount > 50) ? `Hepteract Forge costs are multiplied by ${format(calculateSingularityDebuff('Hepteract Costs', singularityCount), 2, true)}.` : '<span style="color: grey">????????? ????? ????? ??? ?????????? ?? ???</span> <span style="color: red">(Sing 51)</span>';
     const str = getSingularityOridnalText(singularityCount) +
                 `<br>Global Speed is divided by ${format(calculateSingularityDebuff('Global Speed', singularityCount), 2, true)}.
                  Ascension Speed is divided by ${format(calculateSingularityDebuff('Ascension Speed', singularityCount), 2, true)}
@@ -21,7 +21,8 @@ export const updateSingularityPenalties = (): void => {
                  Cube Upgrade Costs (Excluding Cookies) are multiplied by ${format(calculateSingularityDebuff('Cube Upgrades', singularityCount), 2, true)}.
                  ${platonic}
                  ${hepteract}
-                 <br><span style='color: ${color}'>Antiquities of Ant God is ${(player.runelevels[6] > 0) ? '' : 'NOT'} purchased. Penalties are ${(player.runelevels[6] > 0) ? '' : 'NOT'} dispelled!</span>`
+                 Your penalties will sharply increase in <span style="color: red"> Singularity ${format(calculateNextSpike(player.singularityCount), 0, true)}</span>.
+                 <span style='color: ${color}'>Antiquities of Ant God is ${(player.runelevels[6] > 0) ? '' : 'NOT'} purchased. Penalties are ${(player.runelevels[6] > 0) ? '' : 'NOT'} dispelled!</span>`
 
     DOMCacheGetOrSet('singularityPenaltiesMultiline').innerHTML = str;
 }
@@ -1471,7 +1472,32 @@ export const calculateEffectiveSingularities = (singularityCount: number = playe
 
     return effectiveSingularities
 }
+export const calculateNextSpike = (singularityCount: number = player.singularityCount): number => {
+    let PenaltyArray = 11;
+    if (singularityCount > 10) {
+        PenaltyArray = 26
+    }
+    if (singularityCount > 25) {
+        PenaltyArray = 37
+    }
+    if (singularityCount > 36) {
+        PenaltyArray = 51
+    }
+    if (singularityCount > 50) {
+        PenaltyArray = 101
+    }
+    if (singularityCount > 100) {
+        PenaltyArray = 151
+    }
+    if (singularityCount > 150) {
+        PenaltyArray = 250
+    }
+    if (singularityCount === 250) {
+        PenaltyArray = 1337
+    }
 
+    return PenaltyArray
+}
 export const calculateSingularityDebuff = (debuff: SingularityDebuffs, singularityCount: number=player.singularityCount) => {
     if (singularityCount === 0) {
         return 1


### PR DESCRIPTION
Added a few indicators to the Penalty tab to indicate difficulty spikes! 
In specific, there are indicators for: 
When a new Penalty will be unlocked.
When your effective singularity count will be sharply increased.

These changes are meant to help players more easily understand when difficulty spikes are to be expected so that they can better prepare for them and not get blindsided by them unexpectedly.

New penalty unlocks are currently indicated via the following message, replacing the current empty space with:
"???????? ??????? ????? ??? ?????????? ?? ??? (Sing X)" 
This can easily be replaced with something like "A new penalty unlocks in Singularity X" if it is so wished.

The penalty difficulty spikes are indicated via an additional line of text that reads:
"Your penalties will sharply increase in Singularity X"
I am not a good programmer so I believe this could be more elegantly implemented but my baseline can be worked off of. 

Example Image of these changes in action:

![unknown (4)](https://user-images.githubusercontent.com/32188067/193432965-8117358f-3621-4e31-914c-670850c22124.png)
