### PR TITLE
Added auto potion toggle and buy

### DIFF
--- a/index.html
+++ b/index.html
@@ -3307,12 +3307,14 @@ $STAGE$ for synergism stage" style="color: white"></p>
                             <p id="offeringpotionowned" alt="offeringpotionowned" label="offeringpotionowned">Own: 2222</p>
                             <button class="consumablebutton" id="buyofferingpotion" alt="buyofferingpotion" label="buyofferingpotion" style="border: 2px solid white">Buy: 100 Quarks Each</button>
                             <button class="consumablebutton" id="useofferingpotion" alt="useofferingpotion" label="useofferingpotion" style="border: 2px solid orange">CONSUME</button>
+                            <button class="consumablebutton auto" id="toggle42" alt="toggle42" label="toggle42" toggleid="42" alt="42" label="42" format="Auto Use: $" style="border:2px solid red" title="Automatically consumes when toggled on&#013When the amount is insufficient, it will autobuy">Auto Use: OFF</button>
                         </div>
                         <div id="obtainiumPotionHide">
                             <img id="obtainiumPotions" alt="obtainiumPotions" label="obtainiumPotions" src="Pictures/obtainium potion.png" loading="lazy">
                             <p id="obtainiumpotionowned" alt="obtainiumpotionowned" label="obtainiumpotionowned">Own: 0</p>
                             <button class="consumablebutton" id="buyobtainiumpotion" alt="buyobtainiumpotion" label="buyobtainiumpotion" style="border: 2px solid white">Buy: 100 Quarks Each</button>
                             <button class="consumablebutton" id="useobtainiumpotion" alt="useobtainiumpotion" label="useobtainiumpotion" style="border: 2px solid blue">CONSUME</button>
+                            <button class="consumablebutton auto" id="toggle43" alt="toggle43" label="toggle43" toggleid="43" alt="43" label="43" format="Auto Use: $" style="border:2px solid red" title="Automatically consumes when toggled on&#013When the amount is insufficient, it will autobuy">Auto Use: OFF</button>
                         </div>
                     </div>
                     <div id="quarksDisplay" alt="quarksDisplay" label="quarksDisplay">

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -7,7 +7,7 @@ import { visualUpdateOcteracts, visualUpdateResearch } from './UpdateVisuals';
 import { Globals as G } from './Variables';
 import { buyAllBlessings } from './Buy';
 import { buyAllTalismanResources } from './Talismans'
-import { useConsumable } from './Shop';
+import { useConsumable, autoBuyConsumable, shopData } from './Shop';
 
 type TimerInput = 'prestige' | 'transcension' | 'reincarnation' | 'ascension' |
                   'quarks' | 'goldenQuarks' | 'singularity' | 'octeracts' |
@@ -90,13 +90,33 @@ export const addTimers = (input: TimerInput, time = 0) => {
                 if (player.autoPotionTimer >= timerThreshold) {
                     const amountOfPotions = (player.autoPotionTimer - (player.autoPotionTimer % timerThreshold)) / timerThreshold
                     player.autoPotionTimer %= timerThreshold
-                    player.shopUpgrades.offeringPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
-                    player.shopUpgrades.obtainiumPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
-                    void useConsumable('obtainiumPotion', true, amountOfPotions)
-                    void useConsumable('offeringPotion', true, amountOfPotions)
-                }
 
+                    if (player.toggles[42] === true) {
+                        if (player.shopUpgrades.offeringPotion >= amountOfPotions) {
+                            void useConsumable('offeringPotion', true, amountOfPotions)
+                        } else {
+                            autoBuyConsumable('offeringPotion')
+                        }
+                    }
+                    player.shopUpgrades.offeringPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                    if (player.shopUpgrades.offeringPotion > shopData.offeringPotion.maxLevel) {
+                        player.shopUpgrades.offeringPotion = shopData.offeringPotion.maxLevel
+                    }
+
+                    if (player.toggles[43] === true) {
+                        if (player.shopUpgrades.obtainiumPotion >= amountOfPotions) {
+                            void useConsumable('obtainiumPotion', true, amountOfPotions)
+                        } else {
+                            autoBuyConsumable('obtainiumPotion')
+                        }
+                    }
+                    player.shopUpgrades.obtainiumPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                    if (player.shopUpgrades.obtainiumPotion > shopData.obtainiumPotion.maxLevel) {
+                        player.shopUpgrades.obtainiumPotion = shopData.obtainiumPotion.maxLevel
+                    }
+                }
             }
+            break;
         }
     }
 }

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -861,6 +861,20 @@ export const buyConsumable = async (input: ShopUpgradeNames) => {
     }
 }
 
+export const autoBuyConsumable = (input: ShopUpgradeNames) => {
+    const maxBuyablePotions = Math.floor(Math.min(Number(player.worlds) / 100, Math.min(shopData[input].maxLevel - player.shopUpgrades[input], Math.pow(player.highestSingularityCount, 2) * 100)));
+
+    if (shopData[input].maxLevel <= player.shopUpgrades[input]) {
+        return;
+    }
+    if (maxBuyablePotions <= 0) {
+        return;
+    }
+
+    player.worlds.sub(100 * maxBuyablePotions);
+    player.shopUpgrades[input] += maxBuyablePotions;
+}
+
 export const useConsumable = async (input: ShopUpgradeNames, automatic = false, used = 1) => {
 
     const p = (player.shopConfirmationToggle && !automatic)
@@ -874,13 +888,13 @@ export const useConsumable = async (input: ShopUpgradeNames, automatic = false, 
                            used;
 
         if (input === 'offeringPotion') {
-            if (player.shopUpgrades.offeringPotion > 0) {
+            if (player.shopUpgrades.offeringPotion >= used) {
                 player.shopUpgrades.offeringPotion -= used;
                 player.runeshards += Math.floor(7200 * player.offeringpersecond * calculateTimeAcceleration() * multiplier)
                 player.runeshards = Math.min(1e300, player.runeshards)
             }
         } else if (input === 'obtainiumPotion') {
-            if (player.shopUpgrades.obtainiumPotion > 0) {
+            if (player.shopUpgrades.obtainiumPotion >= used) {
                 player.shopUpgrades.obtainiumPotion -= used;
                 player.researchPoints += Math.floor(7200 * player.maxobtainiumpersecond * calculateTimeAcceleration() * multiplier)
                 player.researchPoints = Math.min(1e300, player.researchPoints)
@@ -888,6 +902,7 @@ export const useConsumable = async (input: ShopUpgradeNames, automatic = false, 
         }
     }
 }
+
 export const resetShopUpgrades = async (ignoreBoolean = false) => {
     let p = false
     if (!ignoreBoolean) {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -293,7 +293,9 @@ export const player: Player = {
         38: false,
         39: true,
         40: true,
-        41: true
+        41: true,
+        42: false,
+        43: false
     },
 
     challengecompletions: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -487,7 +487,9 @@ export const revealStuff = () => {
         'toggle38': player.singularityCount > 0, // Researchs Hover to Buy
         'toggle39': player.unlocks.prestige, // Hotkeys
         'toggle40': player.unlocks.prestige, // Number Hotkeys
-        'toggle41': player.challengecompletions[11] > 0 // Loadouts Notifx
+        'toggle41': player.challengecompletions[11] > 0, // Loadouts Notifx
+        'toggle42': player.highestSingularityCount >= 6, // Potion Autogenerator for Offering Potions
+        'toggle43': player.highestSingularityCount >= 6 // Potion Autogenerator for Obtainium Potions
     }
 
     Object.keys(automationUnlocks).forEach(key => {


### PR DESCRIPTION
This PR adds toggle and buy auto potion consumption
![20221007100753](https://user-images.githubusercontent.com/87951297/194465788-169e6168-0f55-4392-be66-01b4b60886dc.png)

If automatic consumption is enabled, it will automatically buy when the number you have is insufficient.
The auto buy count is Math.pow(player.highestSingularityCount, 2) * 100. Max out at Sing 100 or higher. This takes into account that people with less Sing have less Quarks.
Disabling automatic consumption does not disable potion generation. In this case, inventory will increase.