### PR TITLE
Autopot patch

### DIFF
--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -7,7 +7,7 @@ import { visualUpdateOcteracts, visualUpdateResearch } from './UpdateVisuals';
 import { Globals as G } from './Variables';
 import { buyAllBlessings } from './Buy';
 import { buyAllTalismanResources } from './Talismans'
-import { useConsumable, autoBuyConsumable, shopData } from './Shop';
+import { useConsumable } from './Shop';
 
 type TimerInput = 'prestige' | 'transcension' | 'reincarnation' | 'ascension' |
                   'quarks' | 'goldenQuarks' | 'singularity' | 'octeracts' |
@@ -90,29 +90,13 @@ export const addTimers = (input: TimerInput, time = 0) => {
                 if (player.autoPotionTimer >= timerThreshold) {
                     const amountOfPotions = (player.autoPotionTimer - (player.autoPotionTimer % timerThreshold)) / timerThreshold
                     player.autoPotionTimer %= timerThreshold
-
                     if (player.toggles[42] === true) {
-                        if (player.shopUpgrades.offeringPotion >= amountOfPotions) {
-                            void useConsumable('offeringPotion', true, amountOfPotions)
-                        } else {
-                            autoBuyConsumable('offeringPotion')
-                        }
+                        player.shopUpgrades.offeringPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                        void useConsumable('offeringPotion', true, amountOfPotions)
                     }
-                    player.shopUpgrades.offeringPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
-                    if (player.shopUpgrades.offeringPotion > shopData.offeringPotion.maxLevel) {
-                        player.shopUpgrades.offeringPotion = shopData.offeringPotion.maxLevel
-                    }
-
                     if (player.toggles[43] === true) {
-                        if (player.shopUpgrades.obtainiumPotion >= amountOfPotions) {
-                            void useConsumable('obtainiumPotion', true, amountOfPotions)
-                        } else {
-                            autoBuyConsumable('obtainiumPotion')
-                        }
-                    }
-                    player.shopUpgrades.obtainiumPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
-                    if (player.shopUpgrades.obtainiumPotion > shopData.obtainiumPotion.maxLevel) {
-                        player.shopUpgrades.obtainiumPotion = shopData.obtainiumPotion.maxLevel
+                        player.shopUpgrades.obtainiumPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                        void useConsumable('obtainiumPotion', true, amountOfPotions)
                     }
                 }
             }

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -7,7 +7,7 @@ import { visualUpdateOcteracts, visualUpdateResearch } from './UpdateVisuals';
 import { Globals as G } from './Variables';
 import { buyAllBlessings } from './Buy';
 import { buyAllTalismanResources } from './Talismans'
-import { useConsumable } from './Shop';
+import { useConsumable, shopData} from './Shop';
 
 type TimerInput = 'prestige' | 'transcension' | 'reincarnation' | 'ascension' |
                   'quarks' | 'goldenQuarks' | 'singularity' | 'octeracts' |
@@ -92,10 +92,16 @@ export const addTimers = (input: TimerInput, time = 0) => {
                     player.autoPotionTimer %= timerThreshold
                     if (player.toggles[42] === true) {
                         player.shopUpgrades.offeringPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                        if (player.shopUpgrades.offeringPotion > shopData.offeringPotion.maxLevel) {
+                            player.shopUpgrades.offeringPotion = shopData.offeringPotion.maxLevel
+                        }
                         void useConsumable('offeringPotion', true, amountOfPotions)
                     }
                     if (player.toggles[43] === true) {
                         player.shopUpgrades.obtainiumPotion += amountOfPotions * +player.octeractUpgrades.octeractAutoPotionEfficiency.getEffect().bonus / 5
+                        if (player.shopUpgrades.obtainiumPotion > shopData.obtainiumPotion.maxLevel) {
+                            player.shopUpgrades.obtainiumPotion = shopData.obtainiumPotion.maxLevel
+                        }
                         void useConsumable('obtainiumPotion', true, amountOfPotions)
                     }
                 }


### PR DESCRIPTION
Removes the surprising new autobuy feature. Potions will only (attempt to) auto-consume and auto-generate if the new shop toggles are on. The guard in Shop.ts:useConsumable() will prevent consuming more potions than are available.

If potions should generate regardless of the status of the toggle, lines 94-97 and 101-104 can be moved outside of the conditionals they are in.