### PR TITLE
Fix the incomplete reset bug on entering a new singularity

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3128,6 +3128,7 @@ export const resetCheck = async (i: resetNames, manual = true, leaving = false):
         } else {
             await singularity();
             canSave = true;
+            await saveSynergy();
             return Alert('Welcome to Singularity #' + format(player.singularityCount) + '. You\'re back to familiar territory, but something doesn\'t seem right.')
         }
     }
@@ -3973,10 +3974,13 @@ export const reloadShit = async (reset = false) => {
         await calculateOffline();
     } else {
         player.worlds = new QuarkHandler({ bonus: 0, quarks: 0 });
-        const saved = await saveSynergy();
-
-        if (!saved) {
-            return
+        // saving is disabled during a singularity event to prevent bug
+        // early return here if the save fails can keep game state from properly resetting after a singularity
+        if (canSave) {
+            const saved = await saveSynergy();
+            if (!saved) {
+                return
+            }
         }
     }
 


### PR DESCRIPTION
I believe this will fix most/all of the bugs people are experiencing right after entering a new singularity (disabled hotkeys, bad values for coins/timers, etc).

Wrapped the call to `saveSynergy()` inside `reloadShit()` in a conditional to check if saving is disabled (ie during a singularity). This way reloadShit() finishes doing its thing instead of exiting early when it tries to save during a singularity event.

Added a forced save after the singularity event has finished, before showing the "welcome" alert. Without this, there is a ~5 second window where a page reload can result in a bugged game state. Tabs missing because the game doesn't think they're unlocked yet, 3d+ on ascension/sing timers, etc.