### PR TITLE
fix c15 challenge start/end bug

### DIFF
--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -116,11 +116,12 @@ export const toggleChallenges = (i: number, auto = false) => {
             resetrepeat('reincarnationChallenge');
         }
     }
-    if (i >= 11 && ((!auto && player.toggles[31] === false) || player.challengecompletions[10] > 0)) {
-        if ((!auto && player.toggles[31] === false) || (player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0 && player.currentChallenge.ascension === 0)) {
-            player.currentChallenge.ascension = i;
-            reset('ascensionChallenge', false, 'enterChallenge');
+    if (i >= 11 && ((!auto && player.toggles[31] === false) || player.challengecompletions[10] > 0 || (player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0 && player.currentChallenge.ascension === 0))) {
+        if (player.currentChallenge.ascension === 15) {
+            void resetCheck('ascensionChallenge', false, true);
         }
+        player.currentChallenge.ascension = i;
+        reset('ascensionChallenge', false, 'enterChallenge');
     }
     updateChallengeDisplay();
     getChallengeConditions(i);


### PR DESCRIPTION
This fixes the bug, where the c15 exponent is not refreshed, when starting another ascension challenge, while in c15