### PR TITLE
add all current mults to oct multiplier stats tab

### DIFF
--- a/index.html
+++ b/index.html
@@ -3225,7 +3225,20 @@ $STAGE$ for synergism stage" style="color: white"></p>
             <p id="statOcM7" alt="statOcM7" label="statOcM7" class="statPortion singularity">Divine Pack:<span id="sOcM7" alt="sOcM7" label="sOcM7" class="statNumber">0</span></p>
             <p id="statOcM8" alt="statOcM8" label="statOcM8" class="statPortion singularity">Cube Flame:<span id="sOcM8" alt="sOcM8" label="sOcM8" class="statNumber">0</span></p>
             <p id="statOcM9" alt="statOcM9" label="statOcM9" class="statPortion singularity">Cube Blaze:<span id="sOcM9" alt="sOcM9" label="sOcM9" class="statNumber">0</span></p>
-            <p id="statOcM10" alt="statOcM`0" label="statOcM10" class="statPortion singularity">Cube Inferno:<span id="sOcM10" alt="sOcM10" label="sOcM10" class="statNumber">0</span></p>
+            <p id="statOcM10" alt="statOcM10" label="statOcM10" class="statPortion singularity">Cube Inferno:<span id="sOcM10" alt="sOcM10" label="sOcM10" class="statNumber">0</span></p>
+            <p id="statOcM11" alt="statOcM11" label="statOcM11" class="statPortion singularity"> <span id="sOcM11" alt="sOcM11" label="sOcM11" class="statNumber">0</span></p>
+            <p id="statOcM12" alt="statOcM12" label="statOcM12" class="statPortion singularity"> <span id="sOcM12" alt="sOcM12" label="sOcM12" class="statNumber">0</span></p>
+            <p id="statOcM13" alt="statOcM13" label="statOcM13" class="statPortion singularity"> <span id="sOcM13" alt="sOcM13" label="sOcM13" class="statNumber">0</span></p>
+            <p id="statOcM14" alt="statOcM14" label="statOcM14" class="statPortion singularity"> <span id="sOcM14" alt="sOcM14" label="sOcM14" class="statNumber">0</span></p>
+            <p id="statOcM15" alt="statOcM15" label="statOcM15" class="statPortion singularity"> <span id="sOcM15" alt="sOcM15" label="sOcM15" class="statNumber">0</span></p>
+            <p id="statOcM16" alt="statOcM16" label="statOcM16" class="statPortion singularity"> <span id="sOcM16" alt="sOcM16" label="sOcM16" class="statNumber">0</span></p>
+            <p id="statOcM17" alt="statOcM17" label="statOcM17" class="statPortion singularity"> <span id="sOcM17" alt="sOcM17" label="sOcM17" class="statNumber">0</span></p>
+            <p id="statOcM18" alt="statOcM18" label="statOcM18" class="statPortion singularity"> <span id="sOcM18" alt="sOcM18" label="sOcM18" class="statNumber">0</span></p>
+            <p id="statOcM19" alt="statOcM19" label="statOcM19" class="statPortion singularity"> <span id="sOcM19" alt="sOcM19" label="sOcM19" class="statNumber">0</span></p>
+            <p id="statOcM20" alt="statOcM20" label="statOcM20" class="statPortion singularity"> <span id="sOcM20" alt="sOcM20" label="sOcM20" class="statNumber">0</span></p>
+            <p id="statOcM21" alt="statOcM21" label="statOcM21" class="statPortion singularity"> <span id="sOcM21" alt="sOcM21" label="sOcM21" class="statNumber">0</span></p>
+            <p id="statOcM22" alt="statOcM22" label="statOcM22" class="statPortion singularity"> <span id="sOcM22" alt="sOcM22" label="sOcM22" class="statNumber">0</span></p>
+            <p id="statOcM23" alt="statOcM23" label="statOcM23" class="statPortion singularity"> <span id="sOcM23" alt="sOcM23" label="sOcM23" class="statNumber">0</span></p>
             <p id="statOcMT" alt="statOcMT" label="statOcMT" class="statPortion statTotal" style="color: orange">TOTAL OCTERACT MULTIPLIER: <span
                     id="sOcMT" alt="sOcMT" label="sOcMT" class="statNumber statTotal">0</span></p>
         </div>

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1393,36 +1393,46 @@ export const calculateHepteractMultiplier = (score = -1) => {
         mult: productContents(arr)}
 }
 
-export const octeractGainPerSecond = () => {
-    const SCOREREQ = 1e23
-    const currentScore = calculateAscensionScore().effectiveScore
-
-    const baseMultiplier = (currentScore >= SCOREREQ) ? currentScore / SCOREREQ : 0;
+export const getOcteractValueMultipliers = () => {
     const corruptionLevelSum = sumContents(player.usedCorruptions.slice(2, 10))
-
-    const valueMultipliers = [
+    return [
         1 + 1.5 * player.shopUpgrades.seasonPass3 / 100,
         1 + 0.75 * player.shopUpgrades.seasonPassY / 100,
         1 + player.shopUpgrades.seasonPassZ * player.singularityCount / 100,
         1 + player.shopUpgrades.seasonPassLost / 1000,
+        // cube upgrade 70, ie Cx20
         1 + +(corruptionLevelSum >= 14 * 8) * player.cubeUpgrades[70] / 10000,
         1 + +(corruptionLevelSum >= 14 * 8) * +player.singularityUpgrades.divinePack.getEffect().bonus,
+        // next three are flame/blaze/inferno
         +player.singularityUpgrades.singCubes1.getEffect().bonus,
         +player.singularityUpgrades.singCubes2.getEffect().bonus,
         +player.singularityUpgrades.singCubes3.getEffect().bonus,
+        // absinthe through eighth wonder
         +player.singularityUpgrades.singOcteractGain.getEffect().bonus,
         +player.singularityUpgrades.singOcteractGain2.getEffect().bonus,
         +player.singularityUpgrades.singOcteractGain3.getEffect().bonus,
         +player.singularityUpgrades.singOcteractGain4.getEffect().bonus,
         +player.singularityUpgrades.singOcteractGain5.getEffect().bonus,
+        // octeracts for dummies
         1 + 0.2 * +player.octeractUpgrades.octeractStarter.getEffect().bonus,
+        // cogenesis and trigenesis
         +player.octeractUpgrades.octeractGain.getEffect().bonus,
         +player.octeractUpgrades.octeractGain2.getEffect().bonus,
         derpsmithCornucopiaBonus(),
+        // digital octeract accumulator
         Math.pow(1 + +player.octeractUpgrades.octeractAscensionsOcteractGain.getEffect().bonus, 1 + Math.floor(Math.log10(1 + player.ascensionCount))),
         1 + calculateEventBuff('Octeract'),
         1 + +player.singularityUpgrades.platonicDelta.getEffect().bonus * Math.min(9, player.singularityCounter / (3600 * 24))
-    ]
+    ];
+}
+
+export const octeractGainPerSecond = () => {
+    const SCOREREQ = 1e23
+    const currentScore = calculateAscensionScore().effectiveScore
+
+    const baseMultiplier = (currentScore >= SCOREREQ) ? currentScore / SCOREREQ : 0;
+
+    const valueMultipliers = getOcteractValueMultipliers()
 
     const ascensionSpeed = Math.pow(calculateAscensionAcceleration(), 1 / 2)
     const perSecond = 1 / (24 * 3600 * 365 * 1e15) * baseMultiplier * productContents(valueMultipliers) * ascensionSpeed
@@ -1431,33 +1441,16 @@ export const octeractGainPerSecond = () => {
 
 // This is an old calculation used only for Stats for Nerds
 export const calculateOcteractMultiplier = (score = -1) => {
+    const SCOREREQ = 1e23
     if (score < 0) {
         score = calculateAscensionScore().effectiveScore;
     }
-    const corruptionLevelSum = sumContents(player.usedCorruptions.slice(2, 10))
-    const arr = [
-        // ascension score multiplier
-        (score >= 1e32) ? Math.cbrt(score / 1e32) : Math.pow(score / 1e32, 2),
-        // season pass 3
-        1 + 1.5 * player.shopUpgrades.seasonPass3 / 100,
-        // season pass Y
-        1 + 0.75 * player.shopUpgrades.seasonPassY / 100,
-        // season pass Z
-        1 + player.shopUpgrades.seasonPassZ * player.singularityCount / 100,
-        // season pass lost
-        1 + player.shopUpgrades.seasonPassLost / 1000,
-        // cube upgrade 70
-        1 + +(corruptionLevelSum >= 14 * 8) * player.cubeUpgrades[70] / 10000,
-        // divine pack
-        1 + +(corruptionLevelSum >= 14 * 8) * (player.singularityUpgrades.divinePack.level === 1 ? 6.77 : 1.00),
-        // cube flame
-        +player.singularityUpgrades.singCubes1.getEffect().bonus,
-        // cube blaze
-        +player.singularityUpgrades.singCubes2.getEffect().bonus,
-        // cube inferno
-        +player.singularityUpgrades.singCubes3.getEffect().bonus
-        // Total Octeract Multipliers: 11
-    ]
+
+    const arr = getOcteractValueMultipliers()
+
+    // add base score to the beginning and ascension speed mult to the end of the list
+    arr.unshift((score >= SCOREREQ) ? score / SCOREREQ : 0)
+    arr.push(Math.pow(calculateAscensionAcceleration(), 1 / 2))
 
     return {
         list: arr,

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -289,7 +289,7 @@ export const loadStatisticsCubeMultipliers = () => {
 
     DOMCacheGetOrSet('sHeMT').textContent = `x${format(calculateHepteractMultiplier().mult, 3)}`;
 
-    const arr6 = calculateOcteractMultiplier().list;
+    const octMults = calculateOcteractMultiplier();
     const map6: Record<number, { acc: number, desc: string }> = {
         1: {acc: 2, desc: 'Ascension Score Multiplier:'},
         2: {acc: 2, desc: 'Season Pass 3:'},
@@ -300,15 +300,28 @@ export const loadStatisticsCubeMultipliers = () => {
         7: {acc: 2, desc: 'Divine Pack:'},
         8: {acc: 2, desc: 'Cube Flame:'},
         9: {acc: 2, desc: 'Cube Blaze:'},
-        10: {acc: 2, desc: 'Cube Inferno:'}
+        10: {acc: 2, desc: 'Cube Inferno:'},
+        11: {acc: 2, desc: 'Octeract Absinthe'},
+        12: {acc: 2, desc: 'Pieces of Eight'},
+        13: {acc: 2, desc: 'Obelisk Shaped Like an Octagon'},
+        14: {acc: 2, desc: 'Octahedral Synthesis'},
+        15: {acc: 2, desc: 'Eighth Wonder of the World'},
+        16: {acc: 2, desc: 'Octeracts for Dummies'},
+        17: {acc: 2, desc: 'Octeract Cogenesis'},
+        18: {acc: 2, desc: 'Octeract Trigenesis'},
+        19: {acc: 2, desc: 'Singularity Factor'},
+        20: {acc: 2, desc: 'Digital Octeract Accumulator'},
+        21: {acc: 2, desc: 'Event Buff'},
+        22: {acc: 2, desc: 'Platonic DELTA'},
+        23: {acc: 2, desc: 'Ascension Speed Multiplier'}
     }
-    for (let i = 0; i < arr6.length; i++) {
+    for (let i = 0; i < octMults.list.length; i++) {
         const statOcMi = DOMCacheGetOrSet(`statOcM${i + 1}`);
         statOcMi.childNodes[0].textContent = map6[i + 1].desc;
-        DOMCacheGetOrSet(`sOcM${i + 1}`).textContent = `x${format(arr6[i], map6[i + 1].acc, true)}`;
+        DOMCacheGetOrSet(`sOcM${i + 1}`).textContent = `x${format(octMults.list[i], map6[i + 1].acc, true)}`;
     }
 
-    DOMCacheGetOrSet('sOcMT').textContent = `x${format(calculateOcteractMultiplier().mult, 3)}`;
+    DOMCacheGetOrSet('sOcMT').textContent = `x${format(octMults.mult, 3)}`;
 }
 
 export const loadStatisticsOfferingMultipliers = () => {


### PR DESCRIPTION
Previous oct multiplier tab was only showing 11 of the 20+ multipliers that get factored into octeracts. It also was using a different formula for the score multiplier than the real `OcteractGainPerSecond` function was using. 

I pulled the multiplier array up into its own method to avoid code duplication, added new DOM elements to the index.html file and expanded the octeract multiplier map in statistics.