### PR TITLE
fix deleting save file if cancel on 0+0

### DIFF
--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -214,7 +214,7 @@ export const resetGame = async () => {
     const b = window.crypto.getRandomValues(new Uint16Array(1))[0] % 16;
 
     const result = await Prompt(`Answer the question to confirm you'd like to reset: what is ${a}+${b}? (Hint: ${a+b})`)
-    if (Number(result) !== a + b) {
+    if (result === null || Number(result) !== a + b) {
         return Alert('Answer was wrong, not resetting!');
     }
 


### PR DESCRIPTION
The prompt code returns `null` if the player clicks cancel, but that null was then being cast to the number 0. If the addition problem randomly rolled 0+0, this would result in a 'successful' solve of the addition confirmation. 

I added a null check on the prompt result to explicitly check for a cancel.