### PR TITLE
Sing Button now Greyscales without Antiquities

### DIFF
--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -656,7 +656,7 @@ export const buttoncolorchange = () => {
 
     DOMCacheGetOrSet('ascendbtn').style.backgroundColor = player.autoAscend && player.challengecompletions[11] > 0 && player.cubeUpgrades[10] > 0 ? 'green' : '';
     
-    DOMCacheGetOrSet('singularitybtn').style.backgroundColor = player.runelevels[6] > 0 ? '' : '#cd0000';
+    DOMCacheGetOrSet('singularitybtn').style.filter = player.runelevels[6] > 0 ? '' : 'contrast(1.25) sepia(1) grayscale(0.25)';
 
     // Notify new players the reset
     if (player.toggles[33] === true && player.singularityCount === 0) {

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -655,7 +655,7 @@ export const buttoncolorchange = () => {
     DOMCacheGetOrSet('ascendChallengeBtn').style.backgroundColor = player.currentChallenge.ascension === 0 ? '' : 'purple';
 
     DOMCacheGetOrSet('ascendbtn').style.backgroundColor = player.autoAscend && player.challengecompletions[11] > 0 && player.cubeUpgrades[10] > 0 ? 'green' : '';
-    
+
     DOMCacheGetOrSet('singularitybtn').style.filter = player.runelevels[6] > 0 ? '' : 'contrast(1.25) sepia(1) grayscale(0.25)';
 
     // Notify new players the reset

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -655,6 +655,8 @@ export const buttoncolorchange = () => {
     DOMCacheGetOrSet('ascendChallengeBtn').style.backgroundColor = player.currentChallenge.ascension === 0 ? '' : 'purple';
 
     DOMCacheGetOrSet('ascendbtn').style.backgroundColor = player.autoAscend && player.challengecompletions[11] > 0 && player.cubeUpgrades[10] > 0 ? 'green' : '';
+    
+    DOMCacheGetOrSet('singularitybtn').style.backgroundColor = player.runelevels[6] > 0 ? '' : '#cd0000';
 
     // Notify new players the reset
     if (player.toggles[33] === true && player.singularityCount === 0) {


### PR DESCRIPTION
Simple QoL change that changes the coloration of the Singularity button to be more muted when the player does _not_ have Antiquities purchased. This is meant to allow an at a glance way to know if you are able to Singularity and, more importantly, if your penalties are still active!

Example Image Below:
![image](https://user-images.githubusercontent.com/32188067/196013511-765d32d4-588d-4b8a-b702-57ce59366731.png)

