### PR TITLE
DIsplay C15 exponent instead of C15 completions

### DIFF
--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -861,7 +861,11 @@ export const updateChallengeLevel = (k: number) => {
     const el = DOMCacheGetOrSet('challenge' + k + 'level');
     const maxChallenges = getMaxChallenges(k);
 
-    el.textContent = `${player.challengecompletions[k]}/${maxChallenges}`;
+    if (k === 15) {
+        el.textContent = format(player.challenge15Exponent,0,true);
+    } else {
+        el.textContent = `${player.challengecompletions[k]}/${maxChallenges}`;
+    }
 }
 
 export const updateAchievementBG = () => {

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -862,7 +862,7 @@ export const updateChallengeLevel = (k: number) => {
     const maxChallenges = getMaxChallenges(k);
 
     if (k === 15) {
-        el.textContent = format(player.challenge15Exponent,0,true);
+        el.textContent = format(player.challenge15Exponent, 0, true);
     } else {
         el.textContent = `${player.challengecompletions[k]}/${maxChallenges}`;
     }


### PR DESCRIPTION
DIsplay C15 exponent instead of C15 completions
![image](https://user-images.githubusercontent.com/9673110/198346150-e54961fd-a871-46b0-870b-05176307eb4d.png)

When C15 hasn't been run in the current Sing, it looks like this:
![image](https://user-images.githubusercontent.com/9673110/198392659-161c88cd-a6e2-4be4-9902-17cbb9e5fde8.png)

