### PR TITLE
fixed PL-AT Σ

### DIFF
--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -677,7 +677,7 @@ const addCodeInterval = () : number => {
     let time = hour
     time *= (1 - 0.02 * player.shopUpgrades.calculator4)
     time *= (1 - Math.min(.5, (player.highestSingularityCount >= 125 ? player.highestSingularityCount / 1000 : 0)
-                            - (player.highestSingularityCount >= 200 ? player.highestSingularityCount / 1000 : 0)))
+                            + (player.highestSingularityCount >= 200 ? player.highestSingularityCount / 1000 : 0)))
     return time
 }
 

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -1264,8 +1264,15 @@ export const singularityPerks: SingularityPerk[] = [
     {
         name: 'PL-AT Σ',
         levels: [125, 200],
-        description: () => {
-            return 'Code \'add\' refills 0.1% faster per level per singularity (MAX: 50% faster)'
+        description: (n: number, levels: number[]) => {
+            let counter = 0
+            for (const singCount of levels) {
+                if (n >= singCount) {
+                    counter += 1
+                }
+            }
+
+            return `Code 'add' refills ${counter / 10}% faster per level per singularity (MAX: 50% faster)`
         }
     },
     {

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -1268,11 +1268,11 @@ export const singularityPerks: SingularityPerk[] = [
             let counter = 0
             for (const singCount of levels) {
                 if (n >= singCount) {
-                    counter += 1
+                    counter += 0.1
                 }
             }
 
-            return `Code 'add' refills ${counter / 10}% faster per level per singularity (MAX: 50% faster)`
+            return `Code 'add' refills ${counter}% faster per level per singularity (MAX: 50% faster)`
         }
     },
     {


### PR DESCRIPTION
![20221030023224](https://user-images.githubusercontent.com/87951297/198856861-585e012b-ba0e-4f4b-9508-414c21377840.png)

PL-AT Σ becomes level 2 at 200th Singularity, but loses its effectiveness.
Then the explanation of the displayed text is different, so I think it's a bug.
PL-AT Σ - Level 2 may have intended its effect to be +100%, so PR will now change the calculation from - to + and update the description.