### PR TITLE
fix shop refundability perks

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -967,7 +967,7 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
 // so that we can call on save load to fix game state
 export const updateSingularityGlobalPerks = () => {
 
-    const perk_5: boolean = player.achievements[278] > 0;
+    const perk_5 = player.achievements[278] > 0;
     const shopItemPerk_5 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
     shopItemPerk_5.forEach(k => {
         shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -973,7 +973,7 @@ export const updateSingularityGlobalPerks = () => {
         shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;
     });
 
-    const perk_20: boolean = player.singularityCount >= 20;
+    const perk_20 = player.singularityCount >= 20;
     const shopItemPerk_20 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
     shopItemPerk_20.forEach(k => {
         shopData[k].refundable = perk_20 ? false : true;

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -877,11 +877,11 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         achievementaward(113);
     }
     const shopItemPerk_5 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
-    const perk_5: boolean = player.achievements[278] > 0;
+    const perk_5 = player.achievements[278] > 0;
     if (perk_5 && singularityReset) { // Singularity 5
-        shopItemPerk_5.forEach(k => {
-            player.shopUpgrades[k] = 10;
-        });
+        for (const key of shopItemPerk_5) {
+            player.shopUpgrades[key] = 10;
+        }
         player.cubeUpgrades[7] = 1;
     }
     if (player.achievements[279] > 0) { // Singularity 7
@@ -918,7 +918,7 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         player.fifthOwnedAnts = 1;
         player.cubeUpgrades[20] = 1;
     }
-    const perk_20: boolean = player.singularityCount >= 20;
+    const perk_20 = player.singularityCount >= 20;
     const shopItemPerk_20 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
     if (perk_20) {
         player.challengecompletions[9] = 1;
@@ -926,9 +926,9 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         achievementaward(134);
         player.antPoints = new Decimal('1e100');
         player.antUpgrades[11] = 1;
-        shopItemPerk_20.forEach(k => {
-            player.shopUpgrades[k] = shopData[k].maxLevel;
-        });
+        for (const key of shopItemPerk_20) {
+            player.shopUpgrades[key] = shopData[key].maxLevel;
+        }
     }
     if (player.singularityCount >= 25) {
         player.eighthOwnedAnts = 1;
@@ -969,21 +969,21 @@ export const updateSingularityGlobalPerks = () => {
 
     const perk_5 = player.achievements[278] > 0;
     const shopItemPerk_5 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
-    shopItemPerk_5.forEach(k => {
-        shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;
-    });
+    for (const key of shopItemPerk_5) {
+        shopData[key].refundMinimumLevel = perk_5 ? 10 : key.endsWith('Auto') ? 1 : 0;
+    }
 
     const perk_20 = player.singularityCount >= 20;
     const shopItemPerk_20 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
-    shopItemPerk_20.forEach(k => {
-        shopData[k].refundable = perk_20 ? false : true;
-    });
+    for (const key of shopItemPerk_20) {
+        shopData[key].refundable = perk_20 ? false : true;
+    }
 
     const perk_51 = player.singularityCount >= 51;
     const shopItemPerk_51 = ['seasonPass', 'seasonPass2', 'seasonPass3', 'seasonPassY', 'chronometer', 'chronometer2'] as const;
-    shopItemPerk_51.forEach(k => {
-        shopData[k].refundable = perk_51 ? false : true;
-    });
+    for (const key of shopItemPerk_51) {
+        shopData[key].refundable = perk_51 ? false : true;
+    }
 }
 
 export const singularity = async (): Promise<void> => {

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -884,9 +884,6 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         });
         player.cubeUpgrades[7] = 1;
     }
-    shopItemPerk_5.forEach(k => {
-        shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;
-    });
     if (player.achievements[279] > 0) { // Singularity 7
         player.challengecompletions[7] = 1;
         player.highestchallengecompletions[7] = 1;
@@ -933,9 +930,6 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
             player.shopUpgrades[k] = shopData[k].maxLevel;
         });
     }
-    shopItemPerk_20.forEach(k => {
-        shopData[k].refundable = perk_20 ? false : true;
-    });
     if (player.singularityCount >= 25) {
         player.eighthOwnedAnts = 1;
     }
@@ -944,12 +938,6 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
         player.researches[135] = 1;
         player.researches[145] = 1;
     }
-    const perk_51 = player.singularityCount >= 51;
-    const shopItemPerk_51 = ['seasonPass', 'seasonPass2', 'seasonPass3', 'seasonPassY', 'chronometer', 'chronometer2'] as const;
-    shopItemPerk_51.forEach(k => {
-        shopData[k].refundable = perk_51 ? false : true;
-    });
-
     if (player.singularityCount >= 101 && singularityReset) {
         player.cubeUpgrades[51] = 1;
         awardAutosCookieUpgrade();
@@ -971,7 +959,31 @@ export const updateSingularityMilestoneAwards = (singularityReset = true): void 
             updateResearchBG(j);
         }
     }
+    updateSingularityGlobalPerks();
     revealStuff();
+}
+
+// updates singularity perks that do not get saved to player object
+// so that we can call on save load to fix game state
+export const updateSingularityGlobalPerks = () => {
+
+    const perk_5: boolean = player.achievements[278] > 0;
+    const shopItemPerk_5 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
+    shopItemPerk_5.forEach(k => {
+        shopData[k].refundMinimumLevel = perk_5 ? 10 : k.endsWith('Auto') ? 1 : 0;
+    });
+
+    const perk_20: boolean = player.singularityCount >= 20;
+    const shopItemPerk_20 = ['offeringAuto', 'offeringEX', 'obtainiumAuto', 'obtainiumEX', 'antSpeed', 'cashGrab'] as const;
+    shopItemPerk_20.forEach(k => {
+        shopData[k].refundable = perk_20 ? false : true;
+    });
+
+    const perk_51 = player.singularityCount >= 51;
+    const shopItemPerk_51 = ['seasonPass', 'seasonPass2', 'seasonPass3', 'seasonPassY', 'chronometer', 'chronometer2'] as const;
+    shopItemPerk_51.forEach(k => {
+        shopData[k].refundable = perk_51 ? false : true;
+    });
 }
 
 export const singularity = async (): Promise<void> => {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -21,7 +21,7 @@ import { calculatePlatonicBlessings } from './PlatonicCubes';
 import { antSacrificePointsToMultiplier, autoBuyAnts, calculateCrumbToCoinExp } from './Ants';
 import { calculatetax } from './Tax';
 import { ascensionAchievementCheck, challengeachievementcheck, achievementaward, resetachievementcheck, buildingAchievementCheck } from './Achievements';
-import { reset, resetrepeat, singularity, updateSingularityAchievements, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens } from './Reset';
+import { reset, resetrepeat, singularity, updateSingularityAchievements, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens, updateSingularityGlobalPerks } from './Reset';
 import type { TesseractBuildings} from './Buy';
 import { buyMax, buyAccelerator, buyMultiplier, boostAccelerator, buyCrystalUpgrades, buyParticleBuilding, getReductionValue, getCost, buyRuneBonusLevels, buyTesseractBuilding, calculateTessBuildingsInBudget } from './Buy';
 import { autoUpgrades } from './Automation';
@@ -1801,6 +1801,7 @@ const loadSynergy = async () => {
         calculateRuneLevels();
         resetHistoryRenderAllTables();
         updateSingularityAchievements();
+        updateSingularityGlobalPerks();
     }
 
     updateAchievementBG();


### PR DESCRIPTION
moved 'Global' or 'G' variable perks into a separate function so that we can call it on save load to restore perks that are not saved to the 'player' object

This fixes the shop perks. I removed the code from updateSingularityMilestoneAwards() to put it into a new function that can then be called from loadSynergy().