### PR TITLE
Revert overly zealous shop confirmations

### DIFF
--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -806,11 +806,20 @@ export const friendlyShopName = (input: ShopUpgradeNames) => {
 
 export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const shopItem = shopData[input];
-    if (player.shopUpgrades[input] >= shopItem.maxLevel) {
-        return Alert(`You can't purchase ${friendlyShopName(input)} because you are already at the maximum ${shopItem.type === shopUpgradeTypes.UPGRADE ? 'level' : 'capacity'}!`);
-    } else if (Number(player.worlds) < getShopCosts(input)) {
-        return Alert(`You can't purchase ${friendlyShopName(input)} because you don't have enough Quarks!`);
+
+    const maxLevel = player.shopUpgrades[input] >= shopItem.maxLevel;
+    const canAfford = Number(player.worlds) >= getShopCosts(input);
+    if (maxLevel || !canAfford) {
+        if (player.shopConfirmationToggle || (!shopItem.refundable && player.shopBuyMaxToggle)) {
+            if (maxLevel) {
+                return Alert(`You can't purchase ${friendlyShopName(input)} because you are already at the maximum ${shopItem.type === shopUpgradeTypes.UPGRADE ? 'level' : 'capacity'}!`);
+            } else if (!canAfford) {
+                return Alert(`You can't purchase ${friendlyShopName(input)} because you don't have enough Quarks!`);
+            }
+        }
+        return;
     }
+
     // Actually lock for HTML exploit
     if (!isShopUpgradeUnlocked(input)) {
         return Alert(`You do not have the right to purchase ${friendlyShopName(input)}!`);

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -807,17 +807,14 @@ export const friendlyShopName = (input: ShopUpgradeNames) => {
 export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const shopItem = shopData[input];
 
-    const maxLevel = player.shopUpgrades[input] >= shopItem.maxLevel;
-    const canAfford = Number(player.worlds) >= getShopCosts(input);
-    if (maxLevel || !canAfford) {
-        if (player.shopConfirmationToggle || (!shopItem.refundable && player.shopBuyMaxToggle !== false)) {
-            if (maxLevel) {
-                return Alert(`You can't purchase ${friendlyShopName(input)} because you are already at the maximum ${shopItem.type === shopUpgradeTypes.UPGRADE ? 'level' : 'capacity'}!`);
-            } else if (!canAfford) {
-                return Alert(`You can't purchase ${friendlyShopName(input)} because you don't have enough Quarks!`);
-            }
-        }
-        return;
+    if (player.shopUpgrades[input] >= shopItem.maxLevel) {
+        return player.shopConfirmationToggle
+            ? Alert(`You can't purchase ${friendlyShopName(input)} because you are already at the maximum ${shopItem.type === shopUpgradeTypes.UPGRADE ? 'level' : 'capacity'}!`)
+            : null;
+    } else if (Number(player.worlds) < getShopCosts(input)) {
+        return player.shopConfirmationToggle
+            ? Alert(`You can't purchase ${friendlyShopName(input)} because you don't have enough Quarks!`)
+            : null;
     }
 
     // Actually lock for HTML exploit

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -810,7 +810,7 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const maxLevel = player.shopUpgrades[input] >= shopItem.maxLevel;
     const canAfford = Number(player.worlds) >= getShopCosts(input);
     if (maxLevel || !canAfford) {
-        if (player.shopConfirmationToggle || (!shopItem.refundable && player.shopBuyMaxToggle)) {
+        if (player.shopConfirmationToggle || (!shopItem.refundable && player.shopBuyMaxToggle !== false)) {
             if (maxLevel) {
                 return Alert(`You can't purchase ${friendlyShopName(input)} because you are already at the maximum ${shopItem.type === shopUpgradeTypes.UPGRADE ? 'level' : 'capacity'}!`);
             } else if (!canAfford) {


### PR DESCRIPTION
#340 made it so that when you buy refundable shop items and hit max level, there is an alert, even if you have shop confirmations off. This means that doing a shop respec cycle between cubes and speedups and off/obt/ant, it is no longer possible to just hold the enter key and click around the shop screen because you have to dismiss an alert each time it fires.

This PR is a suggestion to fix it, however I have not tested it - I am not sure how to set up a test environment, so would love someone else to test it if possible? @mustache0110 maybe?