### PR TITLE
Daily code stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -2992,6 +2992,7 @@ $STAGE$ for synergism stage" style="color: white"></p>
             <button class="statsNerds hepteracts" id="kHeptMult" alt="kHeptMult" label="kHeptMult" style="border: 2px solid rosybrown">Hepteract Multipliers</button>
             <button class="statsNerds hepteracts" id="kOrbPowderMult" alt="kOrbPowderMult" label="kOrbPowderMult" style="border: 2px solid orchid">Orb to Powder Multipliers</button>
             <button class="statsNerds singularity" id="kOctMult" alt="kOctMult" label="kOctMult" style="border: 2px solid rosybrown">Octeract Multipliers</button>
+            <button class="statsNerds singularity" id="kDailyRewardStats" alt="kDailyRewardStats" label="kDailyRewardStats" style="border: 2px solid cyan">Daily Code Upgrade Levels</button>
         </div>
         <div id="miscStats" alt="miscStats" label="miscStats" class="statContainer activeStats">
             <p class="prestigeunlock statPortion" id="settingtitle3" alt="settingtitle3" label="settingtitle3" style="color: plum; font-size: 1.2em">Miscellaneous Stats</p>
@@ -3255,6 +3256,22 @@ $STAGE$ for synergism stage" style="color: white"></p>
             <p id="statOcM24" alt="statOcM24" label="statOcM24" class="statPortion singularity"> <span id="sOcM24" alt="sOcM24" label="sOcM24" class="statNumber">0</span></p>
             <p id="statOcMT" alt="statOcMT" label="statOcMT" class="statPortion statTotal" style="color: orange">TOTAL OCTERACT MULTIPLIER: <span
                     id="sOcMT" alt="sOcMT" label="sOcMT" class="statNumber statTotal">0</span></p>
+        </div>
+
+        <div id="dailyRewardStats" alt="dailyRewardStats" label="dailyRewardStats" class="statContainer" style="display:none">
+            <p id="dailyRewardStatTitle" alt="dailyRewardStatTitle" label="dailyRewardStatTitle" class="statPortion" style="color: cyan; font-size: 1.2em;">Daily Code Free Singularity Shop Levels</p>
+            <p id="statDailyM1" alt="statDailyM1" label="statDailyM1" class="statPortion singularity"> <span id="sDailyM1" alt="sDailyM1" label="sDailyM1" class="statNumber">0</span></p>
+            <p id="statDailyM2" alt="statDailyM2" label="statDailyM2" class="statPortion singularity"> <span id="sDailyM2" alt="sDailyM2" label="sDailyM2" class="statNumber">0</span></p>
+            <p id="statDailyM3" alt="statDailyM3" label="statDailyM3" class="statPortion singularity"> <span id="sDailyM3" alt="sDailyM3" label="sDailyM3" class="statNumber">0</span></p>
+            <p id="statDailyM4" alt="statDailyM4" label="statDailyM4" class="statPortion singularity"> <span id="sDailyM4" alt="sDailyM4" label="sDailyM4" class="statNumber">0</span></p>
+            <p id="statDailyM5" alt="statDailyM5" label="statDailyM5" class="statPortion singularity"> <span id="sDailyM5" alt="sDailyM5" label="sDailyM5" class="statNumber">0</span></p>
+            <p id="statDailyM6" alt="statDailyM6" label="statDailyM6" class="statPortion singularity"> <span id="sDailyM6" alt="sDailyM6" label="sDailyM6" class="statNumber">0</span></p>
+            <p id="statDailyM7" alt="statDailyM7" label="statDailyM7" class="statPortion singularity"> <span id="sDailyM7" alt="sDailyM7" label="sDailyM7" class="statNumber">0</span></p>
+            <p id="statDailyM8" alt="statDailyM8" label="statDailyM8" class="statPortion singularity"> <span id="sDailyM8" alt="sDailyM8" label="sDailyM8" class="statNumber">0</span></p>
+            <p id="statDailyM9" alt="statDailyM9" label="statDailyM9" class="statPortion singularity"> <span id="sDailyM9" alt="sDailyM9" label="sDailyM9" class="statNumber">0</span></p>
+            <p id="statDailyM10" alt="statDailyM10" label="statDailyM10" class="statPortion singularity"> <span id="sDailyM10" alt="sDailyM10" label="sDailyM10" class="statNumber">0</span></p>
+            <p id="statDailyMT" alt="statDailyMT" label="statDailyMT" class="statPortion statTotal" style="color: orange">TOTAL FREE LEVELS: <span
+                    id="sDailyMT" alt="sDailyMT" label="sDailyMT" class="statNumber statTotal">0</span></p>
         </div>
         <button id="summaryGeneration" style="border: 2px solid grey; height: 20px; width: 250px;">Generate Savefile Stats Summary</button>
     </div>

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1,5 +1,5 @@
 import { player, saveSynergy, format, resourceGain, updateAll, getTimePinnedToLoadDate } from './Synergism';
-import { sumContents, productContents } from './Utility';
+import { sumContents, productContents, calculateContents } from './Utility';
 import { Globals as G } from './Variables';
 import { CalcECC } from './Challenges';
 import Decimal from 'break_infinity.js';
@@ -1991,4 +1991,25 @@ export const derpsmithCornucopiaBonus = () => {
     }
 
     return 1 + counter * player.singularityCount / 100
+}
+
+export const calculateDailyRewardRolls = () => {
+    const rolls = [
+        {'type': '+', 'value': 3 * Math.sqrt(player.singularityCount)},
+        {'type': '+', 'value': +player.octeractUpgrades.octeractImprovedDaily.getEffect().bonus},
+        {'type': '+', 'value': player.shopUpgrades.shopImprovedDaily2},
+        {'type': '+', 'value': player.shopUpgrades.shopImprovedDaily3},
+        {'type': '+', 'value': player.shopUpgrades.shopImprovedDaily4},
+        {'type': '+', 'value': (+player.singularityUpgrades.platonicPhi.getEffect().bonus *
+                Math.min(50, 5 * player.singularityCounter / (3600 * 24)))},
+        {'type': '+', 'value': +player.octeractUpgrades.octeractImprovedDaily3.getEffect().bonus},
+        {'type': '*', 'value': +player.octeractUpgrades.octeractImprovedDaily2.getEffect().bonus},
+        {'type': '*', 'value': 1 + +player.octeractUpgrades.octeractImprovedDaily3.getEffect().bonus / 200},
+        {'type': '*', 'value': player.highestSingularityCount >= 200 ? 2 : 1}
+    ];
+
+    return {
+        list: rolls,
+        total: Math.floor(calculateContents(rolls))
+    };
 }

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -1,5 +1,5 @@
 import { player, saveSynergy, blankSave, reloadShit, format } from './Synergism';
-import { octeractGainPerSecond } from './Calculate';
+import {calculateDailyRewardRolls, octeractGainPerSecond} from './Calculate';
 import { testing, version } from './Config';
 import { cleanString, getElementById } from './Utility';
 import LZString from 'lz-string';
@@ -387,22 +387,8 @@ export const promocodes = async (input: string | null, amount?: number) => {
                 singOfferings1: {value: 1, pdf: (x: number) => 600 < x && x <= 800},
                 ascensions: {value: 1, pdf: (x: number) => 800 < x && x <= 1000}
             }
-            let rolls = 3 * Math.sqrt(player.singularityCount)
-            rolls += +player.octeractUpgrades.octeractImprovedDaily.getEffect().bonus
-            rolls += player.shopUpgrades.shopImprovedDaily2
-            rolls += player.shopUpgrades.shopImprovedDaily3
-            rolls += player.shopUpgrades.shopImprovedDaily4
-            rolls += (+player.singularityUpgrades.platonicPhi.getEffect().bonus *
-                        Math.min(50, 5 * player.singularityCounter / (3600 * 24)))
-            rolls += +player.octeractUpgrades.octeractImprovedDaily3.getEffect().bonus
-            rolls *= +player.octeractUpgrades.octeractImprovedDaily2.getEffect().bonus
-            rolls *= 1 + +player.octeractUpgrades.octeractImprovedDaily3.getEffect().bonus / 200
 
-            if (player.highestSingularityCount >= 200) {
-                rolls *= 2
-            }
-
-            rolls = Math.floor(rolls)
+            const rolls = calculateDailyRewardRolls().total;
 
             const keys = Object
                 .keys(player.singularityUpgrades)

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -1,7 +1,7 @@
 import { player, format, formatTimeShort } from './Synergism';
 import { Globals as G } from './Variables';
 import { hepteractEffective } from './Hepteracts'
-import {calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier, calculateQuarkMultiplier, calculateEventBuff, calculateSingularityQuarkMilestoneMultiplier, calculateTotalOcteractQuarkBonus } from './Calculate';
+import {calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier, calculateQuarkMultiplier, calculateEventBuff, calculateSingularityQuarkMilestoneMultiplier, calculateTotalOcteractQuarkBonus, calculateDailyRewardRolls } from './Calculate';
 import { challenge15ScoreMultiplier } from './Challenges';
 import type { GlobalVariables } from './types/Synergism';
 import { DOMCacheGetOrSet } from './Cache/DOM';
@@ -20,7 +20,8 @@ const associated = new Map<string, string>([
     ['kPlatMult', 'platonicMultiplierStats'],
     ['kHeptMult', 'hepteractMultiplierStats'],
     ['kOrbPowderMult', 'powderMultiplierStats'],
-    ['kOctMult', 'octeractMultiplierStats']
+    ['kOctMult', 'octeractMultiplierStats'],
+    ['kDailyRewardStats', 'dailyRewardStats']
 ]);
 
 export const displayStats = (btn: HTMLElement) => {
@@ -59,6 +60,9 @@ export const loadStatisticsUpdate = () => {
                 break;
             case 'powderMultiplierStats':
                 loadPowderMultiplier();
+                break;
+            case 'dailyRewardStats':
+                loadDailyCodeStats();
                 break;
             default:
                 loadStatisticsCubeMultipliers();
@@ -388,6 +392,32 @@ export const loadPowderMultiplier = () => {
     }
 
     DOMCacheGetOrSet('sPoMT').textContent = `x${format(calculatePowderConversion().mult, 3)}`;
+}
+
+export const loadDailyCodeStats = () => {
+    const statsArray = calculateDailyRewardRolls();
+    const statsMap: Record<number, { acc: number, desc: string }> = {
+        0: {acc: 2, desc: 'Base:'},
+        1: {acc: 0, desc: 'Octeract Improved Daily:'},
+        2: {acc: 0, desc: 'Improved Daily 2 (green):'},
+        3: {acc: 0, desc: 'Improved Daily 3 (red):'},
+        4: {acc: 0, desc: 'Improved Daily 4 (gray):'},
+        5: {acc: 0, desc: 'Octeract Improved Daily 3:'},
+        6: {acc: 2, desc: 'Platonic PHI'},
+        7: {acc: 2, desc: 'Octeract Improved Daily 2:'},
+        8: {acc: 2, desc: 'Octeract Improved Daily 3:'},
+        9: {acc: 2, desc: 'Industrial Daily Codes:'}
+    }
+
+    for (let i = 0; i < statsArray.list.length; i++) {
+        const statRow = DOMCacheGetOrSet(`statDailyM${i + 1}`);
+        const arithmeticSymbol = statsArray.list[i]['type'] === '*' ? 'x' : statsArray.list[i]['type'];
+        const value = format(statsArray.list[i]['value'], statsMap[i].acc);
+        statRow.childNodes[0].textContent = statsMap[i].desc;
+
+        DOMCacheGetOrSet(`sDailyM${i + 1}`).textContent = `${arithmeticSymbol}${value}`;
+    }
+    DOMCacheGetOrSet('sDailyMT').textContent = `${format(statsArray.total, 0)}`;
 }
 
 export const c15RewardUpdate = () => {

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -47,6 +47,24 @@ export const sumContents = (array: number[]): number => {
  */
 export const productContents = (array: number[]): number => array.reduce((a, b) => a * b);
 
+/**
+ * Given an array of {type, value} where type is one of '+' or '*', reduces the values based on the
+ * arithmetic operation associated with each value.
+ * @param toCalc
+ * @returns number
+ */
+export const calculateContents = (toCalc: {'type':string, 'value':number}[]): number => {
+    return toCalc.reduce((accumulator, contents) => {
+        if (contents.type === '+') {
+            return accumulator + contents.value;
+        }
+        if (contents.type === '*') {
+            return accumulator * contents.value;
+        }
+        return accumulator;
+    }, 0)
+}
+
 export const sortWithIndices = (toSort: number[]) => {
     return Array
         .from([...toSort.keys()])


### PR DESCRIPTION
 * Added a new utility function that can handle reducing arrays that have both additive and multiplicative bonuses.
 * Moved the calculation for daily code free upgrade rolls out of ImportExport.ts and into Calculate.ts. The new function returns a `{list, total}` object like the similar functions for cube multipliers etc.
 * Added a new stats for nerds block to display the daily code free upgrade roll bonuses and total.