### PR TITLE
Add onemind to stats

### DIFF
--- a/index.html
+++ b/index.html
@@ -3128,6 +3128,7 @@ $STAGE$ for synergism stage" style="color: white"></p>
             <p id="statGCM20" alt="statGCM20" label="statGCM20" class="statPortion">-<span id="sGCM20" alt="sGCM20" label="sGCM20" class="statNumber">-</span></p>
             <p id="statGCM21" alt="statGCM21" label="statGCM21" class="statPortion">-<span id="sGCM21" alt="sGCM21" label="sGCM21" class="statNumber">-</span></p>
             <p id="statGCM22" alt="statGCM22" label="statGCM22" class="statPortion">-<span id="sGCM22" alt="sGCM22" label="sGCM22" class="statNumber">-</span></p>
+            <p id="statGCM23" alt="statGCM23" label="statGCM23" class="statPortion">-<span id="sGCM23" alt="sGCM23" label="sGCM23" class="statNumber">-</span></p>
             <p id="statGCMT" alt="statGCMT" label="statGCMT" class="statPortion statTotal" style="color: orange">TOTAL GLOBAL CUBE MULTIPLIER: <span
                 id="sGCMT" alt="sGCMT" label="sGCMT" class="statNumber statTotal">0</span></p>
         </div>

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1111,8 +1111,10 @@ export const calculateAllCubeMultiplier = () => {
         // Platonic DELTA
         1 + +player.singularityUpgrades.platonicDelta.getEffect().bonus * Math.min(9, player.singularityCounter / (3600 * 24)),
         // Wow Pass INF
-        Math.pow(1.02, player.shopUpgrades.seasonPassInfinity)
-        // Total Global Cube Multipliers: 19
+        Math.pow(1.02, player.shopUpgrades.seasonPassInfinity),
+        // One Mind
+        player.singularityUpgrades.oneMind.getEffect().bonus ? calculateAscensionAcceleration() / 10 : 1
+        // Total Global Cube Multipliers: 23
     ]
     return {
         mult: productContents(arr),
@@ -1823,12 +1825,9 @@ export const CalcCorruptionStuff = () => {
         cubeBank += challengeModifier * player.highestchallengecompletions[i]
     }
 
-    const oneMindModifier = (player.singularityUpgrades.oneMind.getEffect().bonus) ? calculateAscensionAcceleration() / 10 : 1
-
     // Calculation of Cubes :)
     let cubeGain = cubeBank;
     cubeGain *= calculateCubeMultiplier(effectiveScore).mult;
-    cubeGain *= oneMindModifier
 
     const bonusCubeExponent = (player.singularityUpgrades.platonicTau.getEffect().bonus) ? 1.01 : 1
     cubeGain = Math.pow(cubeGain, bonusCubeExponent)
@@ -1839,22 +1838,18 @@ export const CalcCorruptionStuff = () => {
         tesseractGain += 0.5
     }
     tesseractGain *= calculateTesseractMultiplier(effectiveScore).mult;
-    tesseractGain *= oneMindModifier
 
     // Calculation of Hypercubes :)))
     let hypercubeGain = (effectiveScore >= 1e9) ? 1 : 0;
     hypercubeGain *= calculateHypercubeMultiplier(effectiveScore).mult;
-    hypercubeGain *= oneMindModifier
 
     // Calculation of Platonic Cubes :))))
     let platonicGain = (effectiveScore >= 2.666e12) ? 1 : 0;
     platonicGain *= calculatePlatonicMultiplier(effectiveScore).mult;
-    platonicGain *= oneMindModifier
 
     // Calculation of Hepteracts :)))))
     let hepteractGain = (G['challenge15Rewards']['hepteractUnlocked'] && effectiveScore >= 1.666e17 && player.achievements[255] > 0) ? 1 : 0;
     hepteractGain *= calculateHepteractMultiplier(effectiveScore).mult
-    hepteractGain *= oneMindModifier
 
     return [cubeBank, Math.floor(baseScore), corruptionMultiplier, Math.floor(effectiveScore), Math.floor(cubeGain), Math.max(player.singularityCount, Math.floor(tesseractGain)), Math.floor(hypercubeGain), Math.floor(platonicGain), Math.floor(hepteractGain), (bonusMultiplier)]
 }

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -170,7 +170,8 @@ export const loadStatisticsCubeMultipliers = () => {
         19: {acc: 2, desc: 'Total Octeract Bonus:'},
         20: {acc: 2, desc: 'Citadel [GQ]'},
         21: {acc: 4, desc: 'Platonic DELTA'},
-        22: {acc: 2, desc: 'Wow Pass ∞'}
+        22: {acc: 2, desc: 'Wow Pass ∞'},
+        23: {acc: 4, desc: 'One Mind:'}
     }
     for (let i = 0; i < arr0.length; i++) {
         const statGCMi = DOMCacheGetOrSet(`statGCM${i + 1}`);


### PR DESCRIPTION
Adds a row for the one mind multiplier to the global cube multipliers section of stats for nerds.

To make this possible I moved the calculation for one mind into the `calculateAllCubeMultiplier` function, instead of applying it individually to each cube type in `CalcCorruptionStuff`. 