### PR TITLE
Hide max buy multi octeracts

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -1897,7 +1897,7 @@ p#reincarnatehotkeys {
     margin-top: 20px;
 }
 
-#shopButtons, #octeractButtons {
+#shopButtons, #octeractButtons, #singUpgradeButtons {
     display: flex;
     justify-content: center;
     flex-flow: wrap;
@@ -1906,7 +1906,7 @@ p#reincarnatehotkeys {
     margin-top: 5px;
 }
 
-#shopButtons > button, #octeractButtons > button {
+#shopButtons > button, #octeractButtons > button, #singUpgradeButtons > button {
     min-width: 150px;
     min-height: 40px;
     margin-bottom: 6px;

--- a/Synergism.css
+++ b/Synergism.css
@@ -1897,7 +1897,7 @@ p#reincarnatehotkeys {
     margin-top: 20px;
 }
 
-#shopButtons {
+#shopButtons, #octeractButtons {
     display: flex;
     justify-content: center;
     flex-flow: wrap;
@@ -1906,7 +1906,7 @@ p#reincarnatehotkeys {
     margin-top: 5px;
 }
 
-#shopButtons > button {
+#shopButtons > button, #octeractButtons > button {
     min-width: 150px;
     min-height: 40px;
     margin-bottom: 6px;

--- a/index.html
+++ b/index.html
@@ -3680,9 +3680,6 @@ $STAGE$ for synergism stage" style="color: white"></p>
                     <img src="Pictures/Golden Quark.png" width="32px" height="32px" loading="lazy">
                     <p id="goldenQuarkamount" alt="goldenQuarkamount" label="goldenQuarkamount">You have 0 Golden Quarks!</p>
                 </div>
-                <div id="goldenQuarksMultiBuyInfo">
-                    <p id="goldenQuarkMultiBuyText">Buy multiple levels at once by holding <span style="color: orchid">'SHIFT'</span> while clicking!</p>
-                </div>
                 <div class="boxColor" id="actualSingularityUpgradeContainer" alt="actualSingularityUpgradeContainer" label="actualSingularityUpgradeContainer">
                     <div class="singularityUpgrade">
                         <img id="goldenQuarks1" alt="goldenQuarks1" label="goldenQuarks1" src="Pictures/SingularityCurrency1.png">
@@ -3864,6 +3861,10 @@ $STAGE$ for synergism stage" style="color: white"></p>
                     <div class="singularityUpgrade">
                         <img id="oneMind" src="Pictures/Singularity One Mind.png">
                     </div>
+                </div>
+                <div id="singUpgradeButtons" alt="singUpgradesButtons" label="singUpgradesButtons">
+                    <button id="toggleHideSingUpgrade" alt="toggleHideSingUpgrade" label="toggleHideSingUpgrade" style="border: 2px solid white">Hide Maxed: OFF</button>
+                    <button id="toggleBuyMaxSingUpgrade" alt="toggleBuyMaxSingUpgrade" label="toggleBuyMaxSingUpgrade" style="border: 2px solid white">Buy: 1</button>
                 </div>
             </div>
             <div id="singularityUpgradeShit" alt="singularityUpgradeShit" label="singularityUpgradeShit">

--- a/index.html
+++ b/index.html
@@ -3736,10 +3736,11 @@ $STAGE$ for synergism stage" style="color: white"></p>
                         <img id="cookies4" alt="cookies4" label="cookies4" src="Pictures/SingularityCookies4.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="cookies5" alt="cookies5" label="cookies5" src="Pictures/SingularityCookies5.png" style="cursor: pointer">
+                        <img id="cookies5" alt="cookies5" label="cookies5" src="Pictures/SingularityCookies5.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="ascensions" alt="ascensions" label="ascensions" src="Pictures/Singularity Ascensions.png" style="cursor:pointer">                </div>
+                        <img id="ascensions" alt="ascensions" label="ascensions" src="Pictures/Singularity Ascensions.png">
+                    </div>
                     <div class="singularityUpgrade">
                         <img id="corruptionFourteen" alt="corruptionFourteen" label="corruptionFourteen" src="Pictures/Singularity Corruption 14.png">
                     </div>
@@ -3747,22 +3748,22 @@ $STAGE$ for synergism stage" style="color: white"></p>
                         <img id="corruptionFifteen" alt="corruptionFifteen" label="corruptionFifteen" src="Pictures/Singularity Corruption 15.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="platonicTau" alt="platonicTau" src="Pictures/Singularity Tau.png" style="cursor: pointer">
+                        <img id="platonicTau" alt="platonicTau" src="Pictures/Singularity Tau.png">
                     </div>
                     <div class="singularityUpgrade">
                         <img id="offeringAutomatic" alt="offeringAutomatic" label="offeringAutomatic" src="Pictures/Singularity BlueBerry.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="platonicAlpha" alt="platonicAlpha" src="Pictures/Singularity Alpha.png" style="cursor: pointer">
+                        <img id="platonicAlpha" alt="platonicAlpha" src="Pictures/Singularity Alpha.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="platonicDelta" alt="platonicDelta" src="Pictures/Singularity Delta.png" style="cursor: pointer">
+                        <img id="platonicDelta" alt="platonicDelta" src="Pictures/Singularity Delta.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="platonicPhi" alt="platonicPhi" src="Pictures/Singularity Phi.png" style="cursor: pointer">
+                        <img id="platonicPhi" alt="platonicPhi" src="Pictures/Singularity Phi.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOfferings1" alt="singOfferings1" label="singOfferings1" src="Pictures/Singularity Offerings 1.png" style="cursor: pointer">
+                        <img id="singOfferings1" alt="singOfferings1" label="singOfferings1" src="Pictures/Singularity Offerings 1.png">
                     </div>
                     <div class="singularityUpgrade">
                         <img id="singOfferings2" alt="singOfferings2" label="singOfferings2" src="Pictures/Singularity Offerings 2.png">
@@ -3831,37 +3832,37 @@ $STAGE$ for synergism stage" style="color: white"></p>
                         <img id="singQuarkHepteract3" alt="singQuarkHepteract3" label="singQuarkHepteract3" src="Pictures/Singularity Quark Hepteract 3.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOcteractGain" src="Pictures/Singularity Octeract Gain 1.png" style="cursor: pointer">
+                        <img id="singOcteractGain" src="Pictures/Singularity Octeract Gain 1.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOcteractGain2" src="Pictures/Singularity Octeract Gain 2.png" style="cursor: pointer">
+                        <img id="singOcteractGain2" src="Pictures/Singularity Octeract Gain 2.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOcteractGain3" src="Pictures/Singularity Octeract Gain 3.png" style="cursor: pointer">
+                        <img id="singOcteractGain3" src="Pictures/Singularity Octeract Gain 3.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOcteractGain4" src="Pictures/Singularity Octeract Gain 4.png" style="cursor: pointer">
+                        <img id="singOcteractGain4" src="Pictures/Singularity Octeract Gain 4.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singOcteractGain5" src="Pictures/Singularity Octeract Gain 5.png" style="cursor: pointer">
+                        <img id="singOcteractGain5" src="Pictures/Singularity Octeract Gain 5.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singFastForward" src="Pictures/Singularity Fast Forward.png" style="cursor: pointer">
+                        <img id="singFastForward" src="Pictures/Singularity Fast Forward.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singFastForward2" src="Pictures/Singularity Fast Forward 2.png" style="cursor: pointer">
+                        <img id="singFastForward2" src="Pictures/Singularity Fast Forward 2.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singAscensionSpeed" src="Pictures/Singularity Ascension Speed.png" style="cursor: pointer">
+                        <img id="singAscensionSpeed" src="Pictures/Singularity Ascension Speed.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="singAscensionSpeed2" src="Pictures/Singularity Ascension Speed 2.png" style="cursor: pointer">
+                        <img id="singAscensionSpeed2" src="Pictures/Singularity Ascension Speed 2.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="ultimatePen" src="Pictures/Ultimate Pen.png" style="cursor: pointer">
+                        <img id="ultimatePen" src="Pictures/Ultimate Pen.png">
                     </div>
                     <div class="singularityUpgrade">
-                        <img id="oneMind" src="Pictures/Singularity One Mind.png" style="cursor: pointer">
+                        <img id="oneMind" src="Pictures/Singularity One Mind.png">
                     </div>
                 </div>
             </div>
@@ -3895,106 +3896,104 @@ $STAGE$ for synergism stage" style="color: white"></p>
                     <p id="totalOcteractCubeBonus" alt="totalOcteractCubeBonus" label="totalOcteractCubeBonus">3-7 Dimensional Cubes <span id="octCubeBonus" style="color: yellow">+199%</span></p>
                     <p id="totalOcteractQuarkBonus" alt="totalOcteractQuarkBonus" label="totalOcteractQuarkBonus">Quarks <span id="octQuarkBonus" style="color: aqua">+4%</span></p>
                 </div>
-                <div id="octeractsMultiBuyInfo">
-                    <p id="octeractMultiBuyText">Buy multiple levels at once by holding <span style="color: orchid">'SHIFT'</span> while clicking!</p>
-                </div>
                 <div class="boxColor" id="octeractUpgradeContainer" alt="octeractUpgradeContainer" label="octeractUpgradeContainer">
                     <div class="octeractUpgrade">
-                        <img id="octeractStarter" src='Pictures/OcteractStarter.png' style="cursor: pointer">
+                        <img id="octeractStarter" src='Pictures/OcteractStarter.png'>
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractGain" src='Pictures/Octeract Octeracts.png' style="cursor: pointer">
+                        <img id="octeractGain" src='Pictures/Octeract Octeracts.png'>
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractGain2" src='Pictures/Octeract Octeracts 2.png' style="cursor: pointer">
+                        <img id="octeractGain2" src='Pictures/Octeract Octeracts 2.png'>
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractQuarkGain" src='Pictures/Octeract Quarks.png' style="cursor: pointer">
+                        <img id="octeractQuarkGain" src='Pictures/Octeract Quarks.png'>
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractQuarkGain2" src="Pictures/Octeract Quarks 2.png" style="cursor: pointer">
+                        <img id="octeractQuarkGain2" src="Pictures/Octeract Quarks 2.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractCorruption" src="Pictures/OcteractCorruptions.png" style="cursor: pointer">
+                        <img id="octeractCorruption" src="Pictures/OcteractCorruptions.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractGQCostReduce" src="Pictures/Octeract Golden Quark Cost.png" style="cursor: pointer">
+                        <img id="octeractGQCostReduce" src="Pictures/Octeract Golden Quark Cost.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractExportQuarks" src="Pictures/Octeract Export Quarks.png" style="cursor: pointer">
+                        <img id="octeractExportQuarks" src="Pictures/Octeract Export Quarks.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedDaily" src="Pictures/Octeract Improved Daily.png" style="cursor: pointer">
+                        <img id="octeractImprovedDaily" src="Pictures/Octeract Improved Daily.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedDaily2" src="Pictures/Octeract Improved Daily2.png" style="cursor: pointer">
+                        <img id="octeractImprovedDaily2" src="Pictures/Octeract Improved Daily2.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedDaily3" src="Pictures/Octeract Improved Daily3.png" style="cursor: pointer">
+                        <img id="octeractImprovedDaily3" src="Pictures/Octeract Improved Daily3.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedQuarkHept" src="Pictures/Octeract Improved Quark Hepteract.png" style="cursor:pointer">
+                        <img id="octeractImprovedQuarkHept" src="Pictures/Octeract Improved Quark Hepteract.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedGlobalSpeed" src="Pictures/Octeract Improved Global Speed.png" style="cursor: pointer">
+                        <img id="octeractImprovedGlobalSpeed" src="Pictures/Octeract Improved Global Speed.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedAscensionSpeed" src="Pictures/Octeract Improved Ascension Speed.png" style="cursor: pointer">
+                        <img id="octeractImprovedAscensionSpeed" src="Pictures/Octeract Improved Ascension Speed.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedAscensionSpeed2" src="Pictures/Octeract Improved Ascension Speed 2.png" style="cursor: pointer">
+                        <img id="octeractImprovedAscensionSpeed2" src="Pictures/Octeract Improved Ascension Speed 2.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedFree" src="Pictures/Octeract Free Upgrade Improvement.png" style="cursor: pointer">
+                        <img id="octeractImprovedFree" src="Pictures/Octeract Free Upgrade Improvement.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedFree2" src="Pictures/Octeract Free Upgrade Improvement2.png" style="cursor: pointer">
+                        <img id="octeractImprovedFree2" src="Pictures/Octeract Free Upgrade Improvement2.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedFree3" src="Pictures/Octeract Free Upgrade Improvement3.png" style="cursor: pointer">
+                        <img id="octeractImprovedFree3" src="Pictures/Octeract Free Upgrade Improvement3.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractImprovedFree4" src="Pictures/Octeract Free Upgrade Improvement4.png" style="cursor: pointer">
+                        <img id="octeractImprovedFree4" src="Pictures/Octeract Free Upgrade Improvement4.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractSingUpgradeCap" src="Pictures/Octeract Max Singularity Upgrade.png" style="cursor: pointer">
+                        <img id="octeractSingUpgradeCap" src="Pictures/Octeract Max Singularity Upgrade.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractOfferings1" src="Pictures/Octeract Offerings.png" style="cursor: pointer">
+                        <img id="octeractOfferings1" src="Pictures/Octeract Offerings.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractObtainium1" src="Pictures/Octeract Obtainium.png" style="cursor: pointer">
+                        <img id="octeractObtainium1" src="Pictures/Octeract Obtainium.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractAscensions" src="Pictures/Octeract Ascension Count.png" style="cursor: pointer">
+                        <img id="octeractAscensions" src="Pictures/Octeract Ascension Count.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractAscensions2" src="Pictures/Octeract Ascension Count 2.png" style="cursor: pointer">
+                        <img id="octeractAscensions2" src="Pictures/Octeract Ascension Count 2.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractAscensionsOcteractGain" src="Pictures/Octeract Ascension Octeracts.png" style="cursor: pointer">
+                        <img id="octeractAscensionsOcteractGain" src="Pictures/Octeract Ascension Octeracts.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractFastForward" src="Pictures/Octeract Fast Forward.png" style="cursor: pointer">
+                        <img id="octeractFastForward" src="Pictures/Octeract Fast Forward.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractAutoPotionSpeed" src="Pictures/Octeract Auto Potion Speed.png" style="cursor: pointer">
+                        <img id="octeractAutoPotionSpeed" src="Pictures/Octeract Auto Potion Speed.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractAutoPotionEfficiency" src="Pictures/Octeract Auto Potion Efficiency.png" style="cursor: pointer">
+                        <img id="octeractAutoPotionEfficiency" src="Pictures/Octeract Auto Potion Efficiency.png">
                     </div>
                     <div class="octeractUpgrade">
-                        <img id="octeractOneMindImprover" src="Pictures/Octeract One Mind Improver.png" style="cursor: pointer">
+                        <img id="octeractOneMindImprover" src="Pictures/Octeract One Mind Improver.png">
                     </div>
                 </div>
-
+                <div id="octeractButtons" alt="octeractButtons" label="octeractButtons">
+                    <button id="toggleHideOcteract" alt="toggleHideOcteract" label="toggleHideOcteract" style="border: 2px solid white">Hide Maxed: OFF</button>
+                    <button id="toggleBuyMaxOcteract" alt="toggleBuyMaxOcteract" label="toggleBuyMaxOcteract" style="border: 2px solid white">Buy: 1</button>
+                </div>
                 <div id="octeractUpgradeValues" alt="octeractUpgradeValues" label="octeractUpgradeValues">
                     <p id="singularityOcteractsMultiline" alt="singularityOcteractsMultiline" label="singularityOcteractsMultiline"></p>
                 </div>
-
             </div>
         </div>
-
     </div>
     </body>
 </html>

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -783,6 +783,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.octeractBuyMaxToggle = false;
     }
 
+    if (data.singUpgradeBuyMaxToggle === undefined) {
+        player.singUpgradeBuyMaxToggle = false;
+    }
+
     if (data.wowOcteracts === undefined) {
         player.wowOcteracts = 0;
         player.octeractTimer = 0;
@@ -794,6 +798,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
 
     if (data.octeractHideToggle === undefined) {
         player.octeractHideToggle = false;
+    }
+
+    if (data.singUpgradeHideToggle === undefined) {
+        player.singUpgradeHideToggle = false;
     }
 
     if (data.researchBuyMaxToggle === undefined) {

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -779,6 +779,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.shopConfirmationToggle = true;
     }
 
+    if (data.octeractBuyMaxToggle === undefined) {
+        player.octeractBuyMaxToggle = false;
+    }
+
     if (data.wowOcteracts === undefined) {
         player.wowOcteracts = 0;
         player.octeractTimer = 0;
@@ -786,6 +790,10 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
 
     if (data.shopHideToggle === undefined) {
         player.shopHideToggle = false;
+    }
+
+    if (data.octeractHideToggle === undefined) {
+        player.octeractHideToggle = false;
     }
 
     if (data.researchBuyMaxToggle === undefined) {

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -594,7 +594,7 @@ TODO: Fix this entire tab it's utter shit
     // Part 1: The Settings
     /*Respec The Upgrades*/ DOMCacheGetOrSet('resetShopUpgrades').addEventListener('click', () => resetShopUpgrades())
     /*Toggle Shop Confirmations*/ DOMCacheGetOrSet('toggleConfirmShop').addEventListener('click', () => toggleShopConfirmation())
-    /*Toggle Shop Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxShop').addEventListener('click', (event) => toggleBuyMaxShop(event))
+    /*Toggle Shop Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxShop').addEventListener('click', () => toggleBuyMaxShop())
     /*Toggle Hide Permanent Maxed*/ DOMCacheGetOrSet('toggleHideShop').addEventListener('click', () => toggleHideShop())
 
     // Part 2: Potions
@@ -603,8 +603,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('offeringpotionowned').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('buyofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
     DOMCacheGetOrSet('useofferingpotion').addEventListener('mouseover', () => shopDescriptions('offeringPotion'))
-    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', () => buyShopUpgrades('offeringPotion'))
-    //DOMCacheGetOrSet('offeringPotions').addEventListener('click', () => buyShopUpgrades("offeringPotion"))  //Allow clicking of image to buy also
+    DOMCacheGetOrSet('buyofferingpotion').addEventListener('click', (event) => buyShopUpgrades('offeringPotion', event))
     DOMCacheGetOrSet('useofferingpotion').addEventListener('click', () => useConsumable('offeringPotion'))
     DOMCacheGetOrSet('toggle42').addEventListener('click', () => {
         player.autoPotionTimer = 0;
@@ -614,8 +613,7 @@ TODO: Fix this entire tab it's utter shit
     DOMCacheGetOrSet('obtainiumpotionowned').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('mouseover', () => shopDescriptions('obtainiumPotion'))
-    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', () => buyShopUpgrades('obtainiumPotion'))
-    //DOMCacheGetOrSet('obtainiumPotions').addEventListener('click', () => buyShopUpgrades("obtainiumPotion"))  //Allow clicking of image to buy also
+    DOMCacheGetOrSet('buyobtainiumpotion').addEventListener('click', (event) => buyShopUpgrades('obtainiumPotion', event))
     DOMCacheGetOrSet('useobtainiumpotion').addEventListener('click', () => useConsumable('obtainiumPotion'))
     DOMCacheGetOrSet('toggle43').addEventListener('click', () => {
         player.autoPotionTimerObtainium = 0;
@@ -628,8 +626,7 @@ TODO: Fix this entire tab it's utter shit
             DOMCacheGetOrSet(`${key}`).addEventListener('mouseover', () => shopDescriptions(key))
             DOMCacheGetOrSet(`${key}Level`).addEventListener('mouseover', () => shopDescriptions(key))
             DOMCacheGetOrSet(`${key}Button`).addEventListener('mouseover', () => shopDescriptions(key))
-            //DOMCacheGetOrSet(`${key}`).addEventListener('click', () => buyShopUpgrades(key))  //Allow clicking of image to buy also
-            DOMCacheGetOrSet(`${key}Button`).addEventListener('click', () => buyShopUpgrades(key))
+            DOMCacheGetOrSet(`${key}Button`).addEventListener('click', (event) => buyShopUpgrades(key, event))
         }
     }
     DOMCacheGetOrSet('buySingularityQuarksButton').addEventListener('click', () => buyGoldenQuarks());

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -1,4 +1,4 @@
-import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleAutoBuyFragment, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleSaveOff, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleautoopensCubes, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation, toggleAutoResearchMode, toggleBuyMaxShop, toggleHideShop, toggleHepteractAutoPercentage } from './Toggles'
+import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleAutoBuyFragment, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleSaveOff, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleautoopensCubes, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation, toggleAutoResearchMode, toggleBuyMaxShop, toggleBuyMaxOcteract, toggleHideShop, toggleHideOcteract, toggleHepteractAutoPercentage } from './Toggles'
 import { resetrepeat, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens } from './Reset'
 import { player, resetCheck, saveSynergy } from './Synergism'
 import { boostAccelerator, buyAccelerator, buyMultiplier, buyProducer, buyCrystalUpgrades, buyParticleBuilding, buyTesseractBuilding, buyRuneBonusLevels, buyAllBlessings } from './Buy'
@@ -646,6 +646,9 @@ TODO: Fix this entire tab it's utter shit
         DOMCacheGetOrSet(`${String(key)}`).addEventListener('mouseover', () => player.octeractUpgrades[`${String(key)}`].updateUpgradeHTML())
         DOMCacheGetOrSet(`${String(key)}`).addEventListener('click', (event) => player.octeractUpgrades[`${String(key)}`].buyLevel(event))
     }
+    /*Toggle Hide Maxed*/ DOMCacheGetOrSet('toggleHideOcteract').addEventListener('click', () => toggleHideOcteract())
+    /*Toggle Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxOcteract').addEventListener('click', () => toggleBuyMaxOcteract())
+
     //Toggle subtabs of Singularity tab
     for (let index = 0; index < 4; index++) {
         DOMCacheGetOrSet(`toggleSingularitySubTab${index+1}`).addEventListener('click', () => toggleSubTab(10, index))

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -1,4 +1,4 @@
-import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleAutoBuyFragment, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleSaveOff, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleautoopensCubes, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation, toggleAutoResearchMode, toggleBuyMaxShop, toggleBuyMaxOcteract, toggleHideShop, toggleHideOcteract, toggleHepteractAutoPercentage } from './Toggles'
+import { toggleAscStatPerSecond, toggleTabs, toggleSubTab, toggleBuyAmount, toggleAutoTesseracts, toggleSettings, toggleautoreset, toggleautobuytesseract, toggleShops, toggleAutoSacrifice, toggleAutoBuyFragment, toggleautoenhance, toggleautofortify, updateRuneBlessingBuyAmount, toggleSaveOff, toggleChallenges, toggleAutoChallengesIgnore, toggleAutoChallengeRun, updateAutoChallenge, toggleResearchBuy, toggleAutoResearch, toggleAntMaxBuy, toggleAntAutoSacrifice, toggleMaxBuyCube, toggleautoopensCubes, toggleCorruptionLevel, toggleAutoAscend, toggleShopConfirmation, toggleAutoResearchMode, toggleBuyMaxShop, toggleBuyMaxOcteract, toggleBuyMaxSingUpgrade, toggleHideShop, toggleHideOcteract, toggleHideSingUpgrade, toggleHepteractAutoPercentage } from './Toggles'
 import { resetrepeat, updateAutoReset, updateTesseractAutoBuyAmount, updateAutoCubesOpens } from './Reset'
 import { player, resetCheck, saveSynergy } from './Synergism'
 import { boostAccelerator, buyAccelerator, buyMultiplier, buyProducer, buyCrystalUpgrades, buyParticleBuilding, buyTesseractBuilding, buyRuneBonusLevels, buyAllBlessings } from './Buy'
@@ -636,6 +636,8 @@ TODO: Fix this entire tab it's utter shit
         DOMCacheGetOrSet(`${String(key)}`).addEventListener('mouseover', () => player.singularityUpgrades[`${String(key)}`].updateUpgradeHTML())
         DOMCacheGetOrSet(`${String(key)}`).addEventListener('click', (event) => player.singularityUpgrades[`${String(key)}`].buyLevel(event))
     }
+    /*Toggle Hide Maxed*/ DOMCacheGetOrSet('toggleHideSingUpgrade').addEventListener('click', () => toggleHideSingUpgrade())
+    /*Toggle Buy Max*/ DOMCacheGetOrSet('toggleBuyMaxSingUpgrade').addEventListener('click', () => toggleBuyMaxSingUpgrade())
 
     // Octeract Upgrades
     const octeractUpgrades = Object.keys(player.octeractUpgrades) as (keyof Player['octeractUpgrades'])[];

--- a/src/Octeracts.ts
+++ b/src/Octeracts.ts
@@ -37,25 +37,31 @@ export class OcteractUpgrade extends DynamicUpgrade {
      */
     public async buyLevel(event: MouseEvent): Promise<void> {
         let purchased = 0;
-        let maxPurchasable = 1;
-        let OCTBudget = player.wowOcteracts;
+        let maxPurchasable = 1000000;
+        let octBudget = player.wowOcteracts;
 
-        if (event.shiftKey) {
-            maxPurchasable = 1000000
-            const buy = Number(await Prompt(`How many Octeracts would you like to spend? You have ${format(player.wowOcteracts, 0, true)} OCT. Type -1 to use max!`))
+        if (!event.shiftKey && player.octeractBuyMaxToggle === false) {
+            maxPurchasable = 1;
+        } else {
+            let octToSpend = -1;
 
-            if (isNaN(buy) || !isFinite(buy) || !Number.isInteger(buy)) { // nan + Infinity checks
-                return Alert('Value must be a finite number!');
+            // Shows a prompt to ask how many Octeracts to spend
+            if (event.shiftKey || player.octeractBuyMaxToggle === 'ANY') {
+                octToSpend = Number(await Prompt(`How many Octeracts would you like to spend? You have ${format(player.wowOcteracts, 0, true)} OCT. Type -1 to use max!`))
+
+                if (isNaN(octToSpend) || !isFinite(octToSpend) || !Number.isInteger(octToSpend)) { // nan + Infinity checks
+                    return Alert('Value must be a finite number!');
+                }
             }
 
-            if (buy === -1) {
-                OCTBudget = player.wowOcteracts
-            } else if (buy <= 0) {
+            if (octToSpend === -1) {
+                octBudget = player.wowOcteracts
+            } else if (octToSpend <= 0) {
                 return Alert('Purchase cancelled!')
             } else {
-                OCTBudget = buy
+                octBudget = octToSpend;
             }
-            OCTBudget = Math.min(player.wowOcteracts, OCTBudget)
+            octBudget = Math.min(player.wowOcteracts, octBudget)
         }
 
         if (this.maxLevel > 0) {
@@ -68,11 +74,11 @@ export class OcteractUpgrade extends DynamicUpgrade {
 
         while (maxPurchasable > 0) {
             const cost = this.getCostTNL();
-            if (player.wowOcteracts < cost || OCTBudget < cost) {
+            if (player.wowOcteracts < cost || octBudget < cost) {
                 break;
             } else {
                 player.wowOcteracts -= cost;
-                OCTBudget -= cost;
+                octBudget -= cost;
                 this.octeractsInvested += cost
                 this.level += 1;
                 purchased += 1;

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1133,6 +1133,8 @@ export const singularity = async (): Promise<void> => {
     hold.theme = player.theme
     hold.notation = player.notation
     hold.firstPlayed = player.firstPlayed
+    hold.octeractHideToggle = player.octeractHideToggle
+    hold.octeractBuyMaxToggle = player.octeractBuyMaxToggle
 
     // Quark Hepteract craft is saved entirely. For other crafts we only save their auto setting
     hold.hepteractCrafts.quark = player.hepteractCrafts.quark;

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1135,6 +1135,8 @@ export const singularity = async (): Promise<void> => {
     hold.firstPlayed = player.firstPlayed
     hold.octeractHideToggle = player.octeractHideToggle
     hold.octeractBuyMaxToggle = player.octeractBuyMaxToggle
+    hold.singUpgradeHideToggle = player.singUpgradeHideToggle
+    hold.singUpgradeBuyMaxToggle = player.singUpgradeBuyMaxToggle
 
     // Quark Hepteract craft is saved entirely. For other crafts we only save their auto setting
     hold.hepteractCrafts.quark = player.hepteractCrafts.quark;

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -874,7 +874,7 @@ export const friendlyShopName = (input: ShopUpgradeNames) => {
 
 }
 
-export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
+export const buyShopUpgrades = async (input: ShopUpgradeNames, event: MouseEvent) => {
     const shopItem = shopData[input];
 
     if (player.shopUpgrades[input] >= shopItem.maxLevel) {
@@ -896,20 +896,28 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const maxBuyAmount = shopItem.maxLevel - player.shopUpgrades[input];
     let buyAmount;
     let buyCost;
-    switch (player.shopBuyMaxToggle) {
-        case false:
-            buyAmount = 1;
-            buyCost = getShopCosts(input);
-            break;
-        case 'TEN':
-            buyData = calculateSummationNonLinear(player.shopUpgrades[input], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, Math.min(10,maxBuyAmount))
-            buyAmount = buyData.levelCanBuy - player.shopUpgrades[input];
-            buyCost = buyData.cost;
-            break;
-        default:
-            buyData = calculateSummationNonLinear(player.shopUpgrades[input], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, maxBuyAmount)
-            buyAmount = buyData.levelCanBuy - player.shopUpgrades[input];
-            buyCost = buyData.cost;
+    if (event.shiftKey) {
+        // Buy ANY
+        buyData = calculateSummationNonLinear(player.shopUpgrades[input], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, maxBuyAmount)
+        buyAmount = buyData.levelCanBuy - player.shopUpgrades[input];
+        buyCost = buyData.cost;
+    } else {
+        switch (player.shopBuyMaxToggle) {
+            case false:
+                buyAmount = 1;
+                buyCost = getShopCosts(input);
+                break;
+            case 'TEN':
+                buyData = calculateSummationNonLinear(player.shopUpgrades[input], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, Math.min(10,maxBuyAmount))
+                buyAmount = buyData.levelCanBuy - player.shopUpgrades[input];
+                buyCost = buyData.cost;
+                break;
+            default:
+                // Buy MAX
+                buyData = calculateSummationNonLinear(player.shopUpgrades[input], shopItem.price, +player.worlds, shopItem.priceIncrease / shopItem.price, maxBuyAmount)
+                buyAmount = buyData.levelCanBuy - player.shopUpgrades[input];
+                buyCost = buyData.cost;
+        }
     }
 
     const singular = shopItem.maxLevel === 1;
@@ -917,7 +925,7 @@ export const buyShopUpgrades = async (input: ShopUpgradeNames) => {
     const noRefunds = shopItem.refundable ? '' : '\n\n\u26A0\uFE0F !! No Refunds !! \u26A0\uFE0F';
     const maxPots = shopItem.type === shopUpgradeTypes.CONSUMABLE ? '\n\nType -1 in Buy: ANY to buy equal amounts of both Potions.' : '';
 
-    if (player.shopBuyMaxToggle === 'ANY' && !singular) {
+    if (!singular && (event.shiftKey || player.shopBuyMaxToggle === 'ANY')) {
         const buyInput = await Prompt(`You can afford to purchase up to ${merch} of ${friendlyShopName(input)} for ${buyCost.toLocaleString()} Quarks. How many would you like to buy?${maxPots + noRefunds}`);
         let buyAny;
         if (Number(buyInput) === -1 && shopItem.type === shopUpgradeTypes.CONSUMABLE) {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -806,7 +806,9 @@ export const player: Player = {
 
     dailyCodeUsed: false,
     hepteractAutoCraftPercentage: 50,
-    octeractTimer: 0
+    octeractTimer: 0,
+    octeractHideToggle: false,
+    octeractBuyMaxToggle: false
 }
 
 export const blankSave = Object.assign({}, player, {
@@ -1753,6 +1755,21 @@ const loadSynergy = async () => {
             DOMCacheGetOrSet('toggleHideShop').textContent = 'Hide Maxed: ON'
         } else {
             DOMCacheGetOrSet('toggleHideShop').textContent = 'Hide Maxed: OFF'
+        }
+        switch (player.octeractBuyMaxToggle) {
+            case false:
+                DOMCacheGetOrSet('toggleBuyMaxOcteract').textContent = 'Buy: 1';
+                break;
+            case true:
+                DOMCacheGetOrSet('toggleBuyMaxOcteract').textContent = 'Buy: MAX';
+                break;
+            case 'ANY':
+                DOMCacheGetOrSet('toggleBuyMaxOcteract').textContent = 'Buy: ANY';
+        }
+        if (player.octeractHideToggle) {
+            DOMCacheGetOrSet('toggleHideOcteract').textContent = 'Hide Maxed: ON'
+        } else {
+            DOMCacheGetOrSet('toggleHideOcteract').textContent = 'Hide Maxed: OFF'
         }
         if (player.researchBuyMaxToggle) {
             DOMCacheGetOrSet('toggleresearchbuy').textContent = 'Upgrade: MAX [if possible]'

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -808,7 +808,9 @@ export const player: Player = {
     hepteractAutoCraftPercentage: 50,
     octeractTimer: 0,
     octeractHideToggle: false,
-    octeractBuyMaxToggle: false
+    octeractBuyMaxToggle: false,
+    singUpgradeHideToggle: false,
+    singUpgradeBuyMaxToggle: false
 }
 
 export const blankSave = Object.assign({}, player, {
@@ -1770,6 +1772,21 @@ const loadSynergy = async () => {
             DOMCacheGetOrSet('toggleHideOcteract').textContent = 'Hide Maxed: ON'
         } else {
             DOMCacheGetOrSet('toggleHideOcteract').textContent = 'Hide Maxed: OFF'
+        }
+        switch (player.singUpgradeBuyMaxToggle) {
+            case false:
+                DOMCacheGetOrSet('toggleBuyMaxSingUpgrade').textContent = 'Buy: 1';
+                break;
+            case true:
+                DOMCacheGetOrSet('toggleBuyMaxSingUpgrade').textContent = 'Buy: MAX';
+                break;
+            case 'ANY':
+                DOMCacheGetOrSet('toggleBuyMaxSingUpgrade').textContent = 'Buy: ANY';
+        }
+        if (player.singUpgradeHideToggle) {
+            DOMCacheGetOrSet('toggleHideSingUpgrade').textContent = 'Hide Maxed: ON'
+        } else {
+            DOMCacheGetOrSet('toggleHideSingUpgrade').textContent = 'Hide Maxed: OFF'
         }
         if (player.researchBuyMaxToggle) {
             DOMCacheGetOrSet('toggleresearchbuy').textContent = 'Upgrade: MAX [if possible]'

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -1,7 +1,7 @@
 import { revealStuff, hideStuff, updateChallengeDisplay, showCorruptionStatsLoadouts, changeTabColor, Prompt, Alert } from './UpdateHTML';
 import { player, format, resetCheck } from './Synergism';
 import { Globals as G } from './Variables';
-import { visualUpdateCubes, visualUpdateOcteracts } from './UpdateVisuals';
+import { visualUpdateCubes, visualUpdateOcteracts, visualUpdateSingularity } from './UpdateVisuals';
 import { calculateRuneLevels } from './Calculate';
 import { reset, resetrepeat } from './Reset';
 import { autoResearchEnabled } from './Research';
@@ -794,6 +794,35 @@ export const toggleHideOcteract = () => {
 
     player.octeractHideToggle = !player.octeractHideToggle;
     visualUpdateOcteracts();
+}
+
+export const toggleBuyMaxSingUpgrade = () => {
+    const el = DOMCacheGetOrSet('toggleBuyMaxSingUpgrade')
+
+    switch (player.singUpgradeBuyMaxToggle) {
+        case false:
+            el.innerHTML = 'Buy: ANY';
+            player.singUpgradeBuyMaxToggle = 'ANY';
+            break;
+        case 'ANY':
+            el.innerHTML = 'Buy: MAX';
+            player.singUpgradeBuyMaxToggle = true;
+            break;
+        case true:
+        default:
+            el.innerHTML = 'Buy: 1';
+            player.singUpgradeBuyMaxToggle = false;
+    }
+}
+
+export const toggleHideSingUpgrade = () => {
+    const el = DOMCacheGetOrSet('toggleHideSingUpgrade')
+    el.textContent = player.singUpgradeHideToggle
+        ? 'Hide Maxed: OFF'
+        : 'Hide Maxed: ON';
+
+    player.singUpgradeHideToggle = !player.singUpgradeHideToggle;
+    visualUpdateSingularity();
 }
 
 export const toggleAntMaxBuy = () => {

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -769,6 +769,34 @@ export const toggleHideShop = () => {
     player.shopHideToggle = !player.shopHideToggle;
 }
 
+export const toggleBuyMaxOcteract = () => {
+    const el = DOMCacheGetOrSet('toggleBuyMaxOcteract')
+
+    switch (player.octeractBuyMaxToggle) {
+        case false:
+            el.innerHTML = 'Buy: ANY';
+            player.octeractBuyMaxToggle = 'ANY';
+            break;
+        case 'ANY':
+            el.innerHTML = 'Buy: MAX';
+            player.octeractBuyMaxToggle = true;
+            break;
+        default:
+            el.innerHTML = 'Buy: 1';
+            player.octeractBuyMaxToggle = false;
+    }
+}
+
+export const toggleHideOcteract = () => {
+    const el = DOMCacheGetOrSet('toggleHideOcteract')
+    el.textContent = player.octeractHideToggle
+        ? 'Hide Maxed: OFF'
+        : 'Hide Maxed: ON';
+
+    player.octeractHideToggle = !player.octeractHideToggle;
+    visualUpdateOcteracts();
+}
+
 export const toggleAntMaxBuy = () => {
     const el = DOMCacheGetOrSet('toggleAntMax');
     el.textContent = player.antMax

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -737,25 +737,24 @@ export const toggleShopConfirmation = () => {
     player.shopConfirmationToggle = !player.shopConfirmationToggle;
 }
 
-export const toggleBuyMaxShop = (event: MouseEvent) => {
+export const toggleBuyMaxShop = () => {
     const el = DOMCacheGetOrSet('toggleBuyMaxShop')
-    if (event.shiftKey) {
-        el.textContent = 'Buy: ANY';
-        player.shopBuyMaxToggle = 'ANY';
-        return;
-    }
-    const suf = '<br><span style=\'color: gold; font-size:75%;\'>Shift-Click for Buy: Any</span>';
+
     switch (player.shopBuyMaxToggle) {
         case false:
-            el.innerHTML = `Buy: 10${suf}`;
+            el.innerHTML = 'Buy: 10';
             player.shopBuyMaxToggle = 'TEN';
             break;
         case 'TEN':
-            el.innerHTML = `Buy: MAX${suf}`;
+            el.textContent = 'Buy: ANY';
+            player.shopBuyMaxToggle = 'ANY';
+            break;
+        case 'ANY':
+            el.innerHTML = 'Buy: MAX';
             player.shopBuyMaxToggle = true;
             break;
         default:
-            el.innerHTML = `Buy: 1${suf}`;
+            el.innerHTML = 'Buy: 1';
             player.shopBuyMaxToggle = false;
     }
 }

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -550,8 +550,20 @@ export const visualUpdateSingularity = () => {
     if (G['currentTab'] !== 'singularity') {
         return
     }
-    if (player.subtabNumber === 0) {
+    if (player.subtabNumber <= 1) {
         DOMCacheGetOrSet('goldenQuarkamount').textContent = 'You have ' + format(player.goldenQuarks, 0, true) + ' Golden Quarks!'
+        const keys = Object.keys(player.singularityUpgrades) as (keyof Player['singularityUpgrades'])[];
+        for (const key of keys) {
+            const singUpgradeItem = player.singularityUpgrades[key];
+            const elementToHide = DOMCacheGetOrSet(`${key.toString()}`).parentNode as HTMLElement;
+            const computedMaxLevel = singUpgradeItem.computeMaxLevel();
+            if (player.singUpgradeHideToggle && computedMaxLevel !== -1 && singUpgradeItem.level >= computedMaxLevel) {
+                elementToHide.style.display = 'none';
+                continue;
+            } else {
+                elementToHide.style.display = 'block';
+            }
+        }
     }
 }
 

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -17,6 +17,7 @@ import type { IMultiBuy } from './Cubes';
 import { calculateMaxTalismanLevel } from './Talismans';
 import { getGoldenQuarkCost } from './singularity';
 import { loadStatisticsUpdate } from './Statistics';
+import { octeractData } from './Octeracts';
 
 export const visualUpdateBuildings = () => {
     if (G['currentTab'] !== 'buildings') {
@@ -574,6 +575,18 @@ export const visualUpdateOcteracts = () => {
     DOMCacheGetOrSet('totalOcteractQuarkBonus').style.display = cTOQB >= 0.001 ? 'block' : 'none';
     DOMCacheGetOrSet('octCubeBonus').textContent = `+${format(cTOCB, 3, true)}%`
     DOMCacheGetOrSet('octQuarkBonus').textContent = `+${format(cTOQB, 3, true)}%`
+
+    const keys = Object.keys(player.octeractUpgrades) as (keyof Player['octeractUpgrades'])[];
+    for (const key of keys) {
+        const octeractItem = octeractData[key];
+        const elementToHide = DOMCacheGetOrSet(`${key.toString()}`).parentNode as HTMLElement;
+        if (player.octeractHideToggle && octeractItem.maxLevel !== -1 && player.octeractUpgrades[key].level >= octeractItem.maxLevel) {
+            elementToHide.style.display = 'none';
+            continue;
+        } else {
+            elementToHide.style.display = 'block';
+        }
+    }
 }
 
 export const visualUpdateShop = () => {

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -132,15 +132,21 @@ export class SingularityUpgrade extends DynamicUpgrade {
      */
     public async buyLevel(event: MouseEvent): Promise<void> {
         let purchased = 0;
-        let maxPurchasable = 1
-        let GQBudget = player.goldenQuarks
+        let maxPurchasable = 100000;
+        let GQBudget = player.goldenQuarks;
 
-        if (event.shiftKey) {
-            maxPurchasable = 100000
-            const buy = Number(await Prompt(`How many Golden Quarks would you like to spend? You have ${format(player.goldenQuarks, 0, true)} GQ. Type -1 to use max!`))
+        if (!event.shiftKey && player.singUpgradeBuyMaxToggle === false) {
+            maxPurchasable = 1;
+        } else {
+            let buy = -1;
 
-            if (isNaN(buy) || !isFinite(buy) || !Number.isInteger(buy)) { // nan + Infinity checks
-                return Alert('Value must be a finite number!');
+            // Shows a prompt to ask how many GQ to spend
+            if (event.shiftKey || player.singUpgradeBuyMaxToggle === 'ANY') {
+                buy = Number(await Prompt(`How many Golden Quarks would you like to spend? You have ${format(player.goldenQuarks, 0, true)} GQ. Type -1 to use max!`))
+
+                if (isNaN(buy) || !isFinite(buy) || !Number.isInteger(buy)) { // nan + Infinity checks
+                    return Alert('Value must be a finite number!');
+                }
             }
 
             if (buy === -1) {

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -584,8 +584,9 @@ export interface Player {
     octeractUpgrades: Record<keyof typeof octeractData, OcteractUpgrade>
     dailyCodeUsed: boolean
     hepteractAutoCraftPercentage: number
-    octeractTimer: number
-
+    octeractTimer: number,
+    octeractHideToggle: boolean,
+    octeractBuyMaxToggle: boolean | 'ANY'
 }
 
 export interface GlobalVariables {

--- a/src/types/Synergism.d.ts
+++ b/src/types/Synergism.d.ts
@@ -586,7 +586,9 @@ export interface Player {
     hepteractAutoCraftPercentage: number
     octeractTimer: number,
     octeractHideToggle: boolean,
-    octeractBuyMaxToggle: boolean | 'ANY'
+    octeractBuyMaxToggle: boolean | 'ANY',
+    singUpgradeHideToggle: boolean,
+    singUpgradeBuyMaxToggle: boolean | 'ANY'
 }
 
 export interface GlobalVariables {


### PR DESCRIPTION
For Sing Upgrades and Octeracts:
- added "Hide Maxed" button
- added buy modes button "Buy 1 / Any / Max"
For Quark Shop:
changed buy modes button behavior to be the same as Octeracts/Sing upgrades: the "Buy Any" mode is now available without using the Shift key (useful for mobile users).

On those 3 screens, multi buy is still available with shift+click on the upgrade, not depending on the current multi buy mode

![image](https://user-images.githubusercontent.com/9673110/205920232-5cdbe226-31df-4c07-b1be-e2ebc89251aa.png)
![image](https://user-images.githubusercontent.com/9673110/205920747-eba98a81-5632-47c1-a4bf-3bd8d01a2aee.png)
