### PR TITLE
Rainbow border

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -3355,9 +3355,47 @@ header #obtainiumDisplay { color: pink; }
     font-size: 0;
 }
 
+.singularityChallenge {
+    display: flex;
+    justify-content: center;
+    column-gap: 4px;
+}
+
+.rainbowBorder {
+    width: 64px;
+    height: 64px;
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    overflow: hidden;
+}
+
+.rainbowBorder > img {
+    position: relative;
+    width: calc(100% - 6px); /* 58px */
+    height: calc(100% - 6px);
+    object-fit: none;
+    background-color: var(--bg-color);
+    border-radius: 3px;
+}
+
+.rainbowBorder::before {
+    position: absolute;
+    width: 150%; /* 96px */
+    height: 150%;
+    background-image: conic-gradient(#ca001f, #ffb17f, #fff200, #22b14c, #767dda, #a349a4, #ca001f);
+    animation: 3s linear infinite rotaterainbow;
+    content: "";
+}
+
+@keyframes rotaterainbow {
+    to { transform: rotate(360deg); }
+}
+
 .singularityUpgrade > img,
 .octeractUpgrade > img,
-.singularityChallenge > img {
+.singularityChallenge img {
     cursor: pointer;
 }
 

--- a/index.html
+++ b/index.html
@@ -4004,7 +4004,9 @@ $STAGE$ for synergism stage" style="color: white"></p>
                     <p id="singularityChallengeIntro" alt="singularityChallengeIntro">Do you have what it takes to earn EXALT from Ant God?</p>
                 </div>
                 <div class="singularityChallenge">
-                    <img id='noSingularityUpgrades' src="Pictures/Transparent Pics/No Singularity Upgrade Challenge.png">
+                    <div class="rainbowBorder">
+                        <img id="noSingularityUpgrades" src="Pictures/Transparent Pics/No Singularity Upgrade Challenge.png">
+                    </div>
                 </div>
                 <div id="singularityChallengeDetails" alt="singularityChallengeDetails">
                     <p id="singularityChallengesMultiline" alt="singularityChallengesMultiline"></p>

--- a/src/SingularityChallenges.ts
+++ b/src/SingularityChallenges.ts
@@ -126,7 +126,7 @@ export class SingularityChallenge {
     }
 
     public updateIconHTML(): void {
-        const color = (this.enabled) ? 'orchid' : 'transparent'
+        const color = (this.enabled) ? 'orchid' : ''
         DOMCacheGetOrSet(`${this.HTMLTag}`).style.backgroundColor = color
     }
 


### PR DESCRIPTION
Don't know if can be done better (I tryed using angle rotation of border image, but that's awkwardly skips corners)
Code is minimal (meant everything is important, only display flex can turned into grid)

You can pause annimation by adding animation-play-state: inherit; to ::before element and 'paused' (through JS) to parent element. Or maybe through query selector
You can remove border from element by removing class (image will take it's original look with original border)
Border can be added to any square element by putting them into any container and giving container that class, will only need to adjust container height and width (element will be auto adjusted), potentially increase border-radius. Also will need to remove transparent color BG in JS, instead set it to '', this way color will be of same as html bg