### PR TITLE
Fix singularity challenge exit and import fails

### DIFF
--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -567,7 +567,7 @@ export const generateEventHandlers = () => {
     // Various functions
     DOMCacheGetOrSet('exportgame').addEventListener('click', () => exportSynergism())
     DOMCacheGetOrSet('saveStringInput').addEventListener('blur', e => updateSaveString(e.target as HTMLInputElement));
-    DOMCacheGetOrSet('savegame').addEventListener('click', ({ target }) => saveSynergy(true, target as HTMLButtonElement))
+    DOMCacheGetOrSet('savegame').addEventListener('click', () => saveSynergy(true))
     DOMCacheGetOrSet('deleteGame').addEventListener('click', () => resetGame())
     DOMCacheGetOrSet('preloadDeleteGame').addEventListener('click', () => reloadDeleteGame())
     DOMCacheGetOrSet('promocodes').addEventListener('click', () => promocodesPrompt())

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -1,4 +1,4 @@
-import { player, saveSynergy, blankSave, reloadShit, format } from './Synergism';
+import { player, saveSynergy, blankSave, reloadShit, format, saveCheck } from './Synergism';
 import { octeractGainPerSecond } from './Calculate';
 import { testing, version } from './Config';
 import { cleanString, getElementById } from './Utility';
@@ -253,12 +253,15 @@ export const importSynergism = async (input: string | null, reset = false) => {
             return Alert('Unable to import this file!');
         }
 
+        saveCheck.canSave = false;
         const item = new Blob([saveString], { type: 'text/plain' });
         await localforage.setItem<Blob>('Synergysave2', item);
 
         localStorage.setItem('saveScumIsCheating', Date.now().toString());
 
-        return reloadShit(reset);
+        await reloadShit(reset);
+        saveCheck.canSave = true;
+        return;
     } else {
         return Alert('You are attempting to load a testing file in a non-testing version!');
     }

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1164,6 +1164,7 @@ export const singularity = async (setSingNumber = -1): Promise<void> => {
         }
     }*/
     await importSynergism(btoa(JSON.stringify(hold)), true);
+    //Techically possible to import game during reset. But that will only "hurt" that imported save
 
     // TODO: Do not enable data that has never used an event code
     player.codes.set(39, true);


### PR DESCRIPTION
That fixes old original double Singularity bug, also really old bug with import randomly failing, and lastly fixes exiting Singularity challenge not reseting
Cause of all of them was that saveSynergism function were overwritting localforage that was already used by any of above

I removed some of old double Singularity bug solutions because this one is better
I don't know what player.offlineTick does, I would put extra check if can save before it (original solution doesn't either), but lint is thinking that condition is always falsy (because of code racing it's not), but that mostly just optimization