### PR TITLE
fix multiplier order in getOcteractValueMultipliers

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -1343,9 +1343,9 @@ export const getOcteractValueMultipliers = () => {
         // digital octeract accumulator
         Math.pow(1 + +player.octeractUpgrades.octeractAscensionsOcteractGain.getEffect().bonus, 1 + Math.floor(Math.log10(1 + player.ascensionCount))),
         1 + calculateEventBuff('Octeract'),
+        1 + +player.singularityUpgrades.platonicDelta.getEffect().bonus * Math.min(9, player.singularityCounter / (3600 * 24)),
         // No Singulairty Upgrades
         +player.singularityChallenges.noSingularityUpgrades.rewards.cubes,
-        1 + +player.singularityUpgrades.platonicDelta.getEffect().bonus * Math.min(9, player.singularityCounter / (3600 * 24)),
         // Wow Pass INF
         Math.pow(1.02, player.shopUpgrades.seasonPassInfinity)
     ];


### PR DESCRIPTION
at 'Octeract Multiplier' section in 'Stats for Nerds', labels are 'Event', 'DELTA', 'No Sing', 'Wow Pass ∞' order, but values are 'Event', 'No Sing', 'DELTA', 'Wow Pass ∞' order.
![image](https://user-images.githubusercontent.com/6851003/207920143-76b85816-1a2d-4877-afa0-a4413fd199e9.png)

this PR fixes order of values.

https://github.com/Pseudo-Corp/SynergismOfficial/blob/d12272002f1f001c08c141f9d75cee842d6e98f9/src/Statistics.ts#L325-L328
https://github.com/Pseudo-Corp/SynergismOfficial/blob/d12272002f1f001c08c141f9d75cee842d6e98f9/src/Calculate.ts#L1345-L1350