### PR TITLE
Fix auto research not working when 'manual'

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3780,7 +3780,8 @@ const tack = (dt: number) => {
         }
 
         //Automatically tries and buys researches lol
-        if (player.autoResearchToggle && autoResearchEnabled() && player.autoResearch > 0 && player.autoResearch <= maxRoombaResearchIndex(player)) {
+        if (player.autoResearchToggle && player.autoResearch > 0 && player.autoResearch <= maxRoombaResearchIndex(player) &&
+                (autoResearchEnabled() || player.autoResearchMode === 'manual')) {
             // buyResearch() probably shouldn't even be called if player.autoResearch exceeds the highest unlocked research
             let counter = 0;
             const maxCount = 1 + player.challengecompletions[14];

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -427,7 +427,7 @@ export const toggleResearchBuy = () => {
 
 export const toggleAutoResearch = () => {
     const el = DOMCacheGetOrSet('toggleautoresearch')
-    if (player.autoResearchToggle) {
+    if (player.autoResearchToggle || player.shopUpgrades.obtainiumAuto < 1) {
         player.autoResearchToggle = false;
         el.textContent = 'Automatic: OFF';
         DOMCacheGetOrSet(`res${player.autoResearch || 1}`).classList.remove('researchRoomba');
@@ -445,7 +445,7 @@ export const toggleAutoResearch = () => {
 
 export const toggleAutoResearchMode = () => {
     const el = DOMCacheGetOrSet('toggleautoresearchmode')
-    if (player.autoResearchMode === 'cheapest') {
+    if (player.autoResearchMode === 'cheapest' || !autoResearchEnabled()) {
         player.autoResearchMode = 'manual';
         el.textContent = 'Automatic mode: Manual';
     } else {


### PR DESCRIPTION
Also added check for if you are allowed to switch toggle's (against html cheating, also it's better perfomance wise)

Because of PR that added 'autoResearchEnabled()' auto research if you are on manual would not buy anything unless you would reincarnate, but for really late game reincarnating can really hurt. And in early game most of obtainium comes not from reincarnation anyway