### PR TITLE
feat: adds a global speed stats page

### DIFF
--- a/index.html
+++ b/index.html
@@ -3009,6 +3009,7 @@ $STAGE$ for synergism stage"></p>
             <button class="statsNerds" id="kFreeMult" alt="kFreeMult" label="kFreeMult" style="border: 2px solid lawngreen">Free Multipliers</button>
             <button class="statsNerds" id="kOfferingMult" alt="kOfferingMult" label="kOfferingMult" style="border: 2px solid palegreen">Offering Multipliers</button>
             <button class="statsNerds" id="kQuarkMult" alt="kQuarkMult" label="kQuarkMult" style="border: 2px solid white">Global Quark Multipliers</button>
+            <button class="statsNerds reincarnationunlock" id="kGSpeedMult" alt="kGSpeedMult" label="kGSpeedMult" style="border: 2px solid blue">Global Speed Multipliers</button>
             <button class="statsNerds ascendunlock" id="kASCMult" alt="kASCMult" label="kASCMult" style="border: 2px solid orange">Ascension Speed Multipliers</button>
             <button class="statsNerds ascendunlock" id="kGlobalCubeMult" alt="kGlobalCubeMult" label="kGlobalCubeMult" style="border: 2px solid khaki">Global Cube Multipliers</button>
             <button class="statsNerds ascendunlock" id="kCubeMult" alt="kCubeMult" label="kCubeMult" style="border: 2px solid darkgoldenrod">Cube Multipliers</button>
@@ -3105,6 +3106,43 @@ $STAGE$ for synergism stage"></p>
             <p id="statOff31" alt="statOff31" label="statOff31" class="statPortion">Offering Electrolosis [OC]: <span id="sOff31" alt="sOff31" label="sOff31" class="statNumber">0</span></p>
             <p id="statOff32" alt="statOff32" label="statOff32" class="statPortion">Event: <span id="sOff32" alt="sOff32" label="sOff32" class="statNumber">0</span></p>
             <p id="statOffT" alt="statOffT" label="statOffT" class="statPortion statTotal" style='color: gold'>TOTAL OFFERING MULTIPLIER: <span id="sOffT" alt="sOffT" label="sOffT" class="statNumber statTotal">0</span></p>
+        </div>
+        <div id="globalSpeedMultiplierStats" alt="globalSpeedMultiplierStats" label="globalSpeedMultiplierStats" class="statContainer" style="display: none;">
+            <p id="GlobalSpeedStatTitle" alt="GlobalSpeedStatTitle" label="GlobalSpeedStatTitle" class='statPortion' style="color: blue; font-size: 1.2em">Global Speed Multipliers</p>
+
+            <!-- Corruptable / DR-susceptible set-->
+            <p id="statGSMa1" alt="statGSMa1" label="statGSMa1" class="statPortion reincarnationunlock">Particle Upgrade 2x5:<span id="sGSMa1" alt="sGSMa1" label="sGSMa1" class="statNumber">0</span></p>
+            <p id="statGSMa2" alt="statGSMa2" label="statGSMa2" class="statPortion reincarnationunlock">Research 5x21:<span id="sGSMa2" alt="sGSMa2" label="sGSMa2" class="statNumber">0</span></p>
+            <p id="statGSMa3" alt="statGSMa3" label="statGSMa3" class="statPortion reincarnationunlock">Research 6x11:<span id="sGSMa3" alt="sGSMa3" label="sGSMa3" class="statNumber">0</span></p>
+            <p id="statGSMa4" alt="statGSMa4" label="statGSMa4" class="statPortion reincarnationunlock">Research 7x1:<span id="sGSMa4" alt="sGSMa4" label="sGSMa4" class="statNumber">0</span></p>
+            <p id="statGSMa5" alt="statGSMa5" label="statGSMa5" class="statPortion reincarnationunlock">Research 7x16:<span id="sGSMa5" alt="sGSMa5" label="sGSMa5" class="statNumber">0</span></p>
+            <p id="statGSMa6" alt="statGSMa6" label="statGSMa6" class="statPortion reincarnationunlock">Research 8x6:<span id="sGSMa6" alt="sGSMa6" label="sGSMa6" class="statNumber">0</span></p>
+            <p id="statGSMa7" alt="statGSMa7" label="statGSMa7" class="statPortion reincarnationunlock">Research 8x21:<span id="sGSMa7" alt="sGSMa7" label="sGSMa7" class="statNumber">0</span></p>
+            <p id="statGSMa8" alt="statGSMa8" label="statGSMa8" class="statPortion reincarnationunlock">Blessing Power:<span id="sGSMa8" alt="sGSMa8" label="sGSMa8" class="statNumber">0</span></p>
+            <p id="statGSMa9" alt="statGSMa9" label="statGSMa9" class="statPortion chal12">Spirit Power:<span id="sGSMa9" alt="sGSMa9" label="sGSMa9" class="statNumber">0</span></p>
+            <p id="statGSMa10" alt="statGSMa10" label="statGSMa10" class="statPortion ascendunlock">Chronos' Tribute Multiplier:<span id="sGSMa10" alt="sGSMa10" label="sGSMa10" class="statNumber">0</span></p>
+            <p id="statGSMa11" alt="statGSMa11" label="statGSMa11" class="statPortion ascendunlock">Cube Upgrade 2x8:<span id="sGSMa11" alt="sGSMa11" label="sGSMa11" class="statNumber">0</span></p>
+            <p id="statGSMa12" alt="statGSMa12" label="statGSMa12" class="statPortion chal8">Mortuus Est Formicidae:<span id="sGSMa12" alt="sGSMa12" label="sGSMa12" class="statNumber">0</span></p>
+            <p id="statGSMa13" alt="statGSMa13" label="statGSMa13" class="statPortion chal9">Exemption Talisman:<span id="sGSMa13" alt="sGSMa13" label="sGSMa13" class="statNumber">0</span></p>
+            <p id="statGSMa14" alt="statGSMa14" label="statGSMa14" class="statPortion chal14">Challenge 15:<span id="sGSMa14" alt="sGSMa14" label="sGSMa14" class="statNumber">0</span></p>
+            <p id="statGSMa15" alt="statGSMa15" label="statGSMa15" class="statPortion singularity">Cookie Upgrade 2:<span id="sGSMa15" alt="sGSMa15" label="sGSMa15" class="statNumber">0</span></p>
+
+            <p id="statGSsep1" alt="statGSsep1" label="statGSsep1" class="statPortion">&nbsp;</p>
+
+            <!-- Corruption / DR effects -->
+            <p id="statGSMb1" alt="statGSMb1" label="statGSMb1" class="statPortion chal14">Corruption (Spacial Dilation):<span id="sGSMb1" alt="sGSMb1" label="sGSMb1" class="statNumber">0</span></p>
+            <p id="statGSMb2" alt="statGSMb2" label="statGSMb2" class="statPortion">Global speed softcap:<span id="sGSMb2" alt="sGSMb2" label="sGSMb2" class="statNumber">0</span></p>
+            <p id="statGSMb3" alt="statGSMb3" label="statGSMb3" class="statPortion chal14">Platonic 2x2:<span id="sGSMb3" alt="sGSMb3" label="sGSMb3" class="statNumber">0</span></p>
+            <p id="statGSMb4" alt="statGSMb4" label="statGSMb4" class="statPortion singularity">Singularity Penalty:<span id="sGSMb4" alt="sGSMb4" label="sGSMb4" class="statNumber">0</span></p>
+
+            <p id="statGSsep2" alt="statGSsep2" label="statGSsep2" class="statPortion singularity">&nbsp;</p>
+
+            <!-- Post-corruption / post-DR effects -->
+            <p id="statGSMc1" alt="statGSMc1" label="statGSMc1" class="statPortion chal14">Chronos Statue:<span id="sGSMc1" alt="sGSMc1" label="sGSMc1" class="statNumber">0</span></p>
+            <p id="statGSMc2" alt="statGSMc2" label="statGSMc2" class="statPortion singularity">Intermediate Pack:<span id="sGSMc2" alt="sGSMc2" label="sGSMc2" class="statNumber">0</span></p>
+            <p id="statGSMc3" alt="statGSMc3" label="statGSMc3" class="statPortion singularity">Forbidden Clock of Time:<span id="sGSMc3" alt="sGSMc3" label="sGSMc3" class="statNumber">0</span></p>
+
+            <p id ="statGSMT" alt="statGSMT" label="statGSMT" class="statPortion statTotal" style='color: white'>TOTAL GLOBAL SPEED MULTIPLIER:<span id="sGSMT" alt="sGSMT" label="sGSMT" class="statNumber statTotal">0</span></p>
         </div>
         <div id="globalQuarkMultiplierStats" alt="globalQuarkMultiplierStats" label="globalQuarkMultiplierStats" class="statContainer" style="display: none;">
             <p id="GlobalQuarkStatTitle" alt="GlobalQuarkStatTitle" label="GlobalQuarkStatTitle" class='statPortion' style="color: white; font-size: 1.2em">Global Quark Multipliers</p>

--- a/src/Achievements.ts
+++ b/src/Achievements.ts
@@ -482,7 +482,7 @@ export const areward = (i: number): string => {
         221: 'Gain +4% Platonic Cubes on Ascension!',
         222: 'Gain +3% Platonic Cubes on Ascension!',
         223: `Gain 20% of Excess time after 10 seconds each Ascensions as a linear multiplier to Ascension count. Also: Platonic Cubes +${format(Math.min(200, player.ascensionCount / 13370000), 2)}% [Max: 200% at 2.674B Ascensions]`,
-        240: `Ascension Cube Gain Multipliers is VERY slightly affected by global speed multipliers: ${format(Math.min(1.5, 1 + Math.max(2, Math.log10(calculateTimeAcceleration()))/20), 2)}x (Min: 1.10x, Max: 1.50x)`,
+        240: `Ascension Cube Gain Multipliers is VERY slightly affected by global speed multipliers: ${format(Math.min(1.5, 1 + Math.max(2, Math.log10(calculateTimeAcceleration().mult))/20), 2)}x (Min: 1.10x, Max: 1.50x)`,
         250: 'You gain a permanent +60% Obtainium and Offering bonus, with +6% all Cube types!',
         251: 'You gain a permanent +100% Obtainium and Offering bonus, with +10% all Cube types!',
         253: 'You will gain +10% Hypercubes! Why? I don\'t know.',

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -890,7 +890,7 @@ export const calculateOffline = async (forceTime = 0) => {
 
     player.offlinetick = (player.offlinetick < 1.5e12) ? (Date.now()) : player.offlinetick;
 
-    G['timeMultiplier'] = calculateTimeAcceleration();
+    G['timeMultiplier'] = calculateTimeAcceleration().mult;
     calculateObtainium();
     const obtainiumGain = calculateAutomaticObtainium();
 
@@ -926,7 +926,7 @@ export const calculateOffline = async (forceTime = 0) => {
 
     //200 simulated all ticks [July 12, 2021]
     const runOffline = setInterval(() => {
-        G['timeMultiplier'] = calculateTimeAcceleration();
+        G['timeMultiplier'] = calculateTimeAcceleration().mult;
         calculateObtainium();
 
         //Reset Stuff lmao!
@@ -1124,7 +1124,7 @@ export const calculateAllCubeMultiplier = () => {
         // Sun and Moon achievements
         1 + 6 / 100 * player.achievements[250] + 10 / 100 * player.achievements[251],
         // Speed Achievement
-        1 + player.achievements[240] * Math.min(0.5, Math.max(0.1, 1 / 20 * Math.log10(calculateTimeAcceleration() + 0.01))),
+        1 + player.achievements[240] * Math.min(0.5, Math.max(0.1, 1 / 20 * Math.log10(calculateTimeAcceleration().mult + 0.01))),
         // Challenge 15: All Cube Gain bonuses 1-5
         G['challenge15Rewards'].cube1 * G['challenge15Rewards'].cube2 * G['challenge15Rewards'].cube3 * G['challenge15Rewards'].cube4 * G['challenge15Rewards'].cube5,
         // Rune 6: Infinite Ascent
@@ -1449,34 +1449,60 @@ export const calculateOcteractMultiplier = (score = -1) => {
 }
 
 export const calculateTimeAcceleration = () => {
-    let timeMult = 1;
-    timeMult *= (1 + 1 / 300 * Math.log10(player.maxobtainium + 1) * player.upgrades[70]) //Particle upgrade 2x5
-    timeMult *= (1 + player.researches[121] / 50); // research 5x21
-    timeMult *= (1 + 0.015 * player.researches[136]) // research 6x11
-    timeMult *= (1 + 0.012 * player.researches[151]) // research 7x1
-    timeMult *= (1 + 0.009 * player.researches[166]) // research 7x16
-    timeMult *= (1 + 0.006 * player.researches[181]) // research 8x6
-    timeMult *= (1 + 0.003 * player.researches[196]) // research 8x21
-    timeMult *= (1 + 8 * G['effectiveRuneBlessingPower'][1]); // speed blessing
-    timeMult *= (1 + calculateCorruptionPoints() / 400 * G['effectiveRuneSpiritPower'][1]) // speed SPIRIT
-    timeMult *= G['cubeBonusMultiplier'][10]; // Chronos cube blessing
-    timeMult *= 1 + player.cubeUpgrades[18] / 5; // cube upgrade 2x8
-    timeMult *= calculateSigmoid(2, player.antUpgrades[12-1]! + G['bonusant12'], 69) // ant 12
-    timeMult *= (1 + 0.10 * (player.talismanRarity[2-1] - 1)) // Chronos Talisman bonus
-    timeMult *= G['challenge15Rewards'].globalSpeed // Challenge 15 reward
-    timeMult *= 1 + 0.01 * player.cubeUpgrades[52] // cube upgrade 6x2 (Cx2)
-    timeMult *= G['lazinessMultiplier'][player.usedCorruptions[3]]
-    if (timeMult > 100) {
-        timeMult = 10 * Math.sqrt(timeMult)
+    const preCorruptionArr = [
+        (1 + 1 / 300 * Math.log10(player.maxobtainium + 1) * player.upgrades[70]),  // Particle upgrade 2x5
+        (1 + player.researches[121] / 50),                                          // research 5x21
+        (1 + 0.015 * player.researches[136]),                                       // research 6x11
+        (1 + 0.012 * player.researches[151]),                                       // research 7x1
+        (1 + 0.009 * player.researches[166]),                                       // research 7x16
+        (1 + 0.006 * player.researches[181]),                                       // research 8x6
+        (1 + 0.003 * player.researches[196]),                                       // research 8x21
+        (1 + 8 * G['effectiveRuneBlessingPower'][1]),                               // speed blessing
+        (1 + calculateCorruptionPoints() / 400 * G['effectiveRuneSpiritPower'][1]), // speed SPIRIT
+        G['cubeBonusMultiplier'][10],                                               // Chronos cube blessing
+        1 + player.cubeUpgrades[18] / 5,                                            // cube upgrade 2x8
+        calculateSigmoid(2, player.antUpgrades[12-1]! + G['bonusant12'], 69),       // ant 12
+        (1 + 0.10 * (player.talismanRarity[2-1] - 1)),                              // Chronos Talisman bonus
+        G['challenge15Rewards'].globalSpeed,                                        // Challenge 15 reward
+        1 + 0.01 * player.cubeUpgrades[52]                                          // cube upgrade 6x2 (Cx2)
+    ];
+
+    // Global Speed softcap + Corruption / Corruption-like effects
+    const corruptionArr: number[] = [
+        G['lazinessMultiplier'][player.usedCorruptions[3]]                          // Corruption:  Spacial Dilation
+    ];
+
+    const corruptableTimeMult = productContents(preCorruptionArr) * corruptionArr[0]; // DR applies after base corruption.
+
+    if (corruptableTimeMult > 100) {
+        const postSoftcap = 10 * Math.sqrt(corruptableTimeMult);
+        const softcapRatio = postSoftcap / corruptableTimeMult;
+
+        corruptionArr.push(softcapRatio);
+    } else {
+        corruptionArr.push(1);
     }
-    if (timeMult < 1) {
-        timeMult = Math.pow(timeMult, 1 - player.platonicUpgrades[7] / 30)
+
+    if (corruptableTimeMult < 1) {
+        const postPlat2x2 = Math.pow(corruptableTimeMult, 1 - player.platonicUpgrades[7] / 30);
+        const plat2x2Ratio = postPlat2x2 / corruptableTimeMult;
+
+        corruptionArr.push(plat2x2Ratio);
+    } else {
+        corruptionArr.push(1);
     }
-    timeMult /= calculateSingularityDebuff('Global Speed');
-    timeMult *= G['platonicBonusMultiplier'][7]
-    timeMult *= 1 + calculateEventBuff('Global Speed');
-    timeMult *= 1 + (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0)
-    timeMult *= 1 + +player.octeractUpgrades.octeractImprovedGlobalSpeed.getEffect().bonus * player.singularityCount
+
+    corruptionArr.push(1.0 / calculateSingularityDebuff('Global Speed'));
+
+    // Uncorruptable effects
+    const postCorruptionArr = [
+        G['platonicBonusMultiplier'][7],    // Chronos statue
+        1 + (player.singularityUpgrades.intermediatePack.getEffect().bonus ? 1 : 0),
+        1 + +player.octeractUpgrades.octeractImprovedGlobalSpeed.getEffect().bonus * player.singularityCount
+    ];
+
+    const timeMult = productContents(preCorruptionArr) * productContents(corruptionArr) * productContents(postCorruptionArr);
+
 
     if (player.usedCorruptions[3] >= 6 && player.achievements[241] < 1) {
         achievementaward(241)
@@ -1484,8 +1510,13 @@ export const calculateTimeAcceleration = () => {
     if (timeMult > 3600 && player.achievements[242] < 1) {
         achievementaward(242)
     }
-    //timeMult *= 25
-    return (timeMult)
+
+    return {
+        preList: preCorruptionArr,
+        drList: corruptionArr,
+        postList: postCorruptionArr,
+        mult: timeMult
+    };
 }
 
 export const calculateAscensionSpeedMultiplier = () => {

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -396,7 +396,7 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.usedCorruptions[0] = 0
     }
     if (player.antSacrificeTimerReal === undefined) {
-        player.antSacrificeTimerReal = player.antSacrificeTimer / calculateTimeAcceleration();
+        player.antSacrificeTimerReal = player.antSacrificeTimer / calculateTimeAcceleration().mult;
     }
     if (player.subtabNumber === undefined || data.subtabNumber === undefined) {
         player.subtabNumber = 0;

--- a/src/Helper.ts
+++ b/src/Helper.ts
@@ -20,7 +20,7 @@ type TimerInput = 'prestige' | 'transcension' | 'reincarnation' | 'ascension' |
  */
 export const addTimers = (input: TimerInput, time = 0) => {
     const timeMultiplier = (input === 'ascension' || input === 'quarks' || input === 'goldenQuarks' ||
-                            input === 'singularity' || input === 'octeracts' || input === 'autoPotion') ? 1 : calculateTimeAcceleration();
+                            input === 'singularity' || input === 'octeracts' || input === 'autoPotion') ? 1 : calculateTimeAcceleration().mult;
 
     switch (input){
         case 'prestige': {
@@ -142,7 +142,7 @@ type AutoToolInput = 'addObtainium' | 'addOfferings' | 'runeSacrifice' | 'antSac
  * @param time
  */
 export const automaticTools = (input: AutoToolInput, time: number) => {
-    const timeMultiplier = (input === 'runeSacrifice' || input === 'addOfferings') ? 1 : calculateTimeAcceleration()
+    const timeMultiplier = (input === 'runeSacrifice' || input === 'addOfferings') ? 1 : calculateTimeAcceleration().mult
 
     switch (input){
         case 'addObtainium': {

--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -634,10 +634,10 @@ export const shopDescriptions = (input: ShopUpgradeNames) => {
 
     switch (input) {
         case 'offeringPotion':
-            lol.textContent = 'Gain ' + format((7200 * player.offeringpersecond * calculateTimeAcceleration() * +player.singularityUpgrades.potionBuff.getEffect().bonus), 0, true) + ' Offerings.'
+            lol.textContent = 'Gain ' + format((7200 * player.offeringpersecond * calculateTimeAcceleration().mult * +player.singularityUpgrades.potionBuff.getEffect().bonus), 0, true) + ' Offerings.'
             break;
         case 'obtainiumPotion':
-            lol.textContent = 'Gain ' + format((7200 * player.maxobtainiumpersecond * calculateTimeAcceleration() * +player.singularityUpgrades.potionBuff.getEffect().bonus), 0, true) + ' Obtainium.';
+            lol.textContent = 'Gain ' + format((7200 * player.maxobtainiumpersecond * calculateTimeAcceleration().mult * +player.singularityUpgrades.potionBuff.getEffect().bonus), 0, true) + ' Obtainium.';
             break;
         case 'offeringEX':
             lol.textContent = 'CURRENT Effect: You will gain ' + format(4 * player.shopUpgrades.offeringEX,2,true) + '% more Offerings!'
@@ -983,13 +983,13 @@ export const useConsumable = async (input: ShopUpgradeNames, automatic = false, 
         if (input === 'offeringPotion') {
             if (player.shopUpgrades.offeringPotion >= used || !spend) {
                 player.shopUpgrades.offeringPotion -= (spend ? used: 0);
-                player.runeshards += Math.floor(7200 * player.offeringpersecond * calculateTimeAcceleration() * multiplier)
+                player.runeshards += Math.floor(7200 * player.offeringpersecond * calculateTimeAcceleration().mult * multiplier)
                 player.runeshards = Math.min(1e300, player.runeshards)
             }
         } else if (input === 'obtainiumPotion') {
             if (player.shopUpgrades.obtainiumPotion >= used || !spend) {
                 player.shopUpgrades.obtainiumPotion -= (spend? used: 0);
-                player.researchPoints += Math.floor(7200 * player.maxobtainiumpersecond * calculateTimeAcceleration() * multiplier)
+                player.researchPoints += Math.floor(7200 * player.maxobtainiumpersecond * calculateTimeAcceleration().mult * multiplier)
                 player.researchPoints = Math.min(1e300, player.researchPoints)
             }
         }

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -1,7 +1,7 @@
 import { player, format, formatTimeShort } from './Synergism';
 import { Globals as G } from './Variables';
 import { hepteractEffective } from './Hepteracts'
-import {calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier, calculateQuarkMultiplier, calculateEventBuff, calculateSingularityQuarkMilestoneMultiplier, calculateTotalOcteractQuarkBonus, calculateAscensionSpeedMultiplier, calculateGoldenQuarkMultiplier } from './Calculate';
+import {calculateSigmoidExponential, calculateCubeMultiplier, calculateOfferings, calculateTimeAcceleration, calculateTesseractMultiplier, calculateHypercubeMultiplier, calculatePlatonicMultiplier, calculateHepteractMultiplier, calculateAllCubeMultiplier, calculateSigmoid, calculatePowderConversion, calculateEffectiveIALevel, calculateQuarkMultFromPowder, calculateOcteractMultiplier, calculateQuarkMultiplier, calculateEventBuff, calculateSingularityQuarkMilestoneMultiplier, calculateTotalOcteractQuarkBonus, calculateAscensionSpeedMultiplier, calculateGoldenQuarkMultiplier } from './Calculate';
 import { challenge15ScoreMultiplier } from './Challenges';
 import type { GlobalVariables } from './types/Synergism';
 import { DOMCacheGetOrSet } from './Cache/DOM';
@@ -14,6 +14,7 @@ const associated = new Map<string, string>([
     ['kOfferingMult', 'offeringMultiplierStats'],
     ['kGlobalCubeMult', 'globalCubeMultiplierStats'],
     ['kQuarkMult', 'globalQuarkMultiplierStats'],
+    ['kGSpeedMult', 'globalSpeedMultiplierStats'],
     ['kCubeMult', 'cubeMultiplierStats'],
     ['kTessMult', 'tesseractMultiplierStats'],
     ['kHypercubeMult', 'hypercubeMultiplierStats'],
@@ -58,6 +59,9 @@ export const loadStatisticsUpdate = () => {
                 break;
             case 'globalQuarkMultiplierStats':
                 loadQuarkMultiplier();
+                break;
+            case 'globalSpeedMultiplierStats':
+                loadGlobalSpeedMultiplier();
                 break;
             case 'powderMultiplierStats':
                 loadPowderMultiplier();
@@ -159,6 +163,28 @@ export const loadQuarkMultiplier = () => {
     true)
     DOMCacheGetOrSet('sGQMT').textContent = 'x' + format(player.worlds.applyBonus(1), 3, true)
 }
+
+export const loadGlobalSpeedMultiplier = () => {
+    const globalSpeedStats = calculateTimeAcceleration();
+
+    const preDRlist = globalSpeedStats.preList;
+    for (let i = 0; i < preDRlist.length; i++) {
+        DOMCacheGetOrSet(`sGSMa${i + 1}`).textContent = `x${format(preDRlist[i], 3, true)}`;
+    }
+
+    const drList = globalSpeedStats.drList;
+    for (let i = 0; i < drList.length; i++) {
+        DOMCacheGetOrSet(`sGSMb${i + 1}`).textContent = `x${format(drList[i], 3, true)}`;
+    }
+
+    const postDRlist = globalSpeedStats.postList;
+    for (let i = 0; i < postDRlist.length; i++) {
+        DOMCacheGetOrSet(`sGSMc${i + 1}`).textContent = `x${format(postDRlist[i], 3, true)}`;
+    }
+
+    DOMCacheGetOrSet('sGSMT').textContent = format(globalSpeedStats.mult, 3);
+}
+
 export const loadStatisticsCubeMultipliers = () => {
 
     const arr0 = calculateAllCubeMultiplier().list;

--- a/src/Summary.ts
+++ b/src/Summary.ts
@@ -131,7 +131,7 @@ export const generateExportSummary = async():Promise<void> => {
         reincarnation = reincarnation + `Reincarnation Count: ${format(player.reincarnationCount, 0, true)}\n`
         reincarnation = reincarnation + `Reincarnation Timer: ${formatS(player.reincarnationcounter)}\n`
         reincarnation = reincarnation + `Fastest Reincarnation: ${formatS(player.fastestreincarnate)}\n`
-        reincarnation = reincarnation + `Global Speed Multiplier: ${format(calculateTimeAcceleration(), 2, true)}\n`
+        reincarnation = reincarnation + `Global Speed Multiplier: ${format(calculateTimeAcceleration().mult, 2, true)}\n`
         reincarnation = reincarnation + `Challenge 6 Completions: ${player.highestchallengecompletions[6]}/${getMaxChallenges(6)}\n`
         reincarnation = reincarnation + `Challenge 7 Completions: ${player.highestchallengecompletions[7]}/${getMaxChallenges(7)}\n`
         reincarnation = reincarnation + `Challenge 8 Completions: ${player.highestchallengecompletions[8]}/${getMaxChallenges(8)}\n`

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -3747,7 +3747,7 @@ const tick = () => {
 const tack = (dt: number) => {
     if (!G['timeWarp']) {
         //Adds Resources (coins, ants, etc)
-        const timeMult = calculateTimeAcceleration();
+        const timeMult = calculateTimeAcceleration().mult;
         resourceGain(dt * timeMult)
         //Adds time (in milliseconds) to all reset functions, and quarks timer.
         addTimers('prestige', dt)

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -931,7 +931,7 @@ const updateAscensionStats = () => {
         'ascPlatonic': format(platonic * (player.ascStatToggles[4] ? 1 : 1 / t), 5),
         'ascHepteract': format(hepteract * (player.ascStatToggles[5] ? 1 : 1 / t), 3),
         'ascC10': `${format(player.challengecompletions[10])}`,
-        'ascTimeAccel': `${format(calculateTimeAcceleration(), 3)}x`,
+        'ascTimeAccel': `${format(calculateTimeAcceleration().mult, 3)}x`,
         'ascAscensionTimeAccel': `${format(calculateAscensionAcceleration(), 3)}x${addedAsterisk ? '*' : ''}`,
         'ascSingularityCount': format(player.singularityCount),
         'ascSingLen': formatTimeShort(player.singularityCounter)

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -292,7 +292,7 @@ export const visualUpdateResearch = () => {
     }
 
     if (player.researches[61] > 0) {
-        DOMCacheGetOrSet('automaticobtainium').textContent = 'Thanks to researches you automatically gain ' + format(calculateAutomaticObtainium() * calculateTimeAcceleration(), 3, true) + ' Obtainium per real life second.'
+        DOMCacheGetOrSet('automaticobtainium').textContent = 'Thanks to researches you automatically gain ' + format(calculateAutomaticObtainium() * calculateTimeAcceleration().mult, 3, true) + ' Obtainium per real life second.'
     }
 }
 


### PR DESCRIPTION
The picture of a thousand words:

![image](https://user-images.githubusercontent.com/31546028/209440131-fef867fb-28ba-46a4-bd1b-77dc82478432.png)

Introducing a new "Stats for Nerds" page - "Global Speed Multipliers"!

The three sections are meant to represent the three stages of calculation:
- base multipliers (before DR, corruption)
- Corruption & DR effects
- uncorruptible effects

The 'blue' color was selected due to its existing use in the game's UI - just look at the timer near the top-right.  No reason we can't change that, of course.

Free free to modify the layout & ordering; I do feel like some of the entries would be "better" if positioned earlier than they currently are within their list.  (Example:  Mortuus Est Formicidae unlocks before research 6x11, yet it's much lower within its list!)  For now, I've kept every component of the calculation in its original order within the `calculateTimeAcceleration` method; that should make the initial review easier, since I did have to refactor an important function in the game to expose the various multipliers for the stats page.

Under different conditions (SD = 14):

![image](https://user-images.githubusercontent.com/31546028/209441989-19e1adb5-c225-48eb-9110-57a6e2ce6168.png)
