### PR TITLE
Fixed Singularity reset not doing a full save

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1,4 +1,4 @@
-import { player, format, blankSave, updateAll } from './Synergism';
+import { player, format, blankSave, updateAll, saveSynergy } from './Synergism';
 import {
     calculateOfferings, CalcCorruptionStuff, calculateCubeBlessings, calculateRuneLevels,
     calculateAnts, calculateObtainium, calculateTalismanEffects, calculateAntSacrificeELO,
@@ -1194,6 +1194,9 @@ export const singularity = async (setSingNumber = -1): Promise<void> => {
     updateSingularityMilestoneAwards();
 
     player.rngCode = Date.now();
+
+    // Save again at the end of singularity reset
+    void saveSynergy();
 }
 
 const resetUpgrades = (i: number) => {


### PR DESCRIPTION
Fixed critical issue where updateSingularityMilestoneAwards() and event code usage flags and reset add were not saved if the page was reloaded immediately after a Singularity reset.
This allowed the event code to be used as a repeatable exploit. Because this exploit will definitely break the game. Need a quick merge.

This matter should not be discussed on discord.