### PR TITLE
change: restyles sing shop + oct shop enhanced vision

### DIFF
--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -560,16 +560,28 @@ export const visualUpdateSingularity = () => {
                 continue
             }
             const singItem = player.singularityUpgrades[key];
-            const el = DOMCacheGetOrSet(`${String(key)}`);
+            const el = DOMCacheGetOrSet(`${String(key)}`) as HTMLImageElement;
             if (singItem.maxLevel !== -1 && singItem.level >= singItem.computeMaxLevel()) {
-                el.style.filter = val ? 'brightness(.9)' : 'none';
-            } else if  (singItem.getCostTNL() > player.goldenQuarks || player.singularityCount < singItem.minimumSingularity) {
-                el.style.filter = val ? 'grayscale(.9) brightness(.8)' : 'none';
+                // Upgrade is maxed; provide a makeshift 'completed green' look for these entries.
+                el.style.filter = val ? 'opacity(0.6)' : 'none';
+                el.parentElement!.style.backgroundColor = val ? 'green' : '';
+            } else if (player.singularityCount < singItem.minimumSingularity) {
+                // Upgrade is absolutely unpurchasable
+                el.style.filter = val ? 'saturate(.15) brightness(.6)' : 'none';
+            } else if (singItem.getCostTNL() > player.goldenQuarks) {
+                // Upgrade is not currently purchasable.
+                el.style.filter = val ? 'saturate(.6) brightness(.8)' : 'none';
             } else if (singItem.maxLevel === -1 || singItem.level < singItem.computeMaxLevel()) {
                 if (singItem.freeLevels > singItem.level) {
-                    el.style.filter = val ? 'blur(1px) invert(.9) saturate(200)' : 'none';
+                    // Give it both a hint of enhanced saturation/brightness and a translucent drop-shadow
+                    // using the standard color for "softcapped" text.
+                    el.style.filter = val ? 'saturate(1.6) brightness(2) opacity(0.33) drop-shadow(0 0 1px var(--crimson-text-color))' : 'none';
+                    // Because we made the base image transparent, we replicate it in its parent's background to keep the image itself
+                    // at full opacity when composited.
+                    el.parentElement!.style.backgroundImage = val ? `url(${el.src})` : '';
                 } else {
-                    el.style.filter = val ? 'invert(.9) brightness(1.1)' : 'none';
+                    // Eh, just give it a subtle bit of extra pop, no other tweaks needed.
+                    el.style.filter = val ? 'saturate(1.2) brightness(1.1)' : 'none';
                 }
             }
         }
@@ -580,16 +592,28 @@ export const visualUpdateSingularity = () => {
 
         for (const key of keys) {
             const octItem = player.octeractUpgrades[key];
-            const el = DOMCacheGetOrSet(`${String(key)}`);
+            const el = DOMCacheGetOrSet(`${String(key)}`) as HTMLImageElement;
             if (octItem.maxLevel !== -1 && octItem.level >= octItem.maxLevel) {
-                el.style.filter = val ? 'brightness(.9)' : 'none';
-            } else if  (octItem.getCostTNL() > player.wowOcteracts) {
-                el.style.filter = val ? 'grayscale(.9) brightness(.8)' : 'none';
+                // Upgrade is maxed; provide a makeshift 'completed green' look for these entries.
+                el.style.filter = val ? 'opacity(0.6)' : 'none';
+                el.parentElement!.style.backgroundColor = val ? 'green' : '';
+            } else if (octItem.level == 0 && octItem.getCostTNL() > player.totalWowOcteracts) {
+                // Upgrade is not currently purchasable and has never been purchasable, even with 100% investment.
+                el.style.filter = val ? 'saturate(.15) brightness(.6)' : 'none';
+            } else if (octItem.getCostTNL() > player.wowOcteracts) {
+                // Upgrade is not currently purchasable, but might be reasonable to wait for.
+                el.style.filter = val ? 'saturate(.6) brightness(.8)' : 'none';
             } else if (octItem.maxLevel === -1 || octItem.level < octItem.maxLevel) {
+                // Give it both a hint of enhanced saturation/brightness and a translucent drop-shadow
+                // using the standard color for "softcapped" text.
                 if (octItem.freeLevels > octItem.level) {
-                    el.style.filter = val ? 'blur(2px) invert(.9) saturate(200)' : 'none';
+                    el.style.filter = val ? 'saturate(1.6) brightness(2) opacity(0.33) drop-shadow(0 0 1px var(--crimson-text-color))' : 'none';
+                    // Because we made the base image transparent, we replicate it in its parent's background to keep the image itself
+                    // at full opacity when composited.
+                    el.parentElement!.style.backgroundImage = val ? `url(${el.src})` : '';
                 } else {
-                    el.style.filter = val ? 'invert(.9) brightness(1.1)' : 'none';
+                    // Eh, just give it a subtle bit of extra pop, no other tweaks needed.
+                    el.style.filter = val ? 'saturate(1.2) brightness(1.1)' : 'none';
                 }
             }
         }


### PR DESCRIPTION
The styling introduced for Singularity + Octeract shop "enhanced vision" was met with mixed response in regard to its styling.  The change on hover is quite extreme and takes a bit to get used to, after all.

If nothing else, I hope this prompts some design discussion on what better styling might be & how to make these things to the user without requiring "jarring" styling effects.

------

This proposal keeps the core styling about the same, opting for tweaks that are generally more consistent with other in-game styles where possible.  Where not possible, it opts for commonly-used visual cues if possible.

So, how would this proposed alternative style change things?

![image](https://user-images.githubusercontent.com/31546028/210175418-e7f0e222-73f6-4f00-885a-7f9c6c862947.png)

After some fun CSS experimentation, I figured out a way to give a faux green / "completed" background to fully-purchased shop items.  The trick:  the image element is given partial opacity, while its _parent_ element is given a green background. 
- Note that the green background can't be put on the image element.

The faded crimson background replaces the "blur" styling; that crimson is the same crimson used for the "softcapped" text (as seen in the image) after all filter effects are applied.  Said other effects aim to make the options "pop" more while also reducing opacity in order to composite the 'filtered' version with the original.  (Same image on two layers, one altered, one not - then blended together.)

Items at approximately normal coloration and brightness - they're fully purchasable.  At "half" coloration and brightness, they're "in reach", but the player doesn't have enough quarks.

Finally, the dulled-out, desaturated options are simply unreachable at the current max singularity count ever reached by the player.

----

Oh, and for octeracts:

![image](https://user-images.githubusercontent.com/31546028/210175933-932fb003-cb3e-4d5f-ba96-8bd193546dab.png)

Very similar styling has been applied, though with one notable tweak.  Since octeract bonuses have no minimum singularity count, what to do?

"Half" coloration / brightness is used for perks that are, or have been, attainable to purchase at some point - even if only on previously-attained levels.  Note that the highlighted perk, Vitamin O, has purchased levels.  Here in particular, it costs less octeracts than the player's lifetime total as well.  So, on two counts, this particular oct perk isn't hard for the player to attain.

The dulled-out, desaturated options are considered fully unreachable by the player.  The rule of thumb I used?  If the base level of the perk requires more octeracts than the player has ever generated, it's completely out of reach.

----

It's probably worth note that I am currently unable to test the "completed" styling against the perks with a strong pre-existing background color - some testing may be needed for those.

I've put this PR in draft for now mostly because it could probably use a community review or something, rather than triggering a chain of tweaks across multiple releases.  I don't mind undrafting it if desired, though.