### PR TITLE
i18n enhancement:  adds language-select subtab under Settings

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2326,6 +2326,58 @@ p[id$="BlessingsTotal"] {
     cursor: pointer;
 }
 
+#languagesubtab {
+    flex-direction: row;
+    margin-top: 15px;
+    align-items: center;
+}
+
+.languagesMenu {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    align-items: center;
+    flex-basis: 1;
+    flex-grow: 0;
+    min-width: 450px;
+    max-width: 750px;
+    padding: 5px;
+}
+
+.languageOptions {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
+}
+
+button.language-select {
+    border: 2px solid white;
+    width: 12em;
+    min-width: 150px;
+    min-height: 40px;
+    margin: 5px;
+}
+
+button.language-select span.lang-flag {
+    font-size: 2em;
+    padding-right: 4px;
+    vertical-align: middle;
+}
+
+button.language-select span.lang-name {
+    font-size: 1.2em;
+    vertical-align: middle;
+}
+
+.languageContribution {
+    flex-basis: 1;
+    flex-grow: 0;
+    min-width: 450px;
+    max-width: 750px;
+    padding: 5px;
+}
+
 /* Credits */
 
 #creditssubtab {

--- a/index.html
+++ b/index.html
@@ -3010,7 +3010,7 @@ $STAGE$ for synergism stage"></p>
             <p>
                 Interested in providing a translation for your language?  Visit the <a href="https://www.discord.gg/ameCknq">#translations channel on our Discord!</a>
             </p>
-            <p>Visit our Crowdin project at <a href="https://crowdin.com/project/synergism-official">https://crowdin.com/project/synergism-official</a>!</p>
+            <p>Visit our POEditor project at <a href="https://poeditor.com/join/project/1up4tT24vG">https://poeditor.com/join/project/1up4tT24vG</a>!</p>
             <p>Contribute directly through Github at <a href="https://github.com/Pseudo-Corp/SynergismOfficial">https://github.com/Pseudo-Corp/SynergismOfficial</a>!</p>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -2866,12 +2866,13 @@
 <div id="settings" alt="settings" label="settings" style="display: none;">
     <div class="subtabSwitcher subTabWrapper">
         <button id="switchSettingSubTab1" alt="switchSettingSubTab1" label="switchSettingSubTab1" class="buttonActive" style="border: 2px solid white">Settings</button>
-        <button id="switchSettingSubTab2" alt="switchSettingSubTab2" label="switchSettingSubTab2" style="border: 2px solid gold">Credits</button>
-        <button id="switchSettingSubTab3" alt="switchSettingSubTab3" label="switchSettingSubTab3" style="border: 2px solid orange">Stats for Nerds</button>
-        <button id="switchSettingSubTab4" alt="switchSettingSubTab4" label="switchSettingSubTab4" class="prestigeunlockib" style="border: 2px solid brown">Reset History</button>
-        <button id="switchSettingSubTab5" alt="switchSettingSubTab5" label="switchSettingSubTab5" class="ascendunlockib" style="border: 2px solid darkorange">Ascend History</button>
-        <button id="switchSettingSubTab6" alt="switchSettingSubTab6" label="switchSettingSubTab6" class="singularity" style="border: 2px solid darkorange">Singularity History</button>
-        <button id="switchSettingSubTab7" alt="switchSettingSubTab7" label="switchSettingSubTab7" style="border: 2px solid white">Hotkeys</button>
+        <button id="switchSettingSubTab2" alt="switchSettingSubTab2" label="switchSettingSubTab2" style="border: 2px solid cyan">🌐 Languages 🌐</button>
+        <button id="switchSettingSubTab3" alt="switchSettingSubTab3" label="switchSettingSubTab3" style="border: 2px solid gold">Credits</button>
+        <button id="switchSettingSubTab4" alt="switchSettingSubTab4" label="switchSettingSubTab4" style="border: 2px solid orange">Stats for Nerds</button>
+        <button id="switchSettingSubTab5" alt="switchSettingSubTab5" label="switchSettingSubTab5" class="prestigeunlockib" style="border: 2px solid brown">Reset History</button>
+        <button id="switchSettingSubTab6" alt="switchSettingSubTab6" label="switchSettingSubTab6" class="ascendunlockib" style="border: 2px solid darkorange">Ascend History</button>
+        <button id="switchSettingSubTab7" alt="switchSettingSubTab7" label="switchSettingSubTab7" class="singularity" style="border: 2px solid darkorange">Singularity History</button>
+        <button id="switchSettingSubTab8" alt="switchSettingSubTab8" label="switchSettingSubTab8" style="border: 2px solid white">Hotkeys</button>
     </div>
     <div class="subtabContent subtabDisplayFlex subtabActive" id="settingsubtab" alt="settingsubtab" label="settingsubtab">
         <div class="settingSubTabUpper">
@@ -2998,6 +2999,20 @@ $STAGE$ for synergism stage"></p>
         <div id="event" alt="event" label="event" class="orchidText">Event Status: <span id="eventCurrent" alt="eventCurrent" label="eventCurrent" class="orangeredText"></span></div>
         <div id="eventBuffs" alt="eventBuffs" label="eventBuffs" style="color: lime;">Buffs: </div>
         <a href="#" target="_blank" id="happyHolidays" alt="happyHolidays" label="happyHolidays" style="color: greenyellow"></a>
+    </div>
+    <div class="subtabContent subtabDisplayFlex" id="languagesubtab" alt="languagesubtab" label="languagesubtab">
+        <div class="languagesMenu">
+            <div id="languageOptions" class="languageOptions">
+                <!-- Populated by i18n.ts, `buildLanguageTab` -->
+            </div>
+        </div>
+        <div class="languageContribution">
+            <p>
+                Interested in providing a translation for your language?  Visit the <a href="https://www.discord.gg/ameCknq">#translations channel on our Discord!</a>
+            </p>
+            <p>Visit our Crowdin project at <a href="https://crowdin.com/project/synergism-official">https://crowdin.com/project/synergism-official</a>!</p>
+            <p>Contribute directly through Github at <a href="https://github.com/Pseudo-Corp/SynergismOfficial">https://github.com/Pseudo-Corp/SynergismOfficial</a>!</p>
+        </div>
     </div>
     <div class="subtabContent" id="creditssubtab" alt="creditssubtab" label="creditssubtab">
         <h1>Coders</h1>

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -225,6 +225,7 @@ export const subTabsInMainTab = (mainTab: number) => {
             tabSwitcher: setActiveSettingScreen,
             subTabList: [
                 {subTabID: 'settingsubtab', unlocked: true},
+                {subTabID: 'languagesubtab', unlocked: true},
                 {subTabID: 'creditssubtab', unlocked: true},
                 {subTabID: 'statisticsSubTab', unlocked: true},
                 {subTabID: 'resetHistorySubTab', unlocked: player.unlocks.prestige},

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -4,7 +4,7 @@ import { DOMCacheGetOrSet } from './Cache/DOM';
 
 // For 'flag': https://emojipedia.org/emoji-flag-sequence/
 // Searching "flag <country>" in their search bar will help verify the code.
-const supported: {[langID: string]: {name: string, flag: string}} = {
+const supported: Record<string, { name: string, flag: string }> = {
     // Define language properties and mappings here.
     en: { name: 'English', flag: '🇺🇸'}, // Or '🇺🇸 / 🇬🇧', no name?
     zh: { name: 'Chinese', flag: '🇨🇳'}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,12 +1,19 @@
 import i18next, { type Resource } from 'i18next'
 import { prod } from './Config'
+import { DOMCacheGetOrSet } from './Cache/DOM';
 
-const supported = ['en', 'zh']
+// For 'flag': https://emojipedia.org/emoji-flag-sequence/
+// Searching "flag <country>" in their search bar will help verify the code.
+const supported: {[langID: string]: {name: string, flag: string}} = {
+    // Define language properties and mappings here.
+    en: { name: 'English', flag: '🇺🇸'}, // Or '🇺🇸 / 🇬🇧', no name?
+    zh: { name: 'Chinese', flag: '🇨🇳'}
+};
 
 export const init = async () => {
     const resources: Record<string, Resource> = {}
 
-    for (const lang of supported) {
+    for (const lang in supported) {
         const response = await fetch(`./translations/${lang}.json`)
         resources[lang] = {
             translation: await response.json() as Resource
@@ -17,5 +24,34 @@ export const init = async () => {
         fallbackLng: 'en',
         debug: !prod,
         resources
-    })
+    }).then(() => buildLanguageTab());
+}
+
+function buildLanguageButton(langID: string, name: string, flag: string) {
+    const mainButton = document.createElement('button');
+    mainButton.id = `language_${langID}`;
+    mainButton.className = 'language-select';
+    mainButton.addEventListener('click', () => {
+        void i18next.changeLanguage(langID);
+    });
+
+    const flagSpan = document.createElement('span');
+    flagSpan.className = 'lang-flag';
+    flagSpan.textContent = flag;
+    mainButton.appendChild(flagSpan);
+
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'lang-name';
+    nameSpan.textContent = name;
+    mainButton.appendChild(nameSpan);
+
+    return mainButton;
+}
+
+function buildLanguageTab() {
+    const langSelector = DOMCacheGetOrSet('languageOptions');
+    for (const langID in supported) {
+        const langButton = buildLanguageButton(langID, supported[langID].name, supported[langID].flag);
+        langSelector.appendChild(langButton);
+    }
 }


### PR DESCRIPTION
The new feature:

![image](https://user-images.githubusercontent.com/31546028/212687132-a24a2121-f19f-4007-98e2-ac7341b40b0c.png)

A button will automatically be added for each entry in the `supported` language _map_ defined in i18n.ts.  I did convert `supported` to a 'map' / object rather than leave it as an array; this allows the properties needed for each language button to be properly specified.

From this [PR's changeset](https://github.com/jahwsuf/SynergismOfficial/blob/537bdccfebade0aaa0d5420f666062f10fb1e105/src/i18n.ts#L5-L11):

```typescript
// For 'flag': https://emojipedia.org/emoji-flag-sequence/
// Searching "flag <country>" in their search bar will help verify the code.
const supported: {[langID: string]: {name: string, flag: string}} = {
    // Define language properties and mappings here.
    en: { name: 'English', flag: '🇺🇸'}, // Or '🇺🇸 / 🇬🇧', no name?
    zh: { name: 'Chinese', flag: '🇨🇳'}
};
```

Naturally, feel free to change the information in the right-hand side as desired; I simply thought it'd help fill some of the whitespace and would also provide a good starting point for people to get involved should they care about those details.


**_Other notes_**

I made sure to style it to handle additional languages.  Via node duplication in Developer mode:

![image](https://user-images.githubusercontent.com/31546028/212688609-ad25499b-9b91-4b59-8b21-eb4da4d97d2f.png)

It's not perfect, but it should be a "good enough" starting place.
