### PR TITLE
fix: restores stats for nerds updates

### DIFF
--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -580,7 +580,7 @@ export const visualUpdateSettings = () => {
         DOMCacheGetOrSet('goldenQuarkTimerAmount').textContent =
             `Golden Quarks on export: ${format(Math.floor(player.goldenQuarksTimer * +player.singularityUpgrades.goldenQuarks3.getEffect().bonus/ 3600) * goldenQuarkMultiplier, 2)} [Max ${format(Math.floor(168 * +player.singularityUpgrades.goldenQuarks3.getEffect().bonus * goldenQuarkMultiplier))}]`
     }
-    if (player.subtabNumber === 2) {
+    if (player.subtabNumber === 3) {
         loadStatisticsUpdate();
     }
 }


### PR DESCRIPTION
Since the "Languages" subtab was added before "Credits" (and before "Stats for Nerds")... the "Stats for Nerds" subtab id got incremented. I didn't catch this when writing #443.

![image](https://user-images.githubusercontent.com/31546028/213326931-2e8e979e-5d1d-4a4b-9382-ff146c55828f.png)

So, this is a simple fix to get the stats page auto-updating again.
