### PR TITLE
Make blessing and spirit button numbers clickable

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2785,6 +2785,10 @@ p#ascendHotKeys {
     background-color: var(--blessings-hover-color);
 }
 
+.runeButtonsAvailable > span {
+    pointer-events: none;
+}
+
 #buyRuneBlessingInput {
     min-width: 100px;
     width: 5em;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/14263240/228994816-d89398df-ce19-483c-b819-4ecce59487a3.png)

There was an issue (in Firefox and Chrome from my testing) where if you click on the purple numbers of the button for blessings and spirits, it does not trigger the OnClick event. This PR fixes that.