### PR TITLE
code 'add': Allow saving of attempts and prefill using all attempts

### DIFF
--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -491,7 +491,7 @@ export const promocodes = async (input: string | null, amount?: number) => {
     if (amount) {
       attemptsUsed = amount.toString()
     } else {
-      attemptsUsed = await Prompt(i18next.t('importexport.useXAdds', { x: availableUses }))
+      attemptsUsed = await Prompt(i18next.t('importexport.useXAdds', { x: availableUses }), availableUses.toString())
     }
 
     if (attemptsUsed === null) {

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -501,14 +501,15 @@ export const promocodes = async (input: string | null, amount?: number) => {
     if (
       Number.isNaN(toUse) ||
             !Number.isInteger(toUse) ||
-            toUse <= 0
+            toUse === 0 ||
+            (toUse < 0 && -toUse >= availableUses)
     ) {
       return Alert(i18next.t('general.validation.invalidNumber'))
     }
 
     const addEffects = addCodeBonuses()
 
-    const realAttemptsUsed = Math.min(availableUses, toUse)
+    const realAttemptsUsed = toUse > 0 ? Math.min(availableUses, toUse) : availableUses + toUse
     const actualQuarks = Math.floor(addEffects.quarks * realAttemptsUsed)
     const [first, second] = window.crypto.getRandomValues(new Uint8Array(2))
 

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -1074,7 +1074,7 @@ const AlertCB = (text: string, cb: (value: undefined) => void) => {
     popup.addEventListener('keyup', kbListener)
 }
 
-export const PromptCB = (text: string, cb: (value: string | null) => void, prefill?: string) => {
+export const PromptCB = (text: string, cb: (value: string | null) => void, defaultValue?: string) => {
   const conf = DOMCacheGetOrSet('confirmationBox')
   const confWrap = DOMCacheGetOrSet('promptWrapper')
   const overlay = DOMCacheGetOrSet('transparentBG')
@@ -1089,8 +1089,8 @@ export const PromptCB = (text: string, cb: (value: string | null) => void, prefi
   confWrap.style.display = 'block'
   overlay.style.display = 'block'
     popup.querySelector('label')!.textContent = text
-    if (typeof(prefill) !== 'undefined') {
-      popup.querySelector('input')!.value = prefill
+    if (defaultValue) {
+      popup.querySelector('input')!.value = defaultValue
     }
     popup.querySelector('input')!.focus()
 
@@ -1178,7 +1178,7 @@ const NotificationCB = (text: string, time = 30000, cb: () => void) => {
 export const Alert = (text: string): Promise<undefined> => new Promise(res => AlertCB(text, res))
 /*** Promisified version of the PromptCB function. */
 // eslint-disable-next-line no-promise-executor-return
-export const Prompt = (text: string, prefill?: string): Promise<string | null> => new Promise(res => PromptCB(text, res, prefill))
+export const Prompt = (text: string, defaultValue?: string): Promise<string | null> => new Promise(res => PromptCB(text, res, defaultValue))
 /*** Promisified version of the ConfirmCB function */
 // eslint-disable-next-line no-promise-executor-return
 export const Confirm = (text: string): Promise<boolean> => new Promise(res => ConfirmCB(text, res))

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -1074,7 +1074,7 @@ const AlertCB = (text: string, cb: (value: undefined) => void) => {
     popup.addEventListener('keyup', kbListener)
 }
 
-export const PromptCB = (text: string, cb: (value: string | null) => void) => {
+export const PromptCB = (text: string, cb: (value: string | null) => void, prefill?: string) => {
   const conf = DOMCacheGetOrSet('confirmationBox')
   const confWrap = DOMCacheGetOrSet('promptWrapper')
   const overlay = DOMCacheGetOrSet('transparentBG')
@@ -1089,6 +1089,9 @@ export const PromptCB = (text: string, cb: (value: string | null) => void) => {
   confWrap.style.display = 'block'
   overlay.style.display = 'block'
     popup.querySelector('label')!.textContent = text
+    if (typeof(prefill) !== 'undefined') {
+      popup.querySelector('input')!.value = prefill
+    }
     popup.querySelector('input')!.focus()
 
     // kinda disgusting types but whatever
@@ -1175,7 +1178,7 @@ const NotificationCB = (text: string, time = 30000, cb: () => void) => {
 export const Alert = (text: string): Promise<undefined> => new Promise(res => AlertCB(text, res))
 /*** Promisified version of the PromptCB function. */
 // eslint-disable-next-line no-promise-executor-return
-export const Prompt = (text: string): Promise<string | null> => new Promise(res => PromptCB(text, res))
+export const Prompt = (text: string, prefill?: string): Promise<string | null> => new Promise(res => PromptCB(text, res, prefill))
 /*** Promisified version of the ConfirmCB function */
 // eslint-disable-next-line no-promise-executor-return
 export const Confirm = (text: string): Promise<boolean> => new Promise(res => ConfirmCB(text, res))

--- a/translations/en.json
+++ b/translations/en.json
@@ -3216,7 +3216,7 @@
     "promocodePrompt": "Got a code? Great! Enter it in (CaSe SeNsItIvE). \n [Note to viewer: this is for events and certain always-active codes. \n May I suggest you type in \"synergism2021\" or \"Khafra\" perchance?]",
     "comeBackSoon": "Alright, come back soon!",
     "noAddCodes": "You do not have an 'Add' code attempt! You will gain 1 in {{x}} seconds.",
-    "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use? You can start the input with \"-\" (put in a negative value) to put in a value, that will be saved, which means you use all attempts except the specified number.",
+    "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use? You can enter a negative value which will use all attempts except the specified number.",
     "cancelAdd": "No worries, you didn't lose any of your uses! Come back later!",
     "daily0Uses": "0 uses left. Next: end of the day.",
     "daily1Uses": "1 use left. Next: end of the day.",

--- a/translations/en.json
+++ b/translations/en.json
@@ -3216,7 +3216,7 @@
     "promocodePrompt": "Got a code? Great! Enter it in (CaSe SeNsItIvE). \n [Note to viewer: this is for events and certain always-active codes. \n May I suggest you type in \"synergism2021\" or \"Khafra\" perchance?]",
     "comeBackSoon": "Alright, come back soon!",
     "noAddCodes": "You do not have an 'Add' code attempt! You will gain 1 in {{x}} seconds.",
-    "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use?",
+    "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use? You can start the input with \"-\" (put in a negative value) to put in a value, that will be saved, which means you use all attempts except the specified number.",
     "cancelAdd": "No worries, you didn't lose any of your uses! Come back later!",
     "daily0Uses": "0 uses left. Next: end of the day.",
     "daily1Uses": "1 use left. Next: end of the day.",

--- a/translations/source.json
+++ b/translations/source.json
@@ -3216,7 +3216,7 @@
       "promocodePrompt": "Got a code? Great! Enter it in (CaSe SeNsItIvE). \n [Note to viewer: this is for events and certain always-active codes. \n May I suggest you type in \"synergism2021\" or \"Khafra\" perchance?]",
       "comeBackSoon": "Alright, come back soon!",
       "noAddCodes": "You do not have an 'Add' code attempt! You will gain 1 in {{x}} seconds.",
-      "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use?",
+      "useXAdds": "You can use up to {{x}} attempts at once. How many would you like to use? You can start the input with \"-\" (put in a negative value) to put in a value, that will be saved, which means you use all attempts except the specified number.",
       "cancelAdd": "No worries, you didn't lose any of your uses! Come back later!",
       "daily0Uses": "0 uses left. Next: end of the day.",
       "daily1Uses": "1 use left. Next: end of the day.",


### PR DESCRIPTION
This PR adds 3 separate things:

1. The functions Prompt and PromptCB (from UpdateHTML.ts) can now use an optinal third parameter of type string to prefill the input field.
2.  code 'add' uses this to prefill the field with all available attempts, which I believe is what most people use it for anyway.
3. Players can enter a negative amount of attempts into the code 'add' prompt to save that many attempts (same as with opening cubes).

Images:
![code add prefill](https://github.com/Pseudo-Corp/SynergismOfficial/assets/22898465/ad315122-d6eb-405b-aae3-407736da36d1)
![code add negative entry](https://github.com/Pseudo-Corp/SynergismOfficial/assets/22898465/e913dd81-1910-4e9e-a36a-3d1041db3797)
![code add negative entry 2](https://github.com/Pseudo-Corp/SynergismOfficial/assets/22898465/c069576b-0a06-4cfe-be92-1dc4531c9585)