### PR TITLE
feat: adds loadout highlighting and description on import

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -3714,3 +3714,14 @@ img#singularityPerksIcon {
     max-width: 500%;
     animation: rotation 2s infinite linear;
 }
+
+.hoveredBlueberryLoadout1 div.bbPurchasedLoadout1,
+.hoveredBlueberryLoadout2 div.bbPurchasedLoadout2,
+.hoveredBlueberryLoadout3 div.bbPurchasedLoadout3,
+.hoveredBlueberryLoadout4 div.bbPurchasedLoadout4,
+.hoveredBlueberryLoadout5 div.bbPurchasedLoadout5,
+.hoveredBlueberryLoadout6 div.bbPurchasedLoadout6,
+.hoveredBlueberryLoadout7 div.bbPurchasedLoadout7,
+.hoveredBlueberryLoadout8 div.bbPurchasedLoadout8 {
+    background-color: green;
+}

--- a/src/BlueberryUpgrades.ts
+++ b/src/BlueberryUpgrades.ts
@@ -633,6 +633,8 @@ export const importBlueberryTree = async (input: string | null) => {
     try {
       const modules = JSON.parse(input) as BlueberryOpt
       await createBlueberryTree(modules)
+      createLoadoutDescription(0, modules)
+
     } catch (err) {
       return Alert(i18next.t('ambrosia.importTree.error'))
     }
@@ -648,6 +650,26 @@ export const loadoutHandler = async (n: number, modules: BlueberryOpt) => {
   }
 }
 
+export const updateLoadoutHoverClasses = () => {
+  const upgradeNames = Object.keys(blueberryUpgradeData) as blueberryUpgradeNames[]
+
+  for (const loadoutKey in player.blueberryLoadouts) {
+    const i = Number.parseInt(loadoutKey, 10)
+    // eslint-disable-next-line
+    const loadout = player.blueberryLoadouts[loadoutKey]
+
+    const upgradeHoverClass = `bbPurchasedLoadout${i}`
+    for (const upgradeKey of upgradeNames) {
+      // eslint-disable-next-line
+      if (loadout[upgradeKey]) {
+        DOMCacheGetOrSet(upgradeKey).parentElement?.classList.add(upgradeHoverClass)
+      } else {
+        DOMCacheGetOrSet(upgradeKey).parentElement?.classList.remove(upgradeHoverClass)
+      }
+    }
+  }
+}
+
 export const saveBlueberryTree = async (input: number, previous: BlueberryOpt) => {
 
   if (Object.keys(previous).length > 0) {
@@ -658,12 +680,16 @@ export const saveBlueberryTree = async (input: number, previous: BlueberryOpt) =
   player.blueberryLoadouts[input] = getBlueberryTree()
   // eslint-disable-next-line
   createLoadoutDescription(input, player.blueberryLoadouts[input])
+
+  updateLoadoutHoverClasses()
 }
 
 export const createLoadoutDescription = (input: number, modules: BlueberryOpt) => {
 
   let str = ''
   for (const [key, val] of Object.entries(modules)) {
+    if (!val) continue
+
     const k = key as keyof Player['blueberryUpgrades']
     const name = player.blueberryUpgrades[k].name
     str = str + `<span style="color:orange">${name}</span> <span style="color:yellow">lv${val}</span> | `
@@ -672,6 +698,11 @@ export const createLoadoutDescription = (input: number, modules: BlueberryOpt) =
   if (Object.keys(modules).length === 0) {
     str = i18next.t('ambrosia.loadouts.none')
   }
-  DOMCacheGetOrSet('singularityAmbrosiaMultiline').innerHTML = ` ${i18next.t('ambrosia.loadouts.loadout')} ${input}
+
+  let loadoutTitle = `${i18next.t('ambrosia.loadouts.loadout')} ${input}`
+  if (input == 0) {
+    loadoutTitle = `${i18next.t('ambrosia.loadouts.imported')}`
+  }
+  DOMCacheGetOrSet('singularityAmbrosiaMultiline').innerHTML = ` ${loadoutTitle}
   ${str}`
 }

--- a/src/BlueberryUpgrades.ts
+++ b/src/BlueberryUpgrades.ts
@@ -653,10 +653,10 @@ export const loadoutHandler = async (n: number, modules: BlueberryOpt) => {
 export const updateLoadoutHoverClasses = () => {
   const upgradeNames = Object.keys(blueberryUpgradeData) as blueberryUpgradeNames[]
 
-  for (const loadoutKey in player.blueberryLoadouts) {
+  for (const loadoutKey of Object.keys(player.blueberryLoadouts)) {
     const i = Number.parseInt(loadoutKey, 10)
     // eslint-disable-next-line
-    const loadout = player.blueberryLoadouts[loadoutKey]
+    const loadout = player.blueberryLoadouts[i]
 
     const upgradeHoverClass = `bbPurchasedLoadout${i}`
     for (const upgradeKey of upgradeNames) {
@@ -688,6 +688,12 @@ export const createLoadoutDescription = (input: number, modules: BlueberryOpt) =
 
   let str = ''
   for (const [key, val] of Object.entries(modules)) {
+    /*
+     * If the entry (saved purchase level) for an upgrade is 0, undefined, or null, we skip it.
+     * If 0 - it existed when the loadout was saved; it's just unpurchased
+     * If undefined - it's new, so it's unpurchased - the user couldn't have saved it to a loadout yet
+     * I don't think anything sets an upgrade to null... but we may as well skip then too.
+     */
     if (!val) continue
 
     const k = key as keyof Player['blueberryUpgrades']
@@ -700,8 +706,8 @@ export const createLoadoutDescription = (input: number, modules: BlueberryOpt) =
   }
 
   let loadoutTitle = `${i18next.t('ambrosia.loadouts.loadout')} ${input}`
-  if (input == 0) {
-    loadoutTitle = `${i18next.t('ambrosia.loadouts.imported')}`
+  if (input === 0) {
+    loadoutTitle = i18next.t('ambrosia.loadouts.imported')
   }
   DOMCacheGetOrSet('singularityAmbrosiaMultiline').innerHTML = ` ${loadoutTitle}
   ${str}`

--- a/src/CheckVariables.ts
+++ b/src/CheckVariables.ts
@@ -19,7 +19,7 @@ import type { ISingularityChallengeData } from './SingularityChallenges'
 import { SingularityChallenge, singularityChallengeData } from './SingularityChallenges'
 import i18next from 'i18next'
 import { AmbrosiaGenerationCache, AmbrosiaLuckCache, BlueberryInventoryCache, cacheReinitialize } from './StatCache'
-import type { IBlueberryData } from './BlueberryUpgrades'
+import { type IBlueberryData, updateLoadoutHoverClasses } from './BlueberryUpgrades'
 import { BlueberryUpgrade, blueberryUpgradeData } from './BlueberryUpgrades'
 
 /* eslint-disable @typescript-eslint/no-unnecessary-condition */
@@ -787,6 +787,7 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
   }
 
   if (data.blueberryUpgrades != null) {
+    // blueberry loading here!
     for (const item of Object.keys(blankSave.blueberryUpgrades)) {
       const k = item as keyof Player['blueberryUpgrades']
       let updatedData:IBlueberryData
@@ -816,6 +817,8 @@ export const checkVariablesOnLoad = (data: PlayerSave) => {
         player.blueberryUpgrades[k].name = `[NEW!] ${player.blueberryUpgrades[k].name}`
       }
     }
+
+    updateLoadoutHoverClasses()
   }
 
 

--- a/src/EventListeners.ts
+++ b/src/EventListeners.ts
@@ -688,12 +688,19 @@ TODO: Fix this entire tab it's utter shit
 
   // BLUEBERRY LOADOUTS
   const blueberryLoadouts = Array.from(document.querySelectorAll('[id^="blueberryLoadout"]'))
+  const loadoutContainer = DOMCacheGetOrSet('blueberryUpgradeContainer')
 
   for (let i = 0; i < blueberryLoadouts.length; i++) {
     const shiftedKey = i + 1
     const el = blueberryLoadouts[i]
+    el.addEventListener('mouseover', () => {
     // eslint-disable-next-line
-    el.addEventListener('mouseover', () => createLoadoutDescription(shiftedKey, player.blueberryLoadouts[shiftedKey] ?? { ambrosiaTutorial: 0 }))
+      createLoadoutDescription(shiftedKey, player.blueberryLoadouts[shiftedKey] ?? { ambrosiaTutorial: 0 })
+      loadoutContainer.classList.add(`hoveredBlueberryLoadout${shiftedKey}`)
+    })
+    el.addEventListener('mouseout', () => {
+      loadoutContainer.classList.remove(`hoveredBlueberryLoadout${shiftedKey}`)
+    })
     // eslint-disable-next-line
     el.addEventListener('click', () => loadoutHandler(shiftedKey, player.blueberryLoadouts[shiftedKey] ?? { ambrosiaTutorial: 0 }))
   }

--- a/translations/en.json
+++ b/translations/en.json
@@ -102,7 +102,8 @@
             "save": "MODE: SAVE LOADOUT",
             "none": "No loadout saved in this slot!",
             "loadout": "Loadout",
-            "confirmation": "Saving to this slot will override its build. Are you sure?"
+            "confirmation": "Saving to this slot will override its build. Are you sure?",
+            "imported": "Imported loadout"
         },
         "importTree": {
             "success": "Tree successfully imported!",


### PR DESCRIPTION
I thought I'd take a bit of time to add some quality-of-life for the new loadout feature.

1. When importing a loadout from a file, the game will display the loadout's settings afterward:

![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/e9ff3272-06b2-4036-bd76-993708291864)

2. When hovering over a blueberry loadout button, any upgrades purchased within that loadout will be highlighted:

![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/1be3c6b6-5afd-45e9-96eb-7ea7bf8a40a0)

![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/7060f533-16e4-4720-9c19-350362563b20)

The highlighting effect will disappear on 'mouseout'.

3. From the Discord:

    ![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/c540ad2a-c29f-430f-ac78-ca555506fbb1)

    I was looking at the function anyway for this, so I threw in the fix.