### PR TITLE
feat: formats ambrosia upgrades into tree

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -3496,6 +3496,19 @@ header #obtainiumDisplay { color: pink; }
     gap: 4px;
 }
 
+#blueberryUpgradeContainer {
+    flex-direction: column;
+}
+
+.blueberryUpgradeTier {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    padding: 2px;
+    width: 100%;
+    gap: 4px;
+}
+
 .singularityUpgrade,
 .octeractUpgrade,
 .singularityChallenge,

--- a/index.html
+++ b/index.html
@@ -4355,52 +4355,62 @@ $STAGE$ for synergism stage"></p>
                 </div>
 
                 <div class="blueberryBoxColor" id="blueberryUpgradeContainer" alt="blueberryUpgradeContainer" label="blueberryUpgradeContainer">
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaTutorial" src="Pictures/Default/BlueberryTutorial.png">
+                    <div class="blueberryUpgradeTier">
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaTutorial" src="Pictures/Default/BlueberryTutorial.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaPatreon" src="Pictures/Default/BlueberryPatreon.png">
+                        </div>
                     </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaQuarks1" src="Pictures/Default/BlueberryQuarks.png">
+                    <div class="blueberryUpgradeTier">
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaQuarks1" src="Pictures/Default/BlueberryQuarks.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaCubes1" src="Pictures/Default/BlueberryCubes.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaLuck1" src="Pictures/Default/BlueberryLuck.png">
+                        </div>
                     </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaCubes1" src="Pictures/Default/BlueberryCubes.png">
+                    <div class="blueberryUpgradeTier">
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaCubeQuark1" src="Pictures/Default/BlueberryCubeQuark.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaLuckQuark1" src="Pictures/Default/BlueberryLuckQuark.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaLuckCube1" src="Pictures/Default/BlueberryLuckCube.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaQuarkCube1" src="Pictures/Default/BlueberryQuarkCube.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaCubeLuck1" src="Pictures/Default/BlueberryCubeLuck.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaQuarkLuck1" src="Pictures/Default/BlueberryQuarkLuck.png">
+                        </div>
                     </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaLuck1" src="Pictures/Default/BlueberryLuck.png">
+                    <div class="blueberryUpgradeTier">
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaQuarks2" src="Pictures/Default/BlueberryQuarks.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaCubes2" src="Pictures/Default/BlueberryCubes.png">
+                        </div>
+                        <div class="blueberryUpgrade">
+                            <img id="ambrosiaLuck2" src="Pictures/Default/BlueberryLuck.png">
+                        </div>
                     </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaCubeQuark1" src="Pictures/Default/BlueberryCubeQuark.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaLuckQuark1" src="Pictures/Default/BlueberryLuckQuark.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaLuckCube1" src="Pictures/Default/BlueberryLuckCube.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaQuarkCube1" src="Pictures/Default/BlueberryQuarkCube.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaCubeLuck1" src="Pictures/Default/BlueberryCubeLuck.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaQuarkLuck1" src="Pictures/Default/BlueberryQuarkLuck.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaQuarks2" src="Pictures/Default/BlueberryQuarks.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaCubes2" src="Pictures/Default/BlueberryCubes.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaLuck2" src="Pictures/Default/BlueberryLuck.png">
-                    </div>
-                    <div class="blueberryUpgrade">
-                        <img id="ambrosiaPatreon" src="Pictures/Default/BlueberryPatreon.png">
-                    </div>
+                    <div class="blueberryUpgradeTier">
                         <button id="refundBlueberries" style="border: 2px solid blue" i18n="ambrosia.refundWord"></button>
                         <button id="getBlueberries" style="border: 2px solid blue" i18n="ambrosia.exportTree.exportButton"></button>
                         <label id="importBlueberriesButton" label="importBlueberriesButton" for="importBlueberries" style="border: 2px solid blue" i18n="settings.loadFromFile"></label>
                         <input type="file" id="importBlueberries" label="importBlueberries" accept=".txt" style="display: none">
+                    </div>
                 </div>
                 <div class="blueberryBoxColor" id="bbLoadoutContainer" alt="blueberryLoadoutContainer" label="blueberryLoadoutContainer">
                     <button class="blueberryLoadoutSlot" id="blueberryLoadout1">1</button>


### PR DESCRIPTION
The picture of a thousand words:

![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/2927e82d-339d-4c41-aadd-f839a19074f2)

This is the first layout that came to mind for making an ambrosia _tree_.  Granted, I may be assuming a pattern, but it's a relatively low-effort proof of concept that still provides some notable improvement.

It plays quite nicely with #524 as well:

![image](https://github.com/Pseudo-Corp/SynergismOfficial/assets/31546028/0fcd679a-466c-42d9-9f74-f38b8d1a3bed)

No worries if you have another plan in mind or want to use the styling but with tweaks, choose a different layout, or whatever else.  I just figured offering a clear demo of the idea might help.