### PR TITLE
Fix shop item names

### DIFF
--- a/src/Shop.ts
+++ b/src/Shop.ts
@@ -929,8 +929,8 @@ export const friendlyShopName = (input: ShopUpgradeNames) => {
     shopAmbrosiaGeneration4: 'A FINAL Ambrosia Generation Speedup',
     shopAmbrosiaLuck1: 'Ambrosia Luck Increaser',
     shopAmbrosiaLuck2: 'Another Ambrosia Luck Increaser',
-    shopAmbrosiaLuck3: 'A better Ambrosia Generation Speedup',
-    shopAmbrosiaLuck4: 'A FINAL Ambrosia Generation Speedup'
+    shopAmbrosiaLuck3: 'A better Ambrosia Luck Increaser',
+    shopAmbrosiaLuck4: 'A FINAL Ambrosia Luck Increaser'
   }
 
   return names[input]


### PR DESCRIPTION
shopAmbrosiaLuck3 and 4 are named 'Generation Speedup' instead of 'Luck Increaser'

these names are not visible on game screen afaik, but written in 'Savefile Stats Summary' like below:
```
[★] Ambrosia Generation Speedup: Level 25/25
[★] Another Ambrosia Generation Speedup: Level 30/30
[★] A better Ambrosia Generation Speedup: Level 35/35
[?] A FINAL Ambrosia Generation Speedup: Level 110/1000
[★] Ambrosia Luck Increaser: Level 40/40
[★] Another Ambrosia Luck Increaser: Level 50/50
[★] A better Ambrosia Generation Speedup: Level 60/60
[?] A FINAL Ambrosia Generation Speedup: Level 100/1000
```
