### PR TITLE
various bug fixes

### DIFF
--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1126,7 +1126,7 @@ export const singularity = async (setSingNumber = -1): Promise<void> => {
     Object.entries(player.octeractUpgrades).map(([key, value]) => {
       return [key, {
         level: value.level,
-        goldenQuarksInvested: value.octeractsInvested,
+        octeractsInvested: value.octeractsInvested,
         toggleBuy: value.toggleBuy,
         freeLevels: value.freeLevels
       }]

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -848,11 +848,11 @@ export const buttoncolorchange = () => {
     for (let i = 9; i <= 10; i++) {
       if (player.constantUpgrades[i]! >= 1) {
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeSingle')
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeSingleAvailable')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
       } else if (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!))) {
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeSingleAvailable')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAvailable')
       } else {
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeSingleAvailable')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeSingle')
       }
     }

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -386,7 +386,7 @@ export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
     if (player.constantUpgrades[i]! >=1) {
       toBuy = 0
     } else {
-      toBuy = Math.min(1,Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))
+      toBuy = Math.min(1, Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))
     }
   } else {
     toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -381,12 +381,17 @@ const returnConstUpgEffect = (i: number) => i18next.t(`upgrades.constantEffects.
 export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
   let toBuy
   let cost: Decimal
-  
+
   if (i >= 9) {
-    if (player.constantUpgrades[i]! >=1) {toBuy = 0}
-    else {toBuy = Math.min(1,Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))}
-  } else {toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))}
-  
+    if (player.constantUpgrades[i]! >=1) {
+      toBuy = 0
+    } else {
+      toBuy = Math.min(1,Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))
+    }
+  } else {
+    toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
+  }
+
   if (toBuy > player.constantUpgrades[i]!) {
     cost = Decimal.pow(10, toBuy - 1).times(G.constUpgradeCosts[i]!)
   } else {
@@ -414,7 +419,7 @@ export const buyConstantUpgrades = (i: number, fast = false) => {
         }
         if (!fast) {
           constantUpgradeDescriptions(i)
-        } 
+        }
     }
   }
   calculateAnts()

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -379,13 +379,13 @@ const returnConstUpgDesc = (i: number) => i18next.t(`upgrades.constantUpgrades.$
 const returnConstUpgEffect = (i: number) => i18next.t(`upgrades.constantEffects.${i}`, constUpgEffect[i]?.())
 
 export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
-  const toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
+  const toBuy = i >= 9 && player.constantUpgrades[i]! >= 1 ? 0 : Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
   let cost: Decimal
 
   if (toBuy > player.constantUpgrades[i]!) {
     cost = Decimal.pow(10, toBuy - 1).times(G.constUpgradeCosts[i]!)
   } else {
-    cost = Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)
+    cost = i >= 9 && player.constantUpgrades[i]! >= 1 ? new Decimal(0) : Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)
   }
 
   return [Math.max(1, toBuy - player.constantUpgrades[i]!), cost]
@@ -401,14 +401,16 @@ export const constantUpgradeDescriptions = (i: number) => {
 
 export const buyConstantUpgrades = (i: number, fast = false) => {
   const [level, cost] = getConstUpgradeMetadata(i)
-  if (player.ascendShards.gte(cost)) {
+  if (i <= 8 || (i >= 9 && player.constantUpgrades[i]! < 1)) {
+    if (player.ascendShards.gte(cost)) {
         player.constantUpgrades[i]! += level
         if (player.researches[175] === 0) {
           player.ascendShards = player.ascendShards.sub(cost)
         }
         if (!fast) {
           constantUpgradeDescriptions(i)
-        }
+        } 
+    }
   }
   calculateAnts()
   calculateRuneLevels()

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -379,13 +379,18 @@ const returnConstUpgDesc = (i: number) => i18next.t(`upgrades.constantUpgrades.$
 const returnConstUpgEffect = (i: number) => i18next.t(`upgrades.constantEffects.${i}`, constUpgEffect[i]?.())
 
 export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
-  const toBuy = i >= 9 && player.constantUpgrades[i]! >= 1 ? 0 : Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
+  let toBuy
   let cost: Decimal
-
+  
+  if (i >= 9) {
+    if (player.constantUpgrades[i]! >=1) {toBuy = 0}
+    else {toBuy = Math.min(1,Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))}
+  } else {toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))}
+  
   if (toBuy > player.constantUpgrades[i]!) {
     cost = Decimal.pow(10, toBuy - 1).times(G.constUpgradeCosts[i]!)
   } else {
-    cost = i >= 9 && player.constantUpgrades[i]! >= 1 ? new Decimal(0) : Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)
+    cost = i >= 9 && player.constantUpgrades[i]! >= 1 ? new Decimal('0') : Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)
   }
 
   return [Math.max(1, toBuy - player.constantUpgrades[i]!), cost]


### PR DESCRIPTION
fixed bug: Spent Octeracts resets to 0 on singularity

fixed bug: constant upgrades 9 and 10 do not highlight when the first level is buyable

fixed bug: constant upgrades 9 and 10 are buyable after the first level, leading players to believe that buying more than one level has some additional effect

new behavior: if constant upgrade 9 or 10 are level 1+, they will not highlight, and will show a cost of 0 constant. current level is maintained, but level will be hardcapped to 1 in future singularities