### PR TITLE
crystal+constant upgrade coloration

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -2608,12 +2608,16 @@ p#ascendHotKeys {
 }
 
 .constUpgradeAvailable {
-    background-color: green;
+    background-color: purple;
     cursor: pointer;
 }
 
 .constUpgradeAvailable:hover {
-    background-color: #00b300;
+    background-color: #b300b3;
+}
+
+.constUpgradeAuto {
+    background-color :green;
 }
 
 /* .constUpgradeSingle {

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -782,11 +782,11 @@ export const buttoncolorchange = () => {
       k += 10
     }
 
-    (player.achievements[79] < 1 && player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[0] + G.crystalUpgradeCostIncrement[0] * Math.floor(Math.pow(player.crystalUpgrades[0] + 0.5 - k, 2) / 2))))) ? f.style.backgroundColor = 'purple' : f.style.backgroundColor = '';
-    (player.achievements[86] < 1 && player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[1] + G.crystalUpgradeCostIncrement[1] * Math.floor(Math.pow(player.crystalUpgrades[1] + 0.5 - k, 2) / 2))))) ? g.style.backgroundColor = 'purple' : g.style.backgroundColor = '';
-    (player.achievements[93] < 1 && player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[2] + G.crystalUpgradeCostIncrement[2] * Math.floor(Math.pow(player.crystalUpgrades[2] + 0.5 - k, 2) / 2))))) ? h.style.backgroundColor = 'purple' : h.style.backgroundColor = '';
-    (player.achievements[100] < 1 && player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[3] + G.crystalUpgradeCostIncrement[3] * Math.floor(Math.pow(player.crystalUpgrades[3] + 0.5 - k, 2) / 2))))) ? i.style.backgroundColor = 'purple' : i.style.backgroundColor = '';
-    (player.achievements[107] < 1 && player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[4] + G.crystalUpgradeCostIncrement[4] * Math.floor(Math.pow(player.crystalUpgrades[4] + 0.5 - k, 2) / 2))))) ? j.style.backgroundColor = 'purple' : j.style.backgroundColor = ''
+    player.achievements[79] < 1 ? (player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[0] + G.crystalUpgradeCostIncrement[0] * Math.floor(Math.pow(player.crystalUpgrades[0] + 0.5 - k, 2) / 2)))) ? f.style.backgroundColor = 'purple' : f.style.backgroundColor = '') : f.style.backgroundColor = 'green';
+    player.achievements[86] < 1 ? (player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[1] + G.crystalUpgradeCostIncrement[1] * Math.floor(Math.pow(player.crystalUpgrades[1] + 0.5 - k, 2) / 2)))) ? g.style.backgroundColor = 'purple' : g.style.backgroundColor = '') : g.style.backgroundColor = 'green';
+    player.achievements[93] < 1 ? (player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[2] + G.crystalUpgradeCostIncrement[2] * Math.floor(Math.pow(player.crystalUpgrades[2] + 0.5 - k, 2) / 2)))) ? h.style.backgroundColor = 'purple' : h.style.backgroundColor = '') : h.style.backgroundColor = 'green';
+    player.achievements[100] < 1 ? (player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[3] + G.crystalUpgradeCostIncrement[3] * Math.floor(Math.pow(player.crystalUpgrades[3] + 0.5 - k, 2) / 2)))) ? i.style.backgroundColor = 'purple' : i.style.backgroundColor = '') : i.style.backgroundColor = 'green';
+    player.achievements[107] < 1 ? (player.prestigeShards.gte(Decimal.pow(10, (G.crystalUpgradesCost[4] + G.crystalUpgradeCostIncrement[4] * Math.floor(Math.pow(player.crystalUpgrades[4] + 0.5 - k, 2) / 2)))) ? j.style.backgroundColor = 'purple' : j.style.backgroundColor = '') : j.style.backgroundColor = 'green';
   }
 
   if (G.currentTab === 'runes') {
@@ -841,19 +841,26 @@ export const buttoncolorchange = () => {
         : DOMCacheGetOrSet(`buyTesseracts${i}`).classList.remove('buildingPurchaseBtnAvailable')
     }
     for (let i = 1; i <= 8; i++) {
-      (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)))
+      if (player.researches[190] >= 1) {
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAuto')
+      } else {
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAuto');
+        (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)))
         ? DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAvailable')
         : DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
+      }  
     }
+
     for (let i = 9; i <= 10; i++) {
-      if (player.constantUpgrades[i]! >= 1) {
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeSingle')
+      if (player.researches[190] >= 1 || player.constantUpgrades[i]! >= 1) {
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
-      } else if (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!))) {
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAvailable')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAuto')
       } else {
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
-        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeSingle')
+        DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAuto');
+        (player.ascendShards.gte(Decimal.pow(10, player.constantUpgrades[i]!).times(G.constUpgradeCosts[i]!)))
+        ? DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAvailable')
+        : DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
       }
     }
   }

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -379,17 +379,15 @@ const returnConstUpgDesc = (i: number) => i18next.t(`upgrades.constantUpgrades.$
 const returnConstUpgEffect = (i: number) => i18next.t(`upgrades.constantEffects.${i}`, constUpgEffect[i]?.())
 
 export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
-  let toBuy
+  let toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
   let cost: Decimal
 
   if (i >= 9) {
     if (player.constantUpgrades[i]! >=1) {
       toBuy = 0
     } else {
-      toBuy = Math.min(1, Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10))))
+      toBuy = Math.min(1, toBuy)
     }
-  } else {
-    toBuy = Math.max(0, Math.floor(1 + Decimal.log(Decimal.max(0.01, player.ascendShards), 10) - Math.log(G.constUpgradeCosts[i]!) / Math.log(10)))
   }
 
   if (toBuy > player.constantUpgrades[i]!) {


### PR DESCRIPTION
Bring back green highlight for automated Crystal upgrades
Make constant upgrades turn purple (instead of green) when you can upgrade them, which is consistent with Crystal upgrades
Make constant upgrades turn green when they become automated

this was requested on Discord
https://discord.com/channels/677271830838640680/1135496461350612992/1135496461350612992

In addition to the above, constant upgrades 9 and 10 will be green if they are level 1+. 

(also snuck in a minor optimization to constant upgrade metadata)