### PR TITLE
show max level on constant upgrades 9 and 10

### DIFF
--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -405,7 +405,7 @@ export const constantUpgradeDescriptions = (i: number) => {
   const [level, cost] = getConstUpgradeMetadata(i)
   DOMCacheGetOrSet('constUpgradeDescription').textContent = returnConstUpgDesc(i)
   if (i >= 9) {
-    DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i]) + '/1'
+    DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(Math.min(1, player.constantUpgrades[i]!)) + '/1'
   } else {
     DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i])
   }

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -404,7 +404,11 @@ export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
 export const constantUpgradeDescriptions = (i: number) => {
   const [level, cost] = getConstUpgradeMetadata(i)
   DOMCacheGetOrSet('constUpgradeDescription').textContent = returnConstUpgDesc(i)
-  DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i])
+  if (i >= 9) {
+    DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i]) + '/1'
+  } else {
+    DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i])
+  }
   DOMCacheGetOrSet('constUpgradeCost2').textContent = format(cost) + ' [+' + format(level) + ' LVL]'
   DOMCacheGetOrSet('constUpgradeEffect2').textContent = returnConstUpgEffect(i)
 }


### PR DESCRIPTION
reveals the maximum level of constant upgrades 9 and 10
caps the current level display to 1

the cap on current level isn't strictly necessary, but avoids the confusion of players seeing their current level is above the maximum, if their level was higher than 1 before the maximum level was implemented
(levels higher than the maximum have no effect)