### PR TITLE
A Few Fixes

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -285,7 +285,7 @@ export function calculateOfferings(input: resetNames, calcMult = true, statistic
     }
     a += 1 / 200 * G.rune5level * G.effectiveLevelMult * (1 + player.researches[85] / 200)
     a *= (1 + Math.pow(Decimal.log(player.reincarnationShards.add(1), 10), 2 / 3) / 4)
-    a *= Math.min(Math.pow(player.reincarnationcounter / 10 + 1, 2), 1)
+    a *= Math.min(Math.pow(player.reincarnationcounter / 10, 2), 1)
     if (player.reincarnationcounter >= 5) {
       a *= Math.max(1, player.reincarnationcounter / 10)
     }

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -894,7 +894,7 @@ export const gameStages = (): Stage[] => {
     { stage: 17, tier: 5, name: 'beta-1e15-expo', unlocked: player.challenge15Exponent >= 1e15, reset: player.achievements[183] === 1 },
     { stage: 18, tier: 5, name: '1e15-expo-omega', unlocked: player.platonicUpgrades[15] > 0, reset: player.achievements[183] === 1 },
     { stage: 19, tier: 5, name: 'omega-singularity', unlocked: player.singularityCount > 0 && player.runelevels[6] > 0, reset: player.achievements[183] === 1 },
-    { stage: 20, tier: 6, name: 'singularity-exalt1x1', unlocked: player.singularityUpgrades.wowPass2.level > 0, reset: player.highestSingularityCount > 0 },
+    { stage: 20, tier: 6, name: 'singularity-exalt1x1', unlocked: player.singularityChallenges.noSingularityUpgrades.completions > 0, reset: player.highestSingularityCount > 0 },
     { stage: 21, tier: 6, name: 'exalt1x1-onemind', unlocked: player.singularityUpgrades.oneMind.level > 0, reset: player.highestSingularityCount > 0 },
     { stage: 22, tier: 6, name: 'onemind-end', unlocked: player.singularityUpgrades.offeringAutomatic.level > 0, reset: player.highestSingularityCount > 0 },
     { stage: 23, tier: 6, name: 'end-pen', unlocked: player.singularityUpgrades.ultimatePen.level > 0, reset: player.highestSingularityCount > 0 },

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -841,7 +841,7 @@ export const buttoncolorchange = () => {
         : DOMCacheGetOrSet(`buyTesseracts${i}`).classList.remove('buildingPurchaseBtnAvailable')
     }
     for (let i = 1; i <= 8; i++) {
-      if (player.researches[190] >= 1) {
+      if (player.researches[175] >= 1) {
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAuto')
       } else {
@@ -853,7 +853,7 @@ export const buttoncolorchange = () => {
     }
 
     for (let i = 9; i <= 10; i++) {
-      if (player.researches[190] >= 1 || player.constantUpgrades[i]! >= 1) {
+      if (player.researches[175] >= 1 || player.constantUpgrades[i]! >= 1) {
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.remove('constUpgradeAvailable')
         DOMCacheGetOrSet(`buyConstantUpgrade${i}`).classList.add('constUpgradeAuto')
       } else {

--- a/src/Upgrades.ts
+++ b/src/Upgrades.ts
@@ -404,7 +404,9 @@ export const getConstUpgradeMetadata = (i: number): [number, Decimal] => {
 export const constantUpgradeDescriptions = (i: number) => {
   const [level, cost] = getConstUpgradeMetadata(i)
   DOMCacheGetOrSet('constUpgradeDescription').textContent = returnConstUpgDesc(i)
-  DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i])
+  if (i >= 9) {
+    DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(Math.min(1, player.constantUpgrades[i]!)) + '/1'
+  } else DOMCacheGetOrSet('constUpgradeLevel2').textContent = format(player.constantUpgrades[i])
   DOMCacheGetOrSet('constUpgradeCost2').textContent = format(cost) + ' [+' + format(level) + ' LVL]'
   DOMCacheGetOrSet('constUpgradeEffect2').textContent = returnConstUpgEffect(i)
 }


### PR DESCRIPTION
Issue: Time multiplier to offerings for reincarnations less than 10 seconds is always 1, allowing 0s auto reincarnation exploit for offerings when global speed is very low
Solution: Modified expression to match other similar time multipliers

Issue: Synergism Stage incorrectly changes to "exalt1x1-onemind" after purchase of shop liquidation sale
Solution: Stage now correctly changes to "exalt1x1-onemind" after completion of exalt 1x1

Issue: Constant upgrades autobuy highlighting is triggered by research r8x15 (tesseract building autobuy) (this was my fault)
Solution: Constant upgrades autobuy highlighting is triggered by research r7x25 (constant upgrades autobuy)

Issue: Constant upgrades 9 and 10 do not show they have a maximum level, confusing new players (this was asked about recently)
Solution: Constant upgrades 9 and 10 now show they have a maximum level of 1