### PR TITLE
Fixed a bug where Singularity broke with NaN in exalt5

### DIFF
--- a/src/Quark.ts
+++ b/src/Quark.ts
@@ -109,6 +109,13 @@ export class QuarkHandler {
 
   /** Subtracts quarks, as the name suggests. */
   add(amount: number, useBonus = true) {
+    // must be a valid number
+    if (!Number.isFinite(amount)) {
+      // eslint-disable-next-line no-console
+      console.log('platonic needs to fix')
+      return this
+    }
+
     this.QUARKS += useBonus ? this.applyBonus(amount) : amount
     player.quarksThisSingularity += useBonus ? this.applyBonus(amount) : amount
     return this

--- a/src/Reset.ts
+++ b/src/Reset.ts
@@ -1147,6 +1147,9 @@ export const singularity = async (setSingNumber = -1): Promise<void> => {
   hold.blueberryLoadouts = player.blueberryLoadouts
   hold.blueberryLoadoutMode = player.blueberryLoadoutMode as BlueberryLoadoutMode
 
+  // Required to prevent calls to player.caches.ambrosiaLuck.total
+  hold.loadedOct4Hotfix = true
+
   const saveCode42 = player.codes.get(42) ?? false
   const saveCode43 = player.codes.get(43) ?? false
   const saveCode44 = player.codes.get(44) ?? false


### PR DESCRIPTION
This PR fixes an issue where many variables become NaN when using Singularity and the game does not work properly.
The cause was difficult to identify due to interactions that replicated NaNs.
That is because player.loadedOct4Hotfix is undefined, player.worlds.add() in CheckVariables.ts#L425 is called, runs player.blueberryUpgrades.ambrosiaLuckQuark1.bonus.quarks, and returns undefined player.caches.ambrosiaLuck.total is caused by accessing

PR adds code in two places
- Added hold.loadedOct4Hotfix = true to Singularity reset
- Added code to prevent Quark from becoming NaN