### PR TITLE
Wait for login and event processing on loading

### DIFF
--- a/src/Event.ts
+++ b/src/Event.ts
@@ -73,6 +73,8 @@ let nowEvent: EventData | null = null
 
 export const getEvent = () => nowEvent
 
+let cacheEvents: EventData[] | null = null
+
 export const eventCheck = async () => {
   if (!player.dayCheck) {
     return
@@ -98,6 +100,19 @@ export const eventCheck = async () => {
     }
   })
 
+  cacheEvents = events
+
+  eventUpdate()
+}
+
+export const eventUpdate = async () => {
+  if (cacheEvents === null) {
+    await eventCheck()
+  }
+  if (cacheEvents === null) {
+    return
+  }
+
   const activeEvents: EventData[] = []
   nowEvent = null
 
@@ -105,7 +120,7 @@ export const eventCheck = async () => {
   let start: Date
   let end: Date
 
-  for (const event of events) {
+  for (const event of cacheEvents) {
     // TODO: use setDate instead to set the correct day.
     start = new Date(event.start)
     end = new Date(event.end)


### PR DESCRIPTION
This PR will now wait for login and event handling when loading
Fetching does not occur on singularities and imports
cacheReinitialize() and dailyResetCheck() are executed after login and events

Current specifications run offline bonus without waiting for login and event when loading
As a result, ambrosia, quark, etc. were calculated without events and logins.
This is very annoying because you have to be online all the time to get the full resources.

I think it would get noisy if we discussed this issue on discord, so I'll leave it to the dev discretion
This is especially bad news for people who have used Patreon, so it should be resolved

I'm not that confident in writing the correct code, so I'll wait for approval