### PR TITLE
fix offering calculation

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -516,7 +516,12 @@ export function calculateOfferings (
     q *= 1.05
   }
   q /= calculateSingularityDebuff('Offering')
-  q = (Math.floor(q) * 100) / 100
+
+  // This calculation is not necessary after the singularity
+  if (player.singularityCount < 1) {
+    q = (Math.floor(q) * 100) / 100
+  }
+
   if (player.currentChallenge.ascension === 15) {
     q *= 1 + 7 * player.cubeUpgrades[62]
   }

--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -516,12 +516,6 @@ export function calculateOfferings (
     q *= 1.05
   }
   q /= calculateSingularityDebuff('Offering')
-
-  // This calculation is not necessary after the singularity
-  if (player.singularityCount < 1) {
-    q = (Math.floor(q) * 100) / 100
-  }
-
   if (player.currentChallenge.ascension === 15) {
     q *= 1 + 7 * player.cubeUpgrades[62]
   }


### PR DESCRIPTION
In singularity, the penalty division continues to be enforced.
However, because the line in question uses Math.floor, an issue occurs where Offerings becomes 0 every second when the value falls below 1.
This can be triggered in exalt 1 and exalt 7, preventing completion.
The code appears to have been added before Ascension, so it was likely a meaningful calculation at the time.
As such, we will ignore this calculation from singularity onwards.