### PR TITLE
Fix some post-campaigns score calculation bugs

### DIFF
--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -129,6 +129,7 @@ export class CorruptionLoadout {
       ? 0.33
       : 0
     bonusVal += +player.singularityChallenges.oneChallengeCap.rewards.corrScoreIncrease
+    bonusVal += 0.3 * player.cubeUpgrades[74]
     
     let bonusMult = 1
     if (this.#levels[corr] >= 14 && player.singularityUpgrades.masterPack.getEffect().bonus) {


### PR DESCRIPTION
Fixes 3 things (only the first paragraph of each is the actual change, rest is rationale/testing).

1. The additive score bonuses (from the advanced pack and exalt2) were only being applied if the corruption was at least level 18. This is because a `+ bonusVal` was missing in one of the branches of the final `if`. (edit: also forgot cookie 24 was a thing, though it seems the campaigns code also missed that)

Here's an example of this on the currently live version ([save](https://github.com/user-attachments/files/19077615/demo.txt)):
<img width="1307" alt="image" src="https://github.com/user-attachments/assets/944cfdcb-585d-41d8-aca5-6c21082a8d19" />
The per-corruption score multiplier for level (0 + 2) should be 4 (base) + 1.02 (advanced pack + exalt2x23; cookie 24 would not be counted in this version regardless), but it is instead a flat 4, and the total is 4^8.

With level (15 + 2), the same issue: it should be (33 + 1.02) * 1.1 ~= 37.42, but is instead the flat 33 * 1.1 = 36.3
<img width="525" alt="image" src="https://github.com/user-attachments/assets/ad89f791-0a2e-485a-bb87-e64aa92a3ba9" />

With level (16 + 2), the calculation is correct: (35 + 1.02) * 1.1 ~= 39.62
<img width="528" alt="image" src="https://github.com/user-attachments/assets/3e80c112-14fa-4c34-9e7a-54a889347d29" />

2. The master pack bonus (1.1x for every corruption >= level 14) didn't actually check for the master pack purchase (only lv>=14). 

To see this, load this (hacked) [save](https://github.com/user-attachments/files/19077614/masterless.txt) that has the master pack set to unbought (on the live version). The corruption multiplier should be 1.81e17. If you buy the master pack (and force a recalc by manually saving and refreshing), the multiplier will not change, since the bonus was already applied. This value changes properly with the fix (and is meaningful, since a player would likely unlock lv14 corruptions before the master pack).

3. The master pack bonus applied pre-p4x2 power, leading to a net 1.1^power score multiplier from viscosity. This seems inconsistent with the upgrade's wording "for every level 14 corruption, Ascension score is multiplied by 1.1", which to me clearly implies a 1.1^(#corrs lv>=14) effect, **independent of the corruptions' score multipliers**. 

In particular, [the pre-campaigns behavior](https://github.com/Pseudo-Corp/SynergismOfficial/blob/627fce652fd2acc4efb2443a0a331f41d4b6407e/src/Calculate.ts#L2870) was consistent with my interpretation. If the new behavior is intended, the wording should probably be adjusted. Currently the fix moves the master pack bonus to outside the p4x2 power.

Some other possibly unintended things (that I did not change anything for):
- The campaigns update changed the order of calculation for viscosity: [pre-campaigns](https://github.com/Pseudo-Corp/SynergismOfficial/blob/627fce652fd2acc4efb2443a0a331f41d4b6407e/src/Calculate.ts#L2864) it was score^power + additive, post-campaigns it's (score + additive)^power, leading to a net buff. The in-game wording for these effects is not as precise as the master pack's, so I didn't touch it.
- The `scoreMult` function is obsoleted to merely a wrapper by the change; if it's better for the code structure to be different, I can adjust that too (though it's trickier if the previous line's update was intended).
- The expert pack's post-DR 1.5x score effect isn't factored in anywhere on the page (so the a * b * c = finalScore line on the display will always be off by 1.5x once you have the upgrade).