### PR TITLE
Prevent level 15 corruptions from applying in exalt1/7

### DIFF
--- a/src/Corruptions.ts
+++ b/src/Corruptions.ts
@@ -229,7 +229,7 @@ export class CorruptionLoadout {
   }
 
   get bonusLevels () {
-    let bonusLevel = player.singularityUpgrades.corruptionFifteen.level ? 1 : 0
+    let bonusLevel = player.singularityUpgrades.corruptionFifteen.getEffect().bonus ? 1 : 0
     bonusLevel += +player.singularityChallenges.oneChallengeCap.rewards.freeCorruptionLevel
     return bonusLevel
   }

--- a/translations/da.json
+++ b/translations/da.json
@@ -1898,11 +1898,6 @@
                 "description": "Ascension speed is multiplied by 6 if you have not purchased Antiquities in your current Singularity.",
                 "effect": "The effect is clear"
             },
-            "WIP": {
-                "name": "WIP TEMPLATE",
-                "description": "This is a template! Bottom Text.",
-                "effect": "Update this description at a later time!!!!!!!!!!"
-            },
             "ultimatePen": {
                 "name": "The Ultimate Pen",
                 "description": "You. It is you who is the author of your own story!",

--- a/translations/kaa.json
+++ b/translations/kaa.json
@@ -1898,11 +1898,6 @@
                 "description": "Ascension speed is multiplied by 6 if you have not purchased Antiquities in your current Singularity.",
                 "effect": "The effect is clear"
             },
-            "WIP": {
-                "name": "WIP TEMPLATE",
-                "description": "This is a template! Bottom Text.",
-                "effect": "Update this description at a later time!!!!!!!!!!"
-            },
             "ultimatePen": {
                 "name": "The Ultimate Pen",
                 "description": "You. It is you who is the author of your own story!",

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -2080,11 +2080,6 @@
         "description": "Ascension speed is multiplied by 6 if you have not purchased Antiquities in your current Singularity.",
         "effect": "The effect is clear."
       },
-      "WIP": {
-        "name": "WIP TEMPLATE",
-        "description": "This is a template! Bottom Text.",
-        "effect": "Update this description at a later time!!!!!!!!!!"
-      },
       "ultimatePen": {
         "name": "The Ultimate Pen",
         "description": "You. It is you who is the author of your own story!",

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1898,11 +1898,6 @@
                 "description": "Ascension speed is multiplied by 6 if you have not purchased Antiquities in your current Singularity.",
                 "effect": "The effect is clear"
             },
-            "WIP": {
-                "name": "WIP TEMPLATE",
-                "description": "This is a template! Bottom Text.",
-                "effect": "Update this description at a later time!!!!!!!!!!"
-            },
             "ultimatePen": {
                 "name": "The Ultimate Pen",
                 "description": "You. It is you who is the author of your own story!",

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -1898,11 +1898,6 @@
                 "description": "",
                 "effect": ""
             },
-            "WIP": {
-                "name": "",
-                "description": "",
-                "effect": ""
-            },
             "ultimatePen": {
                 "name": "",
                 "description": "",


### PR DESCRIPTION
screenshot of a [save](https://github.com/user-attachments/files/19122085/Synergism-1x30trial2-2025-03-07.01_30_56.txt) in exalt1x30 (next mult should be (base) 3 + (bonus) .99, and should say 1 free level... was so used to the display being wrong pre-campaigns that I didn't question it)
<img width="838" alt="image" src="https://github.com/user-attachments/assets/88099ee9-373c-47dc-80fd-5079f34558c0" />

ig it also has the same effect on exalt7
