### PR TITLE
fixed challenges and corruptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -1675,7 +1675,7 @@
                     <img id="challenge10" alt="Challenge 10" class="challenge" src="Pictures/Default/Challenge10.png" loading="lazy">
                     <p class="challengeLevels" id="challenge10level">0 / 25</p>
                 </div>
-                <div class="ascendunlock">
+                <div class="chal10">
                     <img id="challenge11" alt="challenge11" class="challenge" src="Pictures/Default/Challenge11.png" loading="lazy">
                     <p class="challengeLevels" id="challenge11level">0 / 10</p>
                 </div>

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "clipboard": "^2.0.11",
     "fast-mersenne-twister": "^1.0.3",
     "i18next": "^22.4.9",
-    "lodash.clonedeepwith": "^4.5.0",
     "lz-string": "^1.4.4",
+    "rfdc": "^1.4.1",
     "worker-timers": "^7.0.53",
     "zod": "^3.23.8"
   },

--- a/src/BlueberryUpgrades.ts
+++ b/src/BlueberryUpgrades.ts
@@ -51,6 +51,7 @@ export class BlueberryUpgrade extends DynamicUpgrade {
   public blueberryCost: number
   readonly preRequisites: BlueberryOpt | undefined
   readonly cacheUpdates: (() => void)[] | undefined
+  #key: string
 
   constructor (data: IBlueberryData, key: string) {
     const name = i18next.t(`ambrosia.data.${key}.name`)
@@ -64,6 +65,7 @@ export class BlueberryUpgrade extends DynamicUpgrade {
     this.blueberriesInvested = data.blueberriesInvested ?? 0
     this.preRequisites = data.prerequisites ?? undefined
     this.cacheUpdates = data.cacheUpdates ?? undefined
+    this.#key = key
   }
 
   getCostTNL (): number {
@@ -305,6 +307,27 @@ export class BlueberryUpgrade extends DynamicUpgrade {
         ? 0
         : this.level
     return this.rewards(effectiveLevel)
+  }
+
+  valueOf (): IBlueberryData {
+    return {
+      blueberryCost: this.blueberryCost,
+      costFormula: this.costFormula,
+      costPerLevel: this.costPerLevel,
+      maxLevel: this.maxLevel,
+      rewards: this.rewards,
+      ambrosiaInvested: this.ambrosiaInvested,
+      blueberriesInvested: this.blueberriesInvested,
+      cacheUpdates: this.cacheUpdates,
+      freeLevels: this.freeLevels,
+      level: this.level,
+      prerequisites: this.preRequisites,
+      toggleBuy: this.toggleBuy
+    }
+  }
+
+  key () {
+    return this.#key
   }
 }
 

--- a/src/Campaign.ts
+++ b/src/Campaign.ts
@@ -351,7 +351,7 @@ export class CampaignManager {
     return {
       currentCampaign: this.#currentCampaign,
       campaigns: this.allC10Completions
-    } as ICampaignManagerData
+    } satisfies ICampaignManagerData
   }
 
   set campaign (key: CampaignKeys) {

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -633,7 +633,7 @@ export const runChallengeSweep = (dt: number) => {
   if (
     autoAscensionChallengeSweepUnlock() && player.currentChallenge.ascension === 15
     && player.shopUpgrades.challenge15Auto === 0
-    && (action === 'start' || action === 'enter') && player.autoAscend && player.challengecompletions[11] > 0
+    && (action === 'start' || action === 'enter') && player.autoAscend && player.highestchallengecompletions[11] > 0
     && player.cubeUpgrades[10] > 0
     && player.autoAscendMode === 'realAscensionTime'
     && player.ascensionCounterRealReal >= Math.max(0.1, player.autoAscendThreshold - 5)

--- a/src/Challenges.ts
+++ b/src/Challenges.ts
@@ -198,7 +198,7 @@ export const challengeDisplay = (i: number, changefocus = true) => {
   const n = DOMCacheGetOrSet('challengeCurrent3')
 
   if (i === G.challengefocus) {
-    const completions = `${player.challengecompletions[i]}/${format(maxChallenges)}`
+    const completions = `${format(player.challengecompletions[i])}/${format(maxChallenges)}`
     const special = (i >= 6 && i <= 10) || i === 15
     const goal = format(challengeRequirement(i, player.challengecompletions[i], special ? i : 0))
 
@@ -214,6 +214,7 @@ export const challengeDisplay = (i: number, changefocus = true) => {
       }
       case 2: {
         current1 = current2 = format(5 * CalcECC('transcend', player.challengecompletions[2]))
+        current3 = format(0.25 * CalcECC('transcend', player.challengecompletions[2]))
         break
       }
       case 3: {

--- a/src/CubeExperimental.ts
+++ b/src/CubeExperimental.ts
@@ -154,6 +154,10 @@ export abstract class Cube {
     return this
   }
 
+  valueOf () {
+    return this.value
+  }
+
   [Symbol.toPrimitive] (h: string) {
     switch (h) {
       case 'string':

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -401,15 +401,18 @@ export class HepteractCraft {
     return this
   }
 
-  // Get balance of item
-  get amount () {
-    return this.BAL
-  }
-  get capacity () {
-    return this.CAP
-  }
-  get discount () {
-    return this.DISCOUNT
+  valueOf (): IHepteractCraft {
+    return {
+      BASE_CAP: this.BASE_CAP,
+      HEPTERACT_CONVERSION: this.HEPTERACT_CONVERSION,
+      OTHER_CONVERSIONS: this.OTHER_CONVERSIONS,
+      HTML_STRING: this.HTML_STRING,
+      UNLOCKED: this.UNLOCKED,
+      BAL: this.BAL,
+      CAP: this.CAP,
+      DISCOUNT: this.DISCOUNT,
+      AUTO: this.AUTO
+    }
   }
 }
 

--- a/src/Octeracts.ts
+++ b/src/Octeracts.ts
@@ -21,6 +21,7 @@ export class OcteractUpgrade extends DynamicUpgrade {
   public octeractsInvested = 0
   public qualityOfLife: boolean
   readonly cacheUpdates: (() => void)[] | undefined
+  #key: string
 
   constructor (data: IOcteractData, key: string) {
     const name = i18next.t(`octeract.data.${key}.name`)
@@ -30,6 +31,7 @@ export class OcteractUpgrade extends DynamicUpgrade {
     this.octeractsInvested = data.octeractsInvested ?? 0
     this.qualityOfLife = data.qualityOfLife ?? false
     this.cacheUpdates = data.cacheUpdates ?? undefined
+    this.#key = key
   }
 
   getCostTNL (): number {
@@ -195,6 +197,25 @@ export class OcteractUpgrade extends DynamicUpgrade {
         cache()
       }
     }
+  }
+
+  valueOf (): IOcteractData {
+    return {
+      costFormula: this.costFormula,
+      costPerLevel: this.costPerLevel,
+      maxLevel: this.maxLevel,
+      cacheUpdates: this.cacheUpdates,
+      effect: this.effect,
+      freeLevels: this.freeLevels,
+      level: this.level,
+      octeractsInvested: this.octeractsInvested,
+      qualityOfLife: this.qualityOfLife,
+      toggleBuy: this.toggleBuy
+    }
+  }
+
+  key () {
+    return this.#key
   }
 }
 

--- a/src/Quark.ts
+++ b/src/Quark.ts
@@ -84,5 +84,9 @@ export class QuarkHandler {
     this.QUARKS = 0
   }
 
+  valueOf () {
+    return this.QUARKS
+  }
+
   [Symbol.toPrimitive] = (t: string) => t === 'number' ? this.QUARKS : null
 }

--- a/src/SingularityChallenges.ts
+++ b/src/SingularityChallenges.ts
@@ -46,6 +46,7 @@ export class SingularityChallenge {
   public scalingrewardcount
   public uniquerewardcount
   readonly cacheUpdates: (() => void)[] | undefined
+  #key: string
 
   public constructor (data: ISingularityChallengeData, key: string) {
     const name = i18next.t(`singularityChallenge.data.${key}.name`)
@@ -70,6 +71,7 @@ export class SingularityChallenge {
     this.updateIconHTML()
     this.updateChallengeCompletions()
     this.cacheUpdates = data.cacheUpdates ?? undefined
+    this.#key = key
   }
 
   public computeSingularityRquirement () {
@@ -279,6 +281,28 @@ export class SingularityChallenge {
 
   public get rewards () {
     return this.effect(this.completions)
+  }
+
+  valueOf (): ISingularityChallengeData {
+    return {
+      baseReq: this.baseReq,
+      effect: this.effect,
+      HTMLTag: this.HTMLTag,
+      maxCompletions: this.maxCompletions,
+      scalingrewardcount: this.scalingrewardcount,
+      singularityRequirement: this.singularityRequirement,
+      uniquerewardcount: this.uniquerewardcount,
+      unlockSingularity: this.unlockSingularity,
+      cacheUpdates: this.cacheUpdates,
+      completions: this.completions,
+      enabled: this.enabled,
+      highestSingularityCompleted: this.highestSingularityCompleted,
+      resetTime: this.resetTime
+    }
+  }
+
+  key () {
+    return this.#key
   }
 }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -14,7 +14,7 @@ import {
   highestChallengeRewards,
   runChallengeSweep
 } from './Challenges'
-import { btoa, cleanString, isDecimal, sortWithIndices, sumContents } from './Utility'
+import { btoa, cleanString, deepClone, isDecimal, sortWithIndices, sumContents } from './Utility'
 import { blankGlobals, Globals as G } from './Variables'
 
 import {
@@ -1577,9 +1577,7 @@ export const player: Player = {
   seed: Array.from({ length: 2 }, () => Date.now())
 }
 
-export const blankSave = Object.assign({}, player, {
-  codes: new Map(Array.from({ length: 48 }, (_, i) => [i + 1, false]))
-})
+export const blankSave = deepClone(player)
 
 export const saveSynergy = (button?: boolean) => {
   player.offlinetick = Date.now()

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2120,6 +2120,8 @@ const loadSynergy = () => {
     )
 
     player.corruptions.used = new CorruptionLoadout(player.corruptions.used.loadout)
+    // This is needed to fix saves that had issues with not resetting corruption at the singularity
+    player.corruptions.used.setCorruptionLevelsWithChallengeRequirement(player.corruptions.used.loadout)
 
     for (let i = 1; i <= 5; i++) {
       const ascendBuildingI = `ascendBuilding${i as OneToFive}` as const

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -60,8 +60,8 @@ export const toggleChallenges = (i: number, auto = false) => {
       resetrepeat('transcensionChallenge')
     }
   }
-  else if (i >= 6 && i <= 10) {
-    if ((player.currentChallenge.ascension !== 15 || player.ascensionCounter >= 2)) {
+  if (i >= 6 && i <= 10) {
+    if (player.currentChallenge.ascension !== 15 || player.ascensionCounter >= 2) {
       player.currentChallenge.reincarnation = i
       reset('reincarnationChallenge', false, 'enterChallenge')
       player.reincarnationCount -= 1
@@ -70,8 +70,8 @@ export const toggleChallenges = (i: number, auto = false) => {
       resetrepeat('reincarnationChallenge')
     }
   }
-  else if (
-    (i >= 11 && i <= 15) && (i === 11 ? player.achievements[141] === 1 : player.highestchallengecompletions[i - 1] > 0)
+  if (
+    (i >= 11 && i <= 15) && ((i === 11 && player.achievements[141] === 1) || player.highestchallengecompletions[i - 1] > 0)
     && ((!auto && !player.toggles[31]) || player.challengecompletions[10] > 0
       || (player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0
         && player.currentChallenge.ascension === 0))

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -50,7 +50,7 @@ export const toggleSettings = (toggle: HTMLElement) => {
 }
 
 export const toggleChallenges = (i: number, auto = false) => {
-  if ((i <= 5)) {
+  if (i >= 0 && i <= 5) {
     if (player.currentChallenge.ascension !== 15 || player.ascensionCounter >= 2) {
       player.currentChallenge.transcension = i
       reset('transcensionChallenge', false, 'enterChallenge')
@@ -60,8 +60,8 @@ export const toggleChallenges = (i: number, auto = false) => {
       resetrepeat('transcensionChallenge')
     }
   }
-  if ((i >= 6 && i < 11)) {
-    if (player.currentChallenge.ascension !== 15 || player.ascensionCounter >= 2) {
+  else if (i >= 6 && i <= 10) {
+    if ((player.currentChallenge.ascension !== 15 || player.ascensionCounter >= 2)) {
       player.currentChallenge.reincarnation = i
       reset('reincarnationChallenge', false, 'enterChallenge')
       player.reincarnationCount -= 1
@@ -70,8 +70,8 @@ export const toggleChallenges = (i: number, auto = false) => {
       resetrepeat('reincarnationChallenge')
     }
   }
-  if (
-    i >= 11
+  else if (
+    (i >= 11 && i <= 15) && (i === 11 ? player.achievements[141] === 1 : player.highestchallengecompletions[i - 1] > 0)
     && ((!auto && !player.toggles[31]) || player.challengecompletions[10] > 0
       || (player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0
         && player.currentChallenge.ascension === 0))

--- a/src/Toggles.ts
+++ b/src/Toggles.ts
@@ -71,7 +71,7 @@ export const toggleChallenges = (i: number, auto = false) => {
     }
   }
   if (
-    (i >= 11 && i <= 15) && ((i === 11 && player.achievements[141] === 1) || player.highestchallengecompletions[i - 1] > 0)
+    (i >= 11 && i <= 15) && (i === 11 ? player.achievements[141] === 1 : player.highestchallengecompletions[i - 1] > 0)
     && ((!auto && !player.toggles[31]) || player.challengecompletions[10] > 0
       || (player.currentChallenge.transcension === 0 && player.currentChallenge.reincarnation === 0
         && player.currentChallenge.ascension === 0))

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -125,10 +125,10 @@ export const revealStuff = () => {
     }
   }
 
-  document.documentElement.dataset.chal11 = player.challengecompletions[11] > 0 ? 'true' : 'false'
-  document.documentElement.dataset.chal12 = player.challengecompletions[12] > 0 ? 'true' : 'false'
-  document.documentElement.dataset.chal13 = player.challengecompletions[13] > 0 ? 'true' : 'false'
-  document.documentElement.dataset.chal14 = player.challengecompletions[14] > 0 ? 'true' : 'false'
+  document.documentElement.dataset.chal11 = player.highestchallengecompletions[11] > 0 ? 'true' : 'false'
+  document.documentElement.dataset.chal12 = player.highestchallengecompletions[12] > 0 ? 'true' : 'false'
+  document.documentElement.dataset.chal13 = player.highestchallengecompletions[13] > 0 ? 'true' : 'false'
+  document.documentElement.dataset.chal14 = player.highestchallengecompletions[14] > 0 ? 'true' : 'false'
 
   document.documentElement.dataset.ascendUnlock = player.ascensionCount > 0 ? 'true' : 'false'
   document.documentElement.dataset.prestigeUnlock = player.unlocks.prestige ? 'true' : 'false'

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -1,17 +1,22 @@
 import Decimal, { type DecimalSource } from 'break_infinity.js'
-import { DOMCacheGetOrSet } from './Cache/DOM'
-import { format } from './Synergism'
 import rfdc from 'rfdc'
-import { QuarkHandler } from './Quark'
+import { BlueberryUpgrade } from './BlueberryUpgrades'
+import { DOMCacheGetOrSet } from './Cache/DOM'
+import { CampaignManager } from './Campaign'
+import { CorruptionLoadout, CorruptionSaves } from './Corruptions'
 import { WowCubes, WowHypercubes, WowPlatonicCubes, WowTesseracts } from './CubeExperimental'
 import { HepteractCraft } from './Hepteracts'
-import { CorruptionLoadout, CorruptionSaves } from './Corruptions'
-import { CampaignManager } from './Campaign'
-import { SingularityUpgrade } from './singularity'
 import { OcteractUpgrade } from './Octeracts'
+import { QuarkHandler } from './Quark'
+import { SingularityUpgrade } from './singularity'
 import { SingularityChallenge } from './SingularityChallenges'
-import { BlueberryUpgrade } from './BlueberryUpgrades'
-import { AmbrosiaGenerationCache, AmbrosiaLuckAdditiveMultCache, AmbrosiaLuckCache, BlueberryInventoryCache } from './StatCache'
+import {
+  AmbrosiaGenerationCache,
+  AmbrosiaLuckAdditiveMultCache,
+  AmbrosiaLuckCache,
+  BlueberryInventoryCache
+} from './StatCache'
+import { format } from './Synergism'
 
 export const isDecimal = (o: unknown): o is Decimal =>
   o instanceof Decimal

--- a/src/Utility.ts
+++ b/src/Utility.ts
@@ -1,7 +1,17 @@
-import Decimal from 'break_infinity.js'
-import cloneDeepWith from 'lodash.clonedeepwith'
+import Decimal, { type DecimalSource } from 'break_infinity.js'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { format } from './Synergism'
+import rfdc from 'rfdc'
+import { QuarkHandler } from './Quark'
+import { WowCubes, WowHypercubes, WowPlatonicCubes, WowTesseracts } from './CubeExperimental'
+import { HepteractCraft } from './Hepteracts'
+import { CorruptionLoadout, CorruptionSaves } from './Corruptions'
+import { CampaignManager } from './Campaign'
+import { SingularityUpgrade } from './singularity'
+import { OcteractUpgrade } from './Octeracts'
+import { SingularityChallenge } from './SingularityChallenges'
+import { BlueberryUpgrade } from './BlueberryUpgrades'
+import { AmbrosiaGenerationCache, AmbrosiaLuckAdditiveMultCache, AmbrosiaLuckCache, BlueberryInventoryCache } from './StatCache'
 
 export const isDecimal = (o: unknown): o is Decimal =>
   o instanceof Decimal
@@ -208,15 +218,31 @@ export const createDeferredPromise = <T>(): DeferredPromise<T> => {
   return { resolve, reject, promise }
 }
 
-export const deepClone = (value: unknown) => {
-  return cloneDeepWith(value, (value) => {
-    if (isDecimal(value) || value instanceof Decimal) {
-      return new Decimal(value)
-    }
-
-    return value
-  })
-}
+export const deepClone = rfdc({
+  proto: false,
+  circles: false,
+  constructorHandlers: [
+    [Decimal, (o: DecimalSource) => new Decimal(o)],
+    [QuarkHandler, (o: QuarkHandler) => new QuarkHandler(o.valueOf())],
+    [WowCubes, (o: WowCubes) => new WowCubes(o.valueOf())],
+    [WowTesseracts, (o: WowTesseracts) => new WowTesseracts(o.valueOf())],
+    [WowHypercubes, (o: WowHypercubes) => new WowHypercubes(o.valueOf())],
+    [WowPlatonicCubes, (o: WowPlatonicCubes) => new WowPlatonicCubes(o.valueOf())],
+    [HepteractCraft, (o: HepteractCraft) => new HepteractCraft(o.valueOf())],
+    [CorruptionLoadout, (o: CorruptionLoadout) => new CorruptionLoadout(o.loadout)],
+    [CorruptionSaves, (o: CorruptionSaves) => new CorruptionSaves(o.corrSaveData)],
+    [CampaignManager, (o: CampaignManager) => new CampaignManager(o.campaignManagerData)],
+    [SingularityUpgrade, (o: SingularityUpgrade) => new SingularityUpgrade(o.valueOf(), o.key())],
+    [OcteractUpgrade, (o: OcteractUpgrade) => new OcteractUpgrade(o.valueOf(), o.key())],
+    [SingularityChallenge, (o: SingularityChallenge) => new SingularityChallenge(o.valueOf(), o.key())],
+    [BlueberryUpgrade, (o: BlueberryUpgrade) => new BlueberryUpgrade(o.valueOf(), o.key())],
+    // WHY THE FUCK ARE THESE ON PLAYER, PLATONIC?
+    [AmbrosiaLuckAdditiveMultCache, () => new AmbrosiaLuckAdditiveMultCache()],
+    [AmbrosiaLuckCache, () => new AmbrosiaLuckCache()],
+    [AmbrosiaGenerationCache, () => new AmbrosiaGenerationCache()],
+    [BlueberryInventoryCache, () => new BlueberryInventoryCache()]
+  ]
+})
 
 export function memoize<Args extends unknown[], Ret> (fn: (...args: Args) => Ret) {
   let ran = false

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -152,6 +152,7 @@ export class SingularityUpgrade extends DynamicUpgrade {
   public specialCostForm: SingularitySpecialCostFormulae
   public qualityOfLife: boolean
   readonly cacheUpdates: (() => void)[] | undefined
+  #key: string
 
   public constructor (data: ISingularityData, key: string) {
     const name = i18next.t(`singularity.data.${key}.name`)
@@ -164,6 +165,7 @@ export class SingularityUpgrade extends DynamicUpgrade {
     this.specialCostForm = data.specialCostForm ?? 'Default'
     this.qualityOfLife = data.qualityOfLife ?? false
     this.cacheUpdates = data.cacheUpdates ?? undefined
+    this.#key = key
   }
 
   /**
@@ -434,6 +436,27 @@ export class SingularityUpgrade extends DynamicUpgrade {
     player.goldenQuarks += this.goldenQuarksInvested
     this.level = 0
     this.goldenQuarksInvested = 0
+  }
+
+  valueOf (): ISingularityData {
+    return {
+      costPerLevel: this.costPerLevel,
+      maxLevel: this.maxLevel,
+      cacheUpdates: this.cacheUpdates,
+      canExceedCap: this.canExceedCap,
+      effect: this.effect,
+      freeLevels: this.freeLevels,
+      goldenQuarksInvested: this.goldenQuarksInvested,
+      level: this.level,
+      minimumSingularity: this.minimumSingularity,
+      qualityOfLife: this.qualityOfLife,
+      specialCostForm: this.specialCostForm,
+      toggleBuy: this.toggleBuy
+    }
+  }
+
+  key () {
+    return this.#key
   }
 }
 


### PR DESCRIPTION
- Set corruptions level to 0 if it is below the requirement on load.
For years, there has been a bug where ascending or corrupting just before a singularity could leave corruptions behind after the singularity.
Since Platonic removed the code for this in a campaign commit, more and more people have complained about this rare issue.
I've once again introduced code to fix problematic saves and make them playable.
Please do not remove the code even if you have fixed this issue, as saves and files from players who played the affected version will not be lost.

- Prevented ascension challenges from starting unless the requirement is actually met.
This is to prevent abuse of CSS styles.

- Once C10 is complete, C11 will unlock without ascending.
You will ascend when you start C11. I've tested this a few times over the past 2 years so it should be fine.