### PR TITLE
Enable tab wrapping on narrow screen such as phone

### DIFF
--- a/src/Tabs.ts
+++ b/src/Tabs.ts
@@ -337,6 +337,7 @@ class TabRow extends HTMLDivElement {
       margin-block: unset;
       padding-inline: unset;
       display: flex;
+      flex-wrap: wrap;
       justify-content: center;
       gap: 0 5px;
     `


### PR DESCRIPTION
I am concerned why there is additionally https://github.com/Pseudo-Corp/SynergismOfficial/blob/22230e9be0e029962b8a97e159d5fb83d5b442fe/Synergism.css#L590

Example on phone size:
![image](https://github.com/user-attachments/assets/b6ef9674-48ce-4ec8-b500-2cbf0e415453)
![image](https://github.com/user-attachments/assets/75a8e7b4-7cbf-4ce9-ac8e-ef53acebf87b)
