### PR TITLE
Tiny fix: lv1 inheritance perk

### DIFF
--- a/src/Calculate.ts
+++ b/src/Calculate.ts
@@ -3534,8 +3534,8 @@ export const inheritanceTokens = () => {
   const tokens = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
 
   for (let i = 15; i > 0; i--) {
-    if (player.highestSingularityCount >= levels[i]) {
-      return tokens[i]
+    if (player.highestSingularityCount >= levels[i - 1]) {
+      return tokens[i - 1]
     }
   }
 

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -1829,9 +1829,9 @@ export const singularityPerks: SingularityPerk[] = [
       const tokens = [1, 10, 25, 40, 75, 100, 150, 200, 250, 300, 350, 400, 500, 600, 750]
 
       for (let i = 15; i > 0; i--) {
-        if (n >= levels[i]) {
+        if (n >= levels[i - 1]) {
           return i18next.t('singularity.perks.tokenInheritance.default', {
-            amount: tokens[i]
+            amount: tokens[i - 1]
           })
         }
       }


### PR DESCRIPTION
Currently does nothing at lv1 (both visually and computationally):
<img width="633" alt="image" src="https://github.com/user-attachments/assets/99cab607-32f3-463a-aa59-e3cebd725faa" />

The rest of the levels were not off by one afaik, just that lv1 was being ignored

saves (they're hacked versions of a main save so none of the numbers will make sense lol, but the perk behaves as expected) - [s1](https://github.com/user-attachments/files/19268814/hack-s1.3.txt), [s2](https://github.com/user-attachments/files/19268815/hack-s2.3.txt), [s5](https://github.com/user-attachments/files/19268817/hack-s5.3.txt), [s276](https://github.com/user-attachments/files/19268818/hack-s276.txt), [s277](https://github.com/user-attachments/files/19268819/hack-s277.txt)
