### PR TITLE
Fast Forward Hardcap into Softcap

### DIFF
--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -2552,7 +2552,7 @@ const handlePerks = (singularityCount: number) => {
 // Indicates the number of extra Singularity count gained on Singularity reset
 export const getFastForwardTotalMultiplier = (): number => {
   let fastForward = 0
-  var ffHardCap = 245 // True Hardcap for FF (Change as needed).
+  const ffHardCap = 245 // True Hardcap for FF (Change as needed).
   // Please for the love of god don't allow FF during a challenge or if Sing is at least at Hardcap (Don't do needless maths).
   if (player.insideSingularityChallenge || player.singularityCount >= ffHardCap) {
     return 0

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -2552,8 +2552,9 @@ const handlePerks = (singularityCount: number) => {
 // Indicates the number of extra Singularity count gained on Singularity reset
 export const getFastForwardTotalMultiplier = (): number => {
   let fastForward = 0
-  // Please for the love of god don't allow FF during a challenge or if Sing is at least 245 (Don't do needless maths).
-  if (player.insideSingularityChallenge || player.singularityCount >= 245) {
+  var ffHardCap = 245 // True Hardcap for FF (Change as needed).
+  // Please for the love of god don't allow FF during a challenge or if Sing is at least at Hardcap (Don't do needless maths).
+  if (player.insideSingularityChallenge || player.singularityCount >= ffHardCap) {
     return 0
   }
 
@@ -2569,12 +2570,12 @@ export const getFastForwardTotalMultiplier = (): number => {
     ))
   }
 
-  // Stop at Sing 245 even if you include fast forward. Also acts as a Negative Value check.
+  // Stop at Hardcap even if you include fast forward. Also acts as a Negative Value check.
   fastForward = Math.max(
     0,
     Math.min(
       fastForward, 
-      245 - player.singularityCount - 1
+      ffHardCap - player.singularityCount - 1
     )
   )
 

--- a/src/singularity.ts
+++ b/src/singularity.ts
@@ -2552,20 +2552,31 @@ const handlePerks = (singularityCount: number) => {
 // Indicates the number of extra Singularity count gained on Singularity reset
 export const getFastForwardTotalMultiplier = (): number => {
   let fastForward = 0
+  // Please for the love of god don't allow FF during a challenge or if Sing is at least 245 (Don't do needless maths).
+  if (player.insideSingularityChallenge || player.singularityCount >= 245) {
+    return 0
+  }
+
+  // Initial Returns done, time to maths.
   fastForward += +player.singularityUpgrades.singFastForward.getEffect().bonus
   fastForward += +player.singularityUpgrades.singFastForward2.getEffect().bonus
   fastForward += +player.octeractUpgrades.octeractFastForward.getEffect().bonus
 
-  // Stop at sing 200 even if you include fast forward
+  // Starting @ Sing 200, FF slows down by 1 every 15 Sings until it is effectively negated @ Sing 245.
+  if (player.singularityCount >= 200) {
+    fastForward -= (Math.floor(
+      (player.singularityCount - 185) / 15
+    ))
+  }
+
+  // Stop at Sing 245 even if you include fast forward. Also acts as a Negative Value check.
   fastForward = Math.max(
     0,
-    Math.min(fastForward, 200 - player.singularityCount - 1)
+    Math.min(
+      fastForward, 
+      245 - player.singularityCount - 1
+    )
   )
-
-  // Please for the love of god don't allow FF during a challenge
-  if (player.insideSingularityChallenge) {
-    return 0
-  }
 
   // If the next singularityCount is greater than the highestSingularityCount, fast forward to be equal to the highestSingularityCount
   if (

--- a/translations/en.json
+++ b/translations/en.json
@@ -1972,9 +1972,9 @@
       },
       "immaculateAlchemy": {
         "name": "Immaculate Alchemy",
-        "hasLevel2": "After Singularity 200, Fast Forwards no longer work! Instead, multiply your GQ gain and divide your GQ buy cost by 8.",
-        "hasLevel1": "After Singularity 200, Fast Forwards no longer work! Instead, multiply your GQ gain and divide your GQ buy cost by 5.",
-        "default": "After Singularity 200, Fast Forwards no longer work! Instead, multiply your GQ gain and divide your GQ buy cost by 3."
+        "hasLevel2": "Starting at Singularity 200, Fast Forwards will be reduced by 1 every 15 Sings! In exchange, multiply your GQ gain and divide your GQ buy cost by 8.",
+        "hasLevel1": "Starting at Singularity 200, Fast Forwards will be reduced by 1 every 15 Sings! In exchange, multiply your GQ gain and divide your GQ buy cost by 5.",
+        "default": "Starting at Singularity 200, Fast Forwards will be reduced by 1 every 15 Sings! In exchange, multiply your GQ gain and divide your GQ buy cost by 3."
       },
       "skrauQ": {
         "name": "skrauQ",


### PR DESCRIPTION
# Fast Forward Hardcap into Softcap
This PR implements a simple change:
Fast Forward is no longer hardcapped at Sing 200 and instead its effect will be reduced by 1 for every 15 Sings past it, up until the effect is entirely negated by Sing 245.

Needing to do at least 100 manual sings is a chore at best and monotonously dull at worst, this change is intended to make that climb smoother up until Sing Penalties start becoming a real problem (Roughly Sing 250).

The code was also refreshed by placing the Exalt check at the front (No doing needless maths), unrolling maths in line with other examples and commenting everything up nice and neatly.

Based on the fact we have had more content and buffs compared to when S200 - 250 was the endgame, I do not believe further changes will be warrented, however this would still be up to Plats descretion. Technically this solution is also flexible in case Plat ever decides to add new FF upgrades so that's something?

## TLDR
- Fast Forward now is a scaling softcap starting at S200, reducing by -1 for every 15 Sings completed.
- Exalt check at the front so you don't do maths on a value that gets immediately zeroed out.
- Cleaned Code around the affected area, including comments.