### PR TITLE
fix Cost and Effect of maxed-out PseudoCoin upgrades

### DIFF
--- a/src/purchases/UpgradesSubtab.ts
+++ b/src/purchases/UpgradesSubtab.ts
@@ -98,10 +98,10 @@ function setActiveUpgrade (upgrade: UpgradesList | undefined) {
         })
       }`
       : 'Cannot buy. Sorry!'
-    const info = showCostAndEffect(upgrade!.internalName)
-    costs.innerHTML = info.cost
-    effects.innerHTML = info.effect
   }
+  const info = showCostAndEffect(upgrade!.internalName)
+  costs.innerHTML = info.cost
+  effects.innerHTML = info.effect
 }
 
 async function purchaseUpgrade (upgrades: Map<number, UpgradesList>) {


### PR DESCRIPTION
Cost and effect for maxed-out PseudoCoin upgrades are not updated properly.
This PR fixes the problem.

![image](https://github.com/user-attachments/assets/25e32352-e67e-40db-b177-9cf793823000)