### PR TITLE
Fix Tesseract/Hypercube effects past softcap

### DIFF
--- a/src/Hypercubes.ts
+++ b/src/Hypercubes.ts
@@ -9,7 +9,7 @@ export const calculateAcceleratorHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.accelerator
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.accelerator, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.accelerator, DR)
   }
 }
 
@@ -21,7 +21,7 @@ export const calculateMultiplierHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.multiplier
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.multiplier, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.multiplier, DR)
   }
 }
 
@@ -33,7 +33,7 @@ export const calculateOfferingHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.offering
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.offering, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.offering, DR)
   }
 }
 
@@ -51,7 +51,7 @@ export const calculateObtainiumHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.obtainium
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.obtainium, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.obtainium, DR)
   }
 }
 
@@ -63,7 +63,7 @@ export const calculateAntSpeedHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.antSpeed
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.antSpeed, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.antSpeed, DR)
   }
 }
 
@@ -75,7 +75,7 @@ export const calculateAntSacrificeHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.antSacrifice
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.antSacrifice, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.antSacrifice, DR)
   }
 }
 
@@ -91,7 +91,7 @@ export const calculateRuneEffectivenessHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.talismanBonus
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.talismanBonus, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.talismanBonus, DR)
   }
 }
 
@@ -103,6 +103,6 @@ export const calculateGlobalSpeedHypercubeBlessing = () => {
     return 1 + effectPerBlessing * player.hypercubeBlessings.globalSpeed
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.globalSpeed, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.hypercubeBlessings.globalSpeed, DR)
   }
 }

--- a/src/Tesseracts.ts
+++ b/src/Tesseracts.ts
@@ -22,7 +22,7 @@ export const calculateAcceleratorTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.accelerator
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.accelerator, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.accelerator, DR)
   }
 }
 
@@ -34,7 +34,7 @@ export const calculateMultiplierTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.multiplier
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.multiplier, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.multiplier, DR)
   }
 }
 
@@ -46,7 +46,7 @@ export const calculateOfferingTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.offering
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.offering, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.offering, DR)
   }
 }
 
@@ -64,7 +64,7 @@ export const calculateObtainiumTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.obtainium
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.obtainium, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.obtainium, DR)
   }
 }
 
@@ -83,7 +83,7 @@ export const calculateAntSacrificeTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.antSacrifice
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.antSacrifice, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.antSacrifice, DR)
   }
 }
 
@@ -100,7 +100,7 @@ export const calculateRuneEffectivenessTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.talismanBonus
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.talismanBonus, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.talismanBonus, DR)
   }
 }
 
@@ -112,6 +112,6 @@ export const calculateGlobalSpeedTesseractBlessing = () => {
     return 1 + effectPerBlessing * player.tesseractBlessings.globalSpeed
   } else {
     const limitMult = Math.pow(limit, 1 - DR)
-    return effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.globalSpeed, DR)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.tesseractBlessings.globalSpeed, DR)
   }
 }


### PR DESCRIPTION
In the recent update, the Tesseract/Hypercube effect formulas past softcap are missing the base of 1 (like the pre-softcap ones), which makes them weaker (by 100% as displayed). This seems to be the reason for the existence of a new timewall past Beta.