### PR TITLE
english spelling pass

### DIFF
--- a/translations/da.json
+++ b/translations/da.json
@@ -1557,7 +1557,7 @@
                 "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
             },
             "midasMilleniumAgedGold": {
-                "name": "Midas' Millenium-Aged Gold",
+                "name": "Midas' Millennium-Aged Gold",
                 "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
             },
             "goldenRevolution4": {
@@ -1676,7 +1676,7 @@
             },
             "singOfferings3": {
                 "name": "Offering Tempest",
-                "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+                "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
                 "effect": "Permanently gain {{n}}% more Offerings."
             },
             "singObtainium1": {
@@ -1711,7 +1711,7 @@
             },
             "singCitadel": {
                 "name": "Citadel of Singularity",
-                "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+                "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
                 "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}%, forever!"
             },
             "singCitadel2": {
@@ -1809,7 +1809,7 @@
             },
             "singQuarkImprover1": {
                 "name": "Marginal Quark Gain Improver Thingy",
-                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
                 "effect": "You gain {{n}}% more Quarks!"
             },
             "singQuarkHepteract": {
@@ -1945,7 +1945,7 @@
             "zeroOrLess": "Only numbers greater than zero, please!",
             "moreThanPlayerHas": "You can't afford this yet!",
             "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-            "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+            "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
             "finiteInt": "Value must be a finite, non-decimal number!",
             "invalidNumber": "Hey! That's not a valid number!"
         },

--- a/translations/de.json
+++ b/translations/de.json
@@ -276,7 +276,7 @@
         "effect": "This upgrade increases Ambrosia Luck by {{amount}}!"
       },
       "redGenerationSpeed": {
-        "name": "Millenium-Aged Red Ambrosia",
+        "name": "Millennium-Aged Red Ambrosia",
         "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by {{amount}}!"
       },
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] Du hast es! +16,666% 3D Würfel durchs Aufsteigen pro Level.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Athena gewährt dir +10% mehr Obtainium, und +80% Auto Obtainium pro Level.",
       "4": "[1x4] Du behältst diese 5 nützlichen Automatisierungs-Upgrades im Reiter für Upgrades!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3199,7 +3199,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -3349,7 +3349,7 @@
       },
       "singOfferings3": {
         "name": "Offering Tempest",
-        "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+        "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
         "effect": "Permanently gain {{n}} more Offerings."
       },
       "singObtainium1": {
@@ -3384,7 +3384,7 @@
       },
       "singCitadel": {
         "name": "Zitadelle der Singularität",
-        "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+        "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
         "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}, forever!"
       },
       "singCitadel2": {
@@ -3482,7 +3482,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginales Quark Einkommen Verbesserer Ding",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "Du erhältst {{n}}% mehr Quarks!"
       },
       "singQuarkHepteract": {
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Hourglass of Minutiae",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Hourglass of Myopathy",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Hourglass of Infinitude",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Hourglass of Reality",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6272,7 +6272,7 @@
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Visited Ambrosia Subtab after clearing EXALT 5x1:",
       "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
-      "RedAmbrosia": "Millenium-Aged Red Ambrosia:",
+      "RedAmbrosia": "Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT Reward - No Ambrosia Upgrades:",
       "Total": "Total Red Bar Points/s:"
     },
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "It seems like this holds the power to be at the End of Time. Do you remember why you need this?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Cubes (lol)"
         },
         "accelerator": {

--- a/translations/en.json
+++ b/translations/en.json
@@ -276,7 +276,7 @@
         "effect": "This upgrade increases Ambrosia Luck by {{amount}}!"
       },
       "redGenerationSpeed": {
-        "name": "Millenium-Aged Red Ambrosia",
+        "name": "Millennium-Aged Red Ambrosia",
         "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by {{amount}}!"
       },
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] You got it! +16.666% 3D Cubes from Ascending per level.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Athena grants you +10% more Obtainium, and +80% Auto Obtainium per level.",
       "4": "[1x4] You keep those 5 useful automation upgrades in the upgrades tab!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3199,7 +3199,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -3349,7 +3349,7 @@
       },
       "singOfferings3": {
         "name": "Offering Tempest",
-        "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+        "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
         "effect": "Permanently gain {{n}} more Offerings."
       },
       "singObtainium1": {
@@ -3384,7 +3384,7 @@
       },
       "singCitadel": {
         "name": "Citadel of Singularity",
-        "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+        "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
         "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}, forever!"
       },
       "singCitadel2": {
@@ -3482,7 +3482,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "You gain {{n}}% more Quarks!"
       },
       "singQuarkHepteract": {
@@ -3737,7 +3737,7 @@
       "zeroOrLess": "Only numbers greater than zero, please!",
       "moreThanPlayerHas": "You can't afford this yet!",
       "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-      "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+      "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
       "finiteInt": "Value must be a finite, non-decimal number!",
       "invalidNumber": "Hey! That's not a valid number!"
     },
@@ -4882,22 +4882,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Hourglass of Minutiae",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Hourglass of Myopathy",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Hourglass of Infinitude",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Hourglass of Reality",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6279,7 +6279,7 @@
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Visited Ambrosia Subtab after clearing EXALT 5x1:",
       "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
-      "RedAmbrosia": "Millenium-Aged Red Ambrosia:",
+      "RedAmbrosia": "Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT Reward - No Ambrosia Upgrades:",
       "Total": "Total Red Bar Points/s:"
     },
@@ -6577,7 +6577,7 @@
         },
         "abyss": {
           "effect": "It seems like this holds the power to be at the End of Time. Do you remember why you need this?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Cubes (lol)"
         },
         "accelerator": {

--- a/translations/es.json
+++ b/translations/es.json
@@ -276,7 +276,7 @@
         "effect": "This upgrade increases Ambrosia Luck by {{amount}}!"
       },
       "redGenerationSpeed": {
-        "name": "Millenium-Aged Red Ambrosia",
+        "name": "Millennium-Aged Red Ambrosia",
         "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by {{amount}}!"
       },
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] ¡Lo tienes! +16.666% Cubos 3D de Ascensiones por nivel.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Atenea te otorga +10% Obtainium extra, y un +80% Auto Obtainium por nivel.",
       "4": "[1x4] ¡Mantienes esas útiles 5 mejoras de automatización en la pestaña de mejoras!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3199,7 +3199,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Reloj de Arena de Minuta",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Reloj de Arena de Miopatía",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Reloj de Arena de Infinidad",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Reloj de Arena de Realidad",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6272,7 +6272,7 @@
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Visited Ambrosia Subtab after clearing EXALT 5x1:",
       "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
-      "RedAmbrosia": "Millenium-Aged Red Ambrosia:",
+      "RedAmbrosia": "Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT Reward - No Ambrosia Upgrades:",
       "Total": "Total Red Bar Points/s:"
     },
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "Parece que esto posee el poder de llegar al Fin de los Tiempos. ¿Me recuerdas por qué lo necesitas?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "Uno de estos te costará {{x}} Hepteractos y {{y}} Cubos ¡Wow! (nice)"
         },
         "accelerator": {

--- a/translations/fr.json
+++ b/translations/fr.json
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] Ça roule ! +16,666% de Cubes 3D lors de l'Ascension par niveau.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Athéna vous accorde +10% d’Obtainium supplémentaire et +80% d’Obtainium auto par niveau.",
       "4": "[1x4] Vous gardez ces 5 améliorations d'automatisation bien pratiques dans l'onglet des Améliorations !",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3482,7 +3482,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "You gain {{n}}% more Quarks!"
       },
       "singQuarkHepteract": {
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Sablier de Minutie",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Sablier de Myopathie",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Sablier d'Infinité",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Sablier de Réalité",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "Il semblerait que celui ci détient le pouvoir d'être à la Fin des Temps. Vous souvenez-vous pourquoi vous en avez besoin ?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "En acheter un vous coûtera {{x}} Hepteracts et {{y}} Cubes Wow! (mdr)"
         },
         "accelerator": {

--- a/translations/ja.json
+++ b/translations/ja.json
@@ -276,7 +276,7 @@
         "effect": "This upgrade increases Ambrosia Luck by {{amount}}!"
       },
       "redGenerationSpeed": {
-        "name": "Millenium-Aged Red Ambrosia",
+        "name": "Millennium-Aged Red Ambrosia",
         "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by {{amount}}!"
       },
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] You got it! +16.666% 3D Cubes from Ascending per level.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Athena grants you +10% more Obtainium, and +80% Auto Obtainium per level.",
       "4": "[1x4] You keep those 5 useful automation upgrades in the upgrades tab!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3199,7 +3199,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -3349,7 +3349,7 @@
       },
       "singOfferings3": {
         "name": "Offering Tempest",
-        "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+        "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
         "effect": "Permanently gain {{n}} more Offerings."
       },
       "singObtainium1": {
@@ -3384,7 +3384,7 @@
       },
       "singCitadel": {
         "name": "Citadel of Singularity",
-        "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+        "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
         "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}, forever!"
       },
       "singCitadel2": {
@@ -3482,7 +3482,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "You gain {{n}}% more Quarks!"
       },
       "singQuarkHepteract": {
@@ -3730,7 +3730,7 @@
       "zeroOrLess": "Only numbers greater than zero, please!",
       "moreThanPlayerHas": "You can't afford this yet!",
       "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-      "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+      "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
       "finiteInt": "Value must be a finite, non-decimal number!",
       "invalidNumber": "Hey! That's not a valid number!"
     },
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Hourglass of Minutiae",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Hourglass of Myopathy",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Hourglass of Infinitude",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Hourglass of Reality",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6272,7 +6272,7 @@
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Visited Ambrosia Subtab after clearing EXALT 5x1:",
       "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
-      "RedAmbrosia": "Millenium-Aged Red Ambrosia:",
+      "RedAmbrosia": "Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT Reward - No Ambrosia Upgrades:",
       "Total": "Total Red Bar Points/s:"
     },
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "It seems like this holds the power to be at the End of Time. Do you remember why you need this?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Cubes (lol)"
         },
         "accelerator": {

--- a/translations/kaa.json
+++ b/translations/kaa.json
@@ -1557,7 +1557,7 @@
                 "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
             },
             "midasMilleniumAgedGold": {
-                "name": "Midas' Millenium-Aged Gold",
+                "name": "Midas' Millennium-Aged Gold",
                 "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
             },
             "goldenRevolution4": {
@@ -1676,7 +1676,7 @@
             },
             "singOfferings3": {
                 "name": "Offering Tempest",
-                "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+                "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
                 "effect": "Permanently gain {{n}}% more Offerings."
             },
             "singObtainium1": {
@@ -1711,7 +1711,7 @@
             },
             "singCitadel": {
                 "name": "Citadel of Singularity",
-                "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+                "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
                 "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}%, forever!"
             },
             "singCitadel2": {
@@ -1809,7 +1809,7 @@
             },
             "singQuarkImprover1": {
                 "name": "Marginal Quark Gain Improver Thingy",
-                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
                 "effect": "You gain {{n}}% more Quarks!"
             },
             "singQuarkHepteract": {
@@ -1945,7 +1945,7 @@
             "zeroOrLess": "Only numbers greater than zero, please!",
             "moreThanPlayerHas": "You can't afford this yet!",
             "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-            "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+            "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
             "finiteInt": "Value must be a finite, non-decimal number!",
             "invalidNumber": "Hey! That's not a valid number!"
         },

--- a/translations/nl.json
+++ b/translations/nl.json
@@ -1733,7 +1733,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -1856,7 +1856,7 @@
       },
       "singOfferings3": {
         "name": "Offering Tempest",
-        "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+        "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
         "effect": "Permanently gain {{n}}% more Offerings."
       },
       "singObtainium1": {
@@ -1891,7 +1891,7 @@
       },
       "singCitadel": {
         "name": "Citadel of Singularity",
-        "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+        "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
         "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}%, forever!"
       },
       "singCitadel2": {
@@ -1989,7 +1989,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "You gain {{n}}% more Quarks!"
       },
       "singQuarkHepteract": {
@@ -2165,7 +2165,7 @@
       "zeroOrLess": "Only numbers greater than zero, please!",
       "moreThanPlayerHas": "You can't afford this yet!",
       "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-      "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+      "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
       "finiteInt": "Value must be a finite, non-decimal number!",
       "invalidNumber": "Hey! That's not a valid number!"
     },
@@ -2942,22 +2942,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Hourglass of Minutiae",
-        "description": "A somewhat primative hourglass which somehow makes your blueberries generate seconds 1% faster per level..",
+        "description": "A somewhat primitive hourglass which somehow makes your blueberries generate seconds 1% faster per level..",
         "effect": "Blueberry Seconds Generation +{{n}}%(!)"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Hourglass of Myopathy",
-        "description": "An hourglass which is still primative, though somehow less so. +1% Blueberry Second Generation per level.",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% Blueberry Second Generation per level.",
         "effect": "Blueberry Seconds Generation +{{n}}%(!)"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Hourglass of Infinitude",
-        "description": "Don't get it twisted- this hourglass is really primative. But it gives +1% Blueberry Second Generation per level and is infinitely levelable!",
+        "description": "Don't get it twisted- this hourglass is really primitive. But it gives +1% Blueberry Second Generation per level and is infinitely levelable!",
         "effect": "Blueberry Seconds Generation +{{n}}%(!)"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Hourglass of Reality",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% Blueberry Second Generation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% Blueberry Second Generation per level.",
         "effect": "Blueberry Seconds Generation +{{n}}%(!)"
       }
     },

--- a/translations/pl.json
+++ b/translations/pl.json
@@ -276,7 +276,7 @@
         "effect": "This upgrade increases Ambrosia Luck by {{amount}}!"
       },
       "redGenerationSpeed": {
-        "name": "Millenium-Aged Red Ambrosia",
+        "name": "Millennium-Aged Red Ambrosia",
         "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by {{amount}}!"
       },
@@ -789,7 +789,7 @@
       "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
       "448": "That's a quadrillion to you: Prestige 1e15 times.",
       "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Presitgious, it becomes ordinary: Prestige 1e20 times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] Mamy to! +16.666% Sześcianów 3D z Ascendencji co poziom.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Atena przyznaje ci 10% więcej Obtainium oraz +80% Automatycznego Obtainium co poziom.",
       "4": "[1x4] Zatrzymaj te 5 użytecznych automatyzacji z zakładki Ulepszenia!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -3199,7 +3199,7 @@
         "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
       },
       "midasMilleniumAgedGold": {
-        "name": "Midas' Millenium-Aged Gold",
+        "name": "Midas' Millennium-Aged Gold",
         "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
       },
       "goldenRevolution4": {
@@ -3349,7 +3349,7 @@
       },
       "singOfferings3": {
         "name": "Offering Tempest",
-        "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+        "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
         "effect": "Permanently gain {{n}} more Offerings."
       },
       "singObtainium1": {
@@ -3384,7 +3384,7 @@
       },
       "singCitadel": {
         "name": "Citadel of Singularity",
-        "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+        "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
         "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}, forever!"
       },
       "singCitadel2": {
@@ -3482,7 +3482,7 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "otrzymasz {{n}}% więcej kwarków!"
       },
       "singQuarkHepteract": {
@@ -3730,7 +3730,7 @@
       "zeroOrLess": "Proszę tylko liczby większe od zera!",
       "moreThanPlayerHas": "Jeszcze cię na to nie stać!",
       "fraction": "Tak, to nie jest liczba całkowita. Nie przyjmujemy tutaj ułamków!",
-      "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+      "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
       "finiteInt": "Value must be a finite, non-decimal number!",
       "invalidNumber": "Hey! That's not a valid number!"
     },
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Hourglass of Minutiae",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Hourglass of Myopathy",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Hourglass of Infinitude",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Hourglass of Reality",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6272,7 +6272,7 @@
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Visited Ambrosia Subtab after clearing EXALT 5x1:",
       "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
-      "RedAmbrosia": "Millenium-Aged Red Ambrosia:",
+      "RedAmbrosia": "Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT Reward - No Ambrosia Upgrades:",
       "Total": "Total Red Bar Points/s:"
     },
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "It seems like this holds the power to be at the End of Time. Do you remember why you need this?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Cubes (lol)"
         },
         "accelerator": {

--- a/translations/pt.json
+++ b/translations/pt.json
@@ -1557,7 +1557,7 @@
                 "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
             },
             "midasMilleniumAgedGold": {
-                "name": "Midas' Millenium-Aged Gold",
+                "name": "Midas' Millennium-Aged Gold",
                 "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
             },
             "goldenRevolution4": {
@@ -1676,7 +1676,7 @@
             },
             "singOfferings3": {
                 "name": "Offering Tempest",
-                "description": "This bar is so prestine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
+                "description": "This bar is so pristine, it'll make anyone submit their Offerings. +4% per level, to be precise.",
                 "effect": "Permanently gain {{n}}% more Offerings."
             },
             "singObtainium1": {
@@ -1711,7 +1711,7 @@
             },
             "singCitadel": {
                 "name": "Citadel of Singularity",
-                "description": "What a unique structual phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
+                "description": "What a unique structural phenomenon... but it gives +2% Obtainium, Offerings, and 3-7D cubes per level! +1% Additional for every 10 levels!",
                 "effect": "Obtainium, Offerings, and 3-7D Cubes +{{n}}%, forever!"
             },
             "singCitadel2": {
@@ -1809,7 +1809,7 @@
             },
             "singQuarkImprover1": {
                 "name": "Marginal Quark Gain Improver Thingy",
-                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitarily long?",
+                "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
                 "effect": "You gain {{n}}% more Quarks!"
             },
             "singQuarkHepteract": {
@@ -1945,7 +1945,7 @@
             "zeroOrLess": "Only numbers greater than zero, please!",
             "moreThanPlayerHas": "You can't afford this yet!",
             "fraction": "Yeah, that isn't an integer. We don't accept fractions here!",
-            "goldenQuarksTooMany": "Sorry, I cannnot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
+            "goldenQuarksTooMany": "Sorry, I cannot sell you this many Golden Quarks! Try buying fewer of them or typing -1 to buy max!",
             "finiteInt": "Value must be a finite, non-decimal number!",
             "invalidNumber": "Hey! That's not a valid number!"
         },

--- a/translations/pt_BR.json
+++ b/translations/pt_BR.json
@@ -1557,7 +1557,7 @@
                 "default": "The 'Add' Special Action refills {{counter}}% faster per level per Singularity. Currently: {{current}} (MAX: -60% Cooldown)"
             },
             "midasMilleniumAgedGold": {
-                "name": "Midas' Millenium-Aged Gold",
+                "name": "Midas' Millennium-Aged Gold",
                 "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
             },
             "goldenRevolution4": {

--- a/translations/ru.json
+++ b/translations/ru.json
@@ -2482,7 +2482,7 @@
     },
     "upgradeDescriptions": {
       "1": "[1x1] Не вопрос! +16.666% 3Д Кубов от Вознесения за уровень.",
-      "2": "[1x2] Plutus grants you +3 Salage per level!",
+      "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Афина дарует вам +10% к Обтаниуму, и +80% Авто Обтаниума за уровень.",
       "4": "[1x4] Вы сохраняете те 5 полезных улучшений автоматизации во вкладке улучшений!",
       "5": "[1x5] You keep the Mythos upgrade automation upgrade in the upgrades tab!",
@@ -4875,22 +4875,22 @@
       },
       "octeractAmbrosiaGeneration2": {
         "name": "Часы Мелочей",
-        "description": "A somewhat primative hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
+        "description": "A somewhat primitive hourglass which somehow grants +1% faster Ambrosia Bar Point creation per level...",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration3": {
         "name": "Часы Миопатии",
-        "description": "An hourglass which is still primative, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
+        "description": "An hourglass which is still primitive, though somehow less so. +1% faster Ambrosia Bar Point creation per level",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration": {
         "name": "Часы Бесконечности",
-        "description": "Don't get it twisted, this hourglass is really primative. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
+        "description": "Don't get it twisted, this hourglass is really primitive. But it gives +1% faster Ambrosia Bar Point creation per level and is infinitely levelable!",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractAmbrosiaGeneration4": {
         "name": "Часы Реальности",
-        "description": "An hourglass which is nonprimative and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
+        "description": "An hourglass which is nonprimitive and 'more timely'- whatever that means. +2% faster Ambrosia Bar Point creation per level.",
         "effect": "Ambrosia Bar Point creation is +{{n}}% faster!"
       },
       "octeractBlueberries": {
@@ -6570,7 +6570,7 @@
         },
         "abyss": {
           "effect": "Похоже, этот владеет силой быть в Конце Времён. Вы ещё помните, зачем вам это нужно?",
-          "currentEffect": "Your rememberance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
+          "currentEffect": "Your remembrance of Time Immemorial grants you <<green|Salvage +{{x}}>>",
           "oneCost": "Один такой будет стоить вам {{x}} Гептерактов и {{y}} Вау! Кубов(лол)"
         },
         "accelerator": {


### PR DESCRIPTION
Fixing "Plutus grants you +3 Salage" and other common spelling errors.

I used cspell to scan the repo and considered trying to add it as a script/devDep. However, the number of custom terms in the repo made the result seem rather finicky, as it picked up many fun/intentional misspellings.  So I'm just pushing the results.