### PR TITLE
Update Ambrosia Luck and Red Luck achievement level effect to match description

### DIFF
--- a/src/Levels.ts
+++ b/src/Levels.ts
@@ -183,7 +183,7 @@ export const synergismLevelRewards: Record<SynergismLevelReward, SynergismLevelR
   ambrosiaLuck: {
     name: () => i18next.t('achievements.levelRewards.ambrosiaLuck.name'),
     description: () => i18next.t('achievements.levelRewards.ambrosiaLuck.description'),
-    effect: (lv: number) => 4 * (lv - 229),
+    effect: (lv: number) => 4 * (lv - 199),
     effectDescription: () => {
       const luck = getLevelReward('ambrosiaLuck')
       return i18next.t('achievements.levelRewards.ambrosiaLuck.effect', {
@@ -197,7 +197,7 @@ export const synergismLevelRewards: Record<SynergismLevelReward, SynergismLevelR
   redAmbrosiaLuck: {
     name: () => i18next.t('achievements.levelRewards.redAmbrosiaLuck.name'),
     description: () => i18next.t('achievements.levelRewards.redAmbrosiaLuck.description'),
-    effect: (lv: number) => lv - 259,
+    effect: (lv: number) => lv - 249,
     effectDescription: () => {
       const luck = getLevelReward('redAmbrosiaLuck')
       return i18next.t('achievements.levelRewards.redAmbrosiaLuck.effect', {


### PR DESCRIPTION
Bug Report here: https://discord.com/channels/677271830838640680/1420457591884218368/1420938026468507700

Changes the Ambrosia Luck and Green Ambrosia Luck bonus from Achievement Level Rewards to the value listed in the description of the reward.  No images included because I don't have a save that deep into the game to test with.