### PR TITLE
fix: hide Hept gain until appropriate time

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -5575,14 +5575,6 @@ html[data-chal14="false"] .chal14 {
     display: none;
 }
 
-html[data-chal15="true"] .chal15 {
-    display: block;
-}
-
-html[data-chal15="false"] .chal15 {
-    display: none;
-}
-
 html[data-ascend-unlock="true"] .ascendunlockib {
     display: inline-block;
 }

--- a/index.html
+++ b/index.html
@@ -2619,7 +2619,7 @@
             <p id="corruptionTesseracts" class="tightText" style="color: white"></p>
             <p id="corruptionHypercubes" class="chal13 tightText" style="color: white"></p>
             <p id="corruptionPlatonicCubes" class="chal14 tightText" style="color: white"></p>
-            <p id="corruptionHepteracts" class="chal15 tightText" style="color: white"></p>
+            <p id="corruptionHepteracts" class="hepteracts tightText" style="color: white"></p>
             <div id="ascensionAutomation" class="cubeUpgrade10 vAlign">
                 <button id="ascensionAutoEnable" class="ascendunlock hCenter tight" style="border: 2px solid green"></button>
                 <button id="ascensionAutoToggle" class="hCenter tight" style="border:2px solid orchid;"></button>

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -153,7 +153,6 @@ export const revealStuff = () => {
   document.documentElement.dataset.chal12 = player.highestchallengecompletions[12] > 0 ? 'true' : 'false'
   document.documentElement.dataset.chal13 = player.highestchallengecompletions[13] > 0 ? 'true' : 'false'
   document.documentElement.dataset.chal14 = player.highestchallengecompletions[14] > 0 ? 'true' : 'false'
-  document.documentElement.dataset.chal15 = player.highestchallengecompletions[15] > 0 ? 'true' : 'false'
 
   document.documentElement.dataset.ascendUnlock = player.ascensionCount > 0 ? 'true' : 'false'
   document.documentElement.dataset.prestigeUnlock = player.unlocks.prestige ? 'true' : 'false'


### PR DESCRIPTION
Hepteracts are using a different logic for show/hide than other cube types, which is causing them to show too early.  This change uses the same css strategy used by other elements, but extends it to chal15 completions.

Reported here: https://discord.com/channels/677271830838640680/1420457591884218368/1421217317873782867

Current:
<img width="625" height="83" alt="image" src="https://github.com/user-attachments/assets/757bbed4-746c-42c0-a0ba-4ce80c426b7b" />
Fixed:
<img width="633" height="67" alt="image" src="https://github.com/user-attachments/assets/c18d6f2a-6311-45f4-b511-e0f8b38e6b46" />
