### PR TITLE
Standardize wowcube color variables and classes

### DIFF
--- a/Synergism.css
+++ b/Synergism.css
@@ -75,6 +75,11 @@ body {
     --lightseagreen-text-color: lightseagreen;
     --amber-text-color: #ffbf00;
     --lightgoldenrodyellow-text-color: lightgoldenrodyellow;
+    --wowcube-color: gold;
+    --tesseract-color: orange;
+    --hypercube-color: #ff004c;
+    --platonic-color: orchid;
+    --hepteract-color: mediumpurple;
     --header-color: var(--bg-color);
     --bg-color: #111;
     --alert-color: #141414;
@@ -135,6 +140,12 @@ body.loading {
 .darkcyanText { color: var(--darkcyan-text-color); }
 .amberText { color: var(--amber-text-color); }
 .lightyellowText { color: var(--lightgoldenrodyellow-text-color); }
+
+.wowcubeText { color: var(--wowcube-color); }
+.wowtesseractText { color: var(--tesseract-color); }
+.wowhypercubeText { color: var(--hypercube-color); }
+.wowplatonicText { color: var(--platonic-color); }
+.wowhepteractText { color: var(--hepteract-color); }
 
 .active-subtab {
     background-color: crimson;
@@ -718,8 +729,8 @@ button.isEvent:hover {
 }
 
 #cubetab {
-    border-color: orange;
-    color: red;
+    border-color: var(--wowcube-color);
+    color: var(--hypercube-color);
 }
 
 #campaigntab {
@@ -2512,7 +2523,7 @@ p#reincarnatehotkeys {
 .cubeBtn {
     min-width: 100px;
     background-color: var(--blackbtn-color);
-    border: 1px solid gold;
+    border: 1px solid var(--wowcube-color);
 }
 
 .autoOpensBtn {
@@ -2541,17 +2552,6 @@ p[id$="BlessingsTotal"] {
     padding: 15px;
     margin-left: 22.5%;
     margin-right: auto;
-}
-
-#cubeBlessingsTotal { color: orange; }
-
-#tesseractBlessingsTotal { color: var(--orchid-text-color); }
-
-#hypercubeBlessingsTotal { color: rgb(255 0 76); }
-
-#platonicBlessingsTotal {
-    color: orange;
-    margin: 0;
 }
 
 #platonicFooter,
@@ -2812,7 +2812,7 @@ button.language-select span.lang-name {
 
 #tesseractAmount {
     color: white;
-    border: 1px solid orange;
+    border: 1px solid var(--tesseract-color);
     background-color: var(--blackbtn-color);
 }
 
@@ -3640,27 +3640,6 @@ header #obtainiumDisplay { color: pink; }
 
 #ascC10 {
     color: limegreen;
-}
-
-#ascCubes {
-    color: yellow;
-}
-
-#ascTess {
-    /* color: var(--orchid-text-color); */
-    color: orange;
-}
-
-#ascHyper {
-    color: var(--crimson-text-color);
-}
-
-#ascPlatonic {
-    color: orchid;
-}
-
-#ascHepteract {
-    color: mediumpurple;
 }
 
 #ascTimeAccel {

--- a/Synergism.css
+++ b/Synergism.css
@@ -75,7 +75,7 @@ body {
     --lightseagreen-text-color: lightseagreen;
     --amber-text-color: #ffbf00;
     --lightgoldenrodyellow-text-color: lightgoldenrodyellow;
-    --wowcube-color: gold;
+    --wowcube-color: #fd0;
     --tesseract-color: orange;
     --hypercube-color: #ff004c;
     --platonic-color: orchid;

--- a/index.html
+++ b/index.html
@@ -178,23 +178,23 @@
         <div id="ascensionStats">
             <span id="ascCubeStats">
                 <img src="Pictures/Default/TinyWow3.png" class="corruptionImg" alt="3D Cube" title="Cube Information" loading="lazy">
-                <span id="ascCubes">x</span> C<span id="unit1">/s</span>
+                <span id="ascCubes" class="wowcubeText">x</span> C<span id="unit1">/s</span>
             </span>
             <span id="ascTessStats">
                 <img src="Pictures/Default/TinyWow4.png" class="corruptionImg" alt="4D Cube" title="Tesseract Information" loading="lazy">
-                <span id="ascTess">x</span> T<span id="unit2">/s</span>
+                <span id="ascTess" class="wowtesseractText">x</span> T<span id="unit2">/s</span>
             </span>
             <span id="ascHyperStats">
                 <img src="Pictures/Default/TinyWow5.png" class="corruptionImg" title="Hypercube Information" loading="lazy">
-                <span id="ascHyper">x</span> Hy<span id="unit3">/s</span>
+                <span id="ascHyper" class="wowhypercubeText">x</span> Hy<span id="unit3">/s</span>
             </span>
             <span id="ascPlatonicStats">
                 <img src="Pictures/Default/TinyWow6.png" class="corruptionImg" title="Platonic Information" loading="lazy">
-                <span id="ascPlatonic">x</span> P<span id="unit4">/s</span>
+                <span id="ascPlatonic" class="wowplatonicText">x</span> P<span id="unit4">/s</span>
             </span>
             <span id="ascHepteractStats">
                 <img src="Pictures/Default/TinyWow7.png" class="corruptionImg" title="Hepteract Information" loading="lazy">
-                <span id="ascHepteract">x</span> He<span id="unit5">/s</span>
+                <span id="ascHepteract" class="wowhepteractText">x</span> He<span id="unit5">/s</span>
             </span>
             <span id="ascTimeTakenStats">
                 <img src="Pictures/Default/TinyA.png" class="corruptionImg" title="Ascension Timer" loading="lazy">
@@ -1786,13 +1786,13 @@
         <div id="cubesWrapper">
             <div id="wowCubeSidebar">
                 <div id="wowCubeSidebarButtons">
-                    <button id="switchCubeSubTab1" class="cubeSwitchTabBtn active-subtab" style="border: 2px solid gold;" i18n="tabs.cubes.cubeTributes"></button>
-                    <button id="switchCubeSubTab2" class="cubeSwitchTabBtn chal11" style="border: 2px solid orange;" i18n="tabs.cubes.tesseract"></button>
-                    <button id="switchCubeSubTab3" class="cubeSwitchTabBtn chal13" style="border: 2px solid red;" i18n="tabs.cubes.hypercube"></button>
-                    <button id="switchCubeSubTab4" class="cubeSwitchTabBtn chal14" style="border: 2px solid orchid;" i18n="tabs.cubes.platonic"></button>
+                    <button id="switchCubeSubTab1" class="cubeSwitchTabBtn active-subtab" style="border: 2px solid var(--wowcube-color);" i18n="tabs.cubes.cubeTributes"></button>
+                    <button id="switchCubeSubTab2" class="cubeSwitchTabBtn chal11" style="border: 2px solid var(--tesseract-color);" i18n="tabs.cubes.tesseract"></button>
+                    <button id="switchCubeSubTab3" class="cubeSwitchTabBtn chal13" style="border: 2px solid var(--hypercube-color);" i18n="tabs.cubes.hypercube"></button>
+                    <button id="switchCubeSubTab4" class="cubeSwitchTabBtn chal14" style="border: 2px solid var(--platonic-color);" i18n="tabs.cubes.platonic"></button>
                     <button id="switchCubeSubTab5" class="cubeSwitchTabBtn" style="border: 2px solid white;" i18n="tabs.cubes.cubeUpgrades"></button>
                     <button id="switchCubeSubTab6" class="cubeSwitchTabBtn chal14" style="border: 2px solid orchid;" i18n="tabs.cubes.challenge15"></button>
-                    <button id="switchCubeSubTab7" class="cubeSwitchTabBtn hepteracts" style="border: 2px solid mediumpurple" i18n="tabs.cubes.hepteract"></button>
+                    <button id="switchCubeSubTab7" class="cubeSwitchTabBtn hepteracts" style="border: 2px solid var(--hepteract-color)" i18n="tabs.cubes.hepteract"></button>
                 </div>
                 <div class="cubesToQuark">
                     <div class="cubeToQuark">
@@ -1822,14 +1822,14 @@
                 </div>
             </div>
             <div id="cubeTab1" class="cubeTab" style="display: flex">
-                <span id="cubeWelcome" class="cubePlacement1" style="color: orange" i18n="wowCubes.cubes.intro"></span>
+                <span id="cubeWelcome" class="cubePlacement1 wowcubeText" i18n="wowCubes.cubes.intro"></span>
                 <span id="cubeExpository1" class="cubePlacement2" style="color: white" i18n="wowCubes.cubes.instructions"></span>
                 <span id="cubeExpository2" class="cubePlacement3" style="color: limegreen" i18n="wowCubes.greenText"></span>
 
                 <div class="openGrid">
                     <img class="openImage" src="Pictures/Default/WowCube.png" loading="lazy">
                     <div class="openButtons">
-                        <span class="inventory" style="color: white" id="cubeQuantity"></span>
+                        <span class="inventory wowcubeText" id="cubeQuantity"></span>
                         <div class="openBtn">
                             <button class="cubeBtn" id="open1Cube" i18n="wowCubes.open1"></button>
                             <button class="cubeBtn" id="open20Cube" i18n="wowCubes.open10%"></button>
@@ -1909,19 +1909,19 @@
                     </table>
                 </div>
                 <div id="cubeFooter">
-                    <p id="cubeBlessingsTotal"></p>
+                    <p id="cubeBlessingsTotal" class="wowcubeText"></p>
                     <p id="cubeFull"></p>
                 </div>
             </div>
             <div id="cubeTab2" class="cubeTab" style="display: none">
-                <span id="tesseractWelcome" class="cubePlacement1 orchidText" i18n="wowCubes.tesseracts.intro"></span>
+                <span id="tesseractWelcome" class="cubePlacement1 wowtesseractText" i18n="wowCubes.tesseracts.intro"></span>
                 <span id="tesseractExpository1" class="cubePlacement2" style="color: white" i18n="wowCubes.tesseracts.instructions"></span>
                 <span id="tesseractExpository2" class="cubePlacement3" style="color: limegreen" i18n="wowCubes.greenText"></span>
 
                 <div class="openGrid">
                     <img class="openImage" src="Pictures/Default/WowTessaract.png" loading="lazy">
                     <div class="openButtons">
-                        <span id="tesseractQuantity" class="inventory orangeText"></span>
+                        <span id="tesseractQuantity" class="inventory wowtesseractText"></span>
                         <div class="openBtn">
                             <button id="open1Tesseract" class="cubeBtn" i18n="wowCubes.open1"></button>
                             <button id="open20Tesseract" class="cubeBtn" i18n="wowCubes.open10%"></button>
@@ -2000,17 +2000,17 @@
                         </tr>
                     </table>
                 </div>
-                <p id="tesseractBlessingsTotal"></p>
+                <p id="tesseractBlessingsTotal"  class="wowtesseractText"></p>
             </div>
             <div id="cubeTab3" class="cubeTab" style="display: none">
-                <span id="hypercubeWelcome" class="cubePlacement1" style="color: rgb(255, 0, 76)" i18n="wowCubes.hypercubes.intro"></span>
+                <span id="hypercubeWelcome" class="cubePlacement1 wowhypercubeText" i18n="wowCubes.hypercubes.intro"></span>
                 <span id="hypercubeExpository1" class="cubePlacement2" style="color: white" i18n="wowCubes.hypercubes.instructions"></span>
                 <span id="hypercubeExpository2" class="cubePlacement3" style="color: limegreen" i18n="wowCubes.greenText"></span>
 
                 <div class="openGrid">
                     <img class="openImage" src="Pictures/Default/WowHypercube.png" loading="lazy">
                     <div class="openButtons">
-                        <span id="hypercubeQuantity" class="inventory" style="color: rgb(255, 0, 76)"></span>
+                        <span id="hypercubeQuantity" class="inventory wowhypercubeText"></span>
                         <div class="openBtn">
                             <button id="open1Hypercube" class="cubeBtn" i18n="wowCubes.open1"></button>
                             <button id="open20Hypercube" class="cubeBtn" i18n="wowCubes.open10%"></button>
@@ -2089,17 +2089,17 @@
                         </tr>
                     </table>
                 </div>
-                <p id="hypercubeBlessingsTotal"></p>
+                <p id="hypercubeBlessingsTotal" class="wowhypercubeText"></p>
             </div>
             <div id="cubeTab4" class="cubeTab" style="display: none">
-                <span id="platonicCubeWelcome" class="cubePlacement1 orangeredText" i18n="wowCubes.platonics.intro"></span>
+                <span id="platonicCubeWelcome" class="cubePlacement1 wowplatonicText" i18n="wowCubes.platonics.intro"></span>
                 <span id="platonicCubeExpository1" class="cubePlacement2" style="color: white" i18n="wowCubes.platonics.instructions"></span>
                 <span id="platonicCubeExpository2" class="cubePlacement3" style="color: limegreen" i18n="wowCubes.greenText"></span>
 
                 <div class="openGrid">
                     <img class="openImage" src="Pictures/Default/PlatonicCube.png" loading="lazy">
                     <div class="openButtons">
-                        <span id="platonicQuantity" class="inventory" style="color:orchid"></span>
+                        <span id="platonicQuantity" class="inventory wowplatonicText"></span>
                         <div class="openBtn">
                             <button id="open1PlatonicCube" class="cubeBtn" i18n="wowCubes.open1"></button>
                             <button id="open40kPlatonicCube" class="cubeBtn" i18n="wowCubes.open10%"></button>
@@ -2167,7 +2167,7 @@
                     </table>
                 </div>
                 <div id="platonicFooter">
-                    <p id="platonicBlessingsTotal"></p>
+                    <p id="platonicBlessingsTotal" class="wowplatonicText"></p>
                     <p id="platonicAsterisk" i18n="wowCubes.platonics.asterisk"></p>
                 </div>
             </div>
@@ -2346,13 +2346,13 @@
                 </div>
             </div>
             <div id="cubeTab7" class="cubeTab" style="display: none">
-                <span id="hepteractWelcome" class="cubePlacement1" style="color: pink" i18n="wowCubes.hepteractForge.howDidIGetHere"></span>
+                <span id="hepteractWelcome" class="cubePlacement1 wowhepteractText" i18n="wowCubes.hepteractForge.howDidIGetHere"></span>
                 <span id="hepteractExpository1" class="cubePlacement2" style="color: white" i18n="wowCubes.hepteractForge.noTimeToWaste"></span>
                 <span id="hepteractExpository2" class="cubePlacement3 redText" i18n="wowCubes.hepteractForge.noPassiveBonus"></span>
                 <div class="openGrid">
                     <img class="openImage" src="Pictures/Default/Hepteract.png" loading="lazy">
                     <div class="NotificationToggle">
-                        <span id="hepteractQuantity" style="color: mediumpurple"></span>
+                        <span id="hepteractQuantity wowhepteractText"></span>
                         <img class="heptNotification" id="heptnotificationpic" alt="Notification" src="Pictures/Default/Notifications.png" title="Notifications" loading="lazy">
                         <button class="auto nonSquare" id="toggle35" toggleid="35" format="[$]" style="border: 2px solid green">[ON]</button>
                     </div>


### PR DESCRIPTION
Inspired by this bug report, which noted inconsistency in the Wow cube subtabs: https://discord.com/channels/677271830838640680/1420457591884218368/1421404440979836958

This PR consists of new css variables/classes specifically for the wow cube family of colors, refactor of some html to use the new variables, and some changes to gives wow cubes Subtabs more consistent styling.  This especially effected Hypercubes, which  used `red` and `rgb(255 0 76)` (`#ff004c`) interchangeably at different points, and Wow Cubes, which used `gold` (`#ffd700`) when the png themself were `#ffdd00`.

### Top Bar
Before
<img width="840" height="34" alt="image" src="https://github.com/user-attachments/assets/68e92bec-35ef-4f52-953d-803aa66c1c23" />
After
<img width="862" height="34" alt="image" src="https://github.com/user-attachments/assets/5ea568d9-7feb-4399-b760-9503c2670235" />

### Wow Cube Subtab
Before
<img width="1104" height="637" alt="image" src="https://github.com/user-attachments/assets/344fbdb2-b263-4bc8-a958-6a8f7b41a650" />
After
<img width="1069" height="638" alt="image" src="https://github.com/user-attachments/assets/a2993bbf-71c5-4cac-a224-37961b00566a" />

### Wow Tesseract Subtab
Before
<img width="1137" height="630" alt="image" src="https://github.com/user-attachments/assets/2249ce73-1fff-4e90-97eb-f8d229a96d89" />
After
<img width="1180" height="627" alt="image" src="https://github.com/user-attachments/assets/51ca9687-7260-407e-b2b7-0a4142da415b" />

### Wow Hypercube Subtab
Before
<img width="1138" height="647" alt="image" src="https://github.com/user-attachments/assets/a7bda5aa-cc7f-48e9-988c-352686157c00" />
After
<img width="1154" height="633" alt="image" src="https://github.com/user-attachments/assets/75f5de5f-b44c-4cf2-963c-1fddf12c525f" />

### Wow Platonic Subtab
Before
<img width="1148" height="605" alt="image" src="https://github.com/user-attachments/assets/133a679f-419f-492d-9ebb-6e8a049db4a3" />
After
<img width="1229" height="628" alt="image" src="https://github.com/user-attachments/assets/4b6412e7-9316-4817-8457-978915fb4932" />

### Wow Hept Subtab
NOTE this may look a bit off in both pictures, as my save file doesn't actually have these unlocked, so I had to css edit in browser to get the page to display.
Before:
<img width="1282" height="646" alt="image" src="https://github.com/user-attachments/assets/e2117ad5-1008-488e-9056-a99188cc7815" />
After
<img width="1263" height="668" alt="image" src="https://github.com/user-attachments/assets/e102afe6-15aa-4a9f-afa3-b7e8cbac995b" />

### Other changes
Before (gold and red)
<img width="121" height="37" alt="image" src="https://github.com/user-attachments/assets/14ea97b4-71e0-4004-a841-2a7a20f38b82" />
After (wowcube-gold and wowhypercube-red)
<img width="118" height="29" alt="image" src="https://github.com/user-attachments/assets/ae76f648-2840-4cf8-a806-eb94315dc22b" />
Before (the border)
<img width="164" height="32" alt="image" src="https://github.com/user-attachments/assets/2cce0827-481a-4f62-86e5-7c57587f4f15" />
After (Same color, just using css variable now)
<img width="170" height="34" alt="image" src="https://github.com/user-attachments/assets/73da162b-3f18-4677-9f5b-597d690c6d8d" />


