### PR TITLE
Visual nitpick: align selected campaign with other campaign images

### DIFF
--- a/src/Campaign.ts
+++ b/src/Campaign.ts
@@ -1510,12 +1510,14 @@ export const campaignIconHTMLUpdate = (key: CampaignKeys) => {
 
   icon.classList.remove('green-background', 'purple-background')
   icon.style.setProperty('border', 'none')
+  icon.style.removeProperty('margin')
   const completions = player.campaigns.getCampaign(key).c10Completions
   const limit = campaignDatas[key].limit
 
   if (key === player.campaigns.current) {
     icon.classList.add('purple-background')
     icon.style.setProperty('border', '1px solid turquoise')
+    icon.style.setProperty('margin', '-1px')
   } else if (completions === limit) {
     icon.classList.add('green-background')
   }


### PR DESCRIPTION
Reported here: https://discord.com/channels/677271830838640680/1420456264147669105/1422228155816738967

Before
<img width="218" height="118" alt="image" src="https://github.com/user-attachments/assets/a4942b9b-3e05-4cc6-bc60-a972bb399404" />
After
<img width="266" height="54" alt="image" src="https://github.com/user-attachments/assets/8e026d5a-01bf-43f3-b4a4-00f9d35f9f5d" />
