### PR TITLE
Fix a bug for Cx14 when I opened less than 40000 Platonic Cubes at once

### DIFF
--- a/src/CubeExperimental.ts
+++ b/src/CubeExperimental.ts
@@ -365,6 +365,7 @@ export class WowPlatonicCubes extends Cube {
       const num = Math.random()
       if (toSpendModulo / 40000 >= num && toSpendModulo !== 0) {
         player.platonicBlessings[platonicRNGesus[i] as keyof Player['platonicBlessings']] += 1
+        if (player.cubeUpgrades[64] > 0) player.platonicBlessings[platonicRNGesus[i] as keyof Player['platonicBlessings']] += 1 // Doubled!
         toSpendModulo -= 1
       }
     }
@@ -384,6 +385,9 @@ export class WowPlatonicCubes extends Cube {
       for (const key in player.platonicBlessings) {
         if (platonicBlessings[key as keyof typeof platonicBlessings].pdf(num)) {
           player.platonicBlessings[key as keyof Player['platonicBlessings']] += 1
+          if (platonicBlessings[key as keyof typeof platonicBlessings].weight === 1 && player.cubeUpgrades[64] > 0) {
+            player.platonicBlessings[key as keyof Player['platonicBlessings']] += 1 // Doubled!
+          }
         }
       }
     }


### PR DESCRIPTION
Fix a bug for Cx14 when I opened less than 40000 Platonic Cubes at once
When I opened less than 40000 Platonic Cubes at once with Cx14, cube upgrade Cx14 does not apply for statue calculations. This PR will fix the bug.
To reproduce the bug: start a new singularity with Cx14 unlocked. Don't open any Platonic Cubes before Cx14 bought. After Cx14 bought, open 39999 Platonic Cubes at once.