### PR TITLE
Fix Negative Blueberries

### DIFF
--- a/src/Octeracts.ts
+++ b/src/Octeracts.ts
@@ -953,7 +953,7 @@ export const octeractUpgrades: {
     effectDescription: (n: number) => i18next.t('octeract.data.octeractBlueberries.effect', { n: format(n) }),
     name: () => i18next.t('octeract.data.octeractBlueberries.name'),
     description: () => i18next.t('octeract.data.octeractBlueberries.description'),
-    qualityOfLife: false
+    qualityOfLife: true
   },
   octeractInfiniteShopUpgrades: {
     level: 0,


### PR DESCRIPTION
Fix 'Unspent blueberries can become negative in Exalts 5 or 8 due to the Octeract upgrade giving Blueberries not being marked as QoL.' bug.