### PR TITLE
fix scientific notation

### DIFF
--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2292,23 +2292,23 @@ export const format = (
       return `E${format(power, 3)}`
     }
     accuracy = power === 2 && accuracy > 2 ? 2 : accuracy
+
+    const safeFloor = (f: number) => Math.floor(f + 1e-7)
+
     if (power >= 6 || power < 0) {
       accuracy = accuracy < 2 ? 2 : accuracy
       // Makes the power group 3 with commas
       const mantissaLook = (
-        Math.floor(mantissa * Math.pow(10, accuracy)) / Math.pow(10, accuracy)
+        safeFloor(mantissa * Math.pow(10, accuracy)) / Math.pow(10, accuracy)
       ).toLocaleString(undefined, locOpts)
       const powerLook = padEvery(power.toString())
       // returns format (1.23e456,789)
       return `${mantissaLook}e${powerLook}`
     }
     mantissa = mantissa * Math.pow(10, power)
-    if (mantissa - Math.floor(mantissa) > 0.9999999) {
-      mantissa = Math.ceil(mantissa)
-    }
 
     return (
-      Math.floor(mantissa * Math.pow(10, accuracy)) / Math.pow(10, accuracy)
+      safeFloor(mantissa * Math.pow(10, accuracy)) / Math.pow(10, accuracy)
     ).toLocaleString(undefined, {
       minimumFractionDigits: accuracy,
       maximumFractionDigits: accuracy


### PR DESCRIPTION
Fix last digit of scientific notation.

### Before

<img width="256" height="146" alt="image" src="https://github.com/user-attachments/assets/39597699-d6a9-4bd3-9e17-5411b3eef437" />
<img width="618" height="26" alt="image" src="https://github.com/user-attachments/assets/1d47c7cf-9f16-4f76-a3eb-272347b03a4b" />

### After

<img width="356" height="138" alt="image" src="https://github.com/user-attachments/assets/68a5c689-8a52-4e9b-b4a8-c85d7b252462" />
<img width="612" height="30" alt="image" src="https://github.com/user-attachments/assets/4401d214-ce57-484a-b5c0-6f01e87f6371" />
