### PR TITLE
Fix negative salvage perk to reduce negative salvage instead of increasing it

### DIFF
--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -3142,7 +3142,7 @@ export const negativeSalvageStatMultiplier: NumberStatLineCategory = {
     },
     {
       i18n: 'SingularityPerk',
-      stat: () => negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
+      stat: () => -negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
     },
     {
       i18n: 'AchievementTalisman',


### PR DESCRIPTION
The Singularity negative salvage perk is intended to reduce negative salvage, as described by the in-game text.

Currently, `negativeSalvageStatMultiplier` returns a positive value for the `SingularityPerk` modifier:

```ts
stat: () => negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
```

Since this stat category uses additive multipliers, the positive value increases the magnitude of negative salvage instead of reducing it.

This change returns the value as a negative modifier:

```ts
stat: () => -negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
```

This makes the perk behavior consistent with its description and reduces negative salvage as intended.
