### PR TITLE
Format fix

### DIFF
--- a/src/Achievements.ts
+++ b/src/Achievements.ts
@@ -3756,7 +3756,7 @@ const createGroupedAchievementDescription = (group: AchievementGroups) => {
             currTier + 1
           } • ${
             i18next.t(`achievements.achievementRewards.${index}.${rewardGroup}`, {
-              val: format(rewardFunction(), 2, false)
+              val: format(rewardFunction(), 3, false)
             })
           }</span><br>`
         }
@@ -3847,7 +3847,7 @@ const generateUngroupedDescription = (name: UngroupedAchievementNames) => {
       } else if (typeof rewardValue === 'number') {
         extraText += `<span style="color:${hasAch ? 'green' : 'maroon'}">${
           i18next.t(`achievements.achievementRewards.${index}.${rewardType}`, {
-            val: format(rewardFunction(), 2, false)
+            val: format(rewardFunction(), 3, false)
           })
         }</span><br>`
       }

--- a/src/BlueberryUpgrades.ts
+++ b/src/BlueberryUpgrades.ts
@@ -424,7 +424,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const quarks = getAmbrosiaUpgradeEffects('ambrosiaQuarks2', 'quarks')
       return i18next.t('ambrosia.data.ambrosiaQuarks2.effect', {
-        amount: format(100 * (quarks - 1), 0, true)
+        amount: format(100 * (quarks - 1), 2, true)
       })
     },
     extraLevelCalc: () => getRedAmbrosiaUpgradeEffects('freeLevelsRow4', 'freeLevels'),
@@ -520,7 +520,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const quarks = getAmbrosiaUpgradeEffects('ambrosiaQuarks3', 'quarks')
       return i18next.t('ambrosia.data.ambrosiaQuarks3.effect', {
-        amount: format(100 * (quarks - 1), 0, true)
+        amount: format(100 * (quarks - 1), 2, true)
       })
     },
     extraLevelCalc: () => getRedAmbrosiaUpgradeEffects('freeLevelsRow5', 'freeLevels'),
@@ -635,7 +635,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const blueberryGeneration = getAmbrosiaUpgradeEffects('ambrosiaPatreon', 'blueberryGeneration')
       return i18next.t('ambrosia.data.ambrosiaPatreon.effect', {
-        amount: format(100 * (blueberryGeneration - 1), 0, true)
+        amount: format(100 * (blueberryGeneration - 1), 2, true)
       })
     },
     extraLevelCalc: () => 0,
@@ -662,7 +662,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const obtainiumMult = getAmbrosiaUpgradeEffects('ambrosiaObtainium1', 'obtainiumMult')
       return i18next.t('ambrosia.data.ambrosiaObtainium1.effect', {
-        amount: format(obtainiumMult / 10, 1, true)
+        amount: format((obtainiumMult - 1) * 100, 1, true)
       })
     },
     extraLevelCalc: () => 0,
@@ -689,7 +689,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const offeringMult = getAmbrosiaUpgradeEffects('ambrosiaOffering1', 'offeringMult')
       return i18next.t('ambrosia.data.ambrosiaOffering1.effect', {
-        amount: format(offeringMult / 10, 1, true)
+        amount: format((offeringMult - 1) * 100, 1, true)
       })
     },
     extraLevelCalc: () => 0,
@@ -718,7 +718,7 @@ export const ambrosiaUpgrades: {
     effectsDescription: function() {
       const hyperflux = getAmbrosiaUpgradeEffects('ambrosiaHyperflux', 'hyperFlux')
       return i18next.t('ambrosia.data.ambrosiaHyperflux.effect', {
-        amount: format(100 * (hyperflux - 1))
+        amount: format(100 * (hyperflux - 1), 2, true)
       })
     },
     extraLevelCalc: () => 0,

--- a/src/Features/Ants/AntUpgrades/data/data.ts
+++ b/src/Features/Ants/AntUpgrades/data/data.ts
@@ -94,7 +94,7 @@ export const antUpgradeData: { [K in AntUpgrades]: AntUpgradeData<K> } = {
     },
     effectDescription: () => {
       const taxReduction = getAntUpgradeEffect(AntUpgrades.Taxes).taxReduction
-      return i18next.t('ants.upgrades.taxes.effect', { x: formatAsPercentIncrease(taxReduction, 4) })
+      return i18next.t('ants.upgrades.taxes.effect', { x: formatAsPercentIncrease(2 - taxReduction, 4) })
     },
     lockedAutoDescription: () => i18next.t('ants.upgrades.taxes.lockedAutomation')
   },

--- a/src/Features/Ants/Automation/sacrifice.ts
+++ b/src/Features/Ants/Automation/sacrifice.ts
@@ -15,8 +15,8 @@ export const autoSacrificeData: Record<AutoSacrificeModes, AutoSacrificeModeData
     modeName: () => i18next.t('ants.autoSacrifice.inGameTimer.name'),
     infoText: () =>
       i18next.t('ants.autoSacrifice.inGameTimer.info', {
-        curr: format(player.antSacrificeTimer, 2, true),
-        req: format(player.ants.toggles.autoSacrificeThreshold, 0, true)
+        curr: format(player.antSacrificeTimer, 2, true, false),
+        req: format(player.ants.toggles.autoSacrificeThreshold, 2, true)
       }),
     modeHTMLcolor: 'var(--lightseagreen-text-color)'
   },
@@ -27,15 +27,15 @@ export const autoSacrificeData: Record<AutoSacrificeModes, AutoSacrificeModeData
     modeName: () => i18next.t('ants.autoSacrifice.realLifeTimer.name'),
     infoText: () =>
       i18next.t('ants.autoSacrifice.realLifeTimer.info', {
-        curr: format(player.antSacrificeTimerReal, 2, true),
-        req: format(player.ants.toggles.autoSacrificeThreshold, 0, true)
+        curr: format(player.antSacrificeTimerReal, 2, true, false),
+        req: format(player.ants.toggles.autoSacrificeThreshold, 2, true)
       }),
     modeHTMLcolor: 'lightgray'
   },
   [AutoSacrificeModes.ImmortalELOGain]: {
     sacrificeCheck: () => {
       const immortalELOToGain = antSacrificeRewards().immortalELO
-      return immortalELOToGain >= player.ants.toggles.autoSacrificeThreshold // Todo: Replace with an actual criterion in Ants
+      return immortalELOToGain >= Math.floor(player.ants.toggles.autoSacrificeThreshold) // Todo: Replace with an actual criterion in Ants
     },
     modeName: () => i18next.t('ants.autoSacrifice.immortalELOGain.name'),
     infoText: () =>

--- a/src/Features/Ants/HTML/modals/mastery-modal.ts
+++ b/src/Features/Ants/HTML/modals/mastery-modal.ts
@@ -52,7 +52,7 @@ export const antMasteryHTML = (ant: AntProducers): string => {
     }</span>`
     effectHTML += `<br><span>${
       i18next.t(`ants.mastery.${ant}.notMaxedSelfPer`, {
-        x: format(1 + selfPowerBase, 3, true),
+        x: format(1 + selfPowerBase, 3),
         y: format(1 + selfPowerBaseNextLevel, 3, true)
       })
     }</span>`
@@ -66,15 +66,15 @@ export const antMasteryHTML = (ant: AntProducers): string => {
     const reqELO = antMasteryData[ant].totalELORequirements[level]
     const reqELOHTML = `<span>${
       i18next.t('ants.mastery.eloRequirement', {
-        x: format(reqELO, 0, true),
-        y: format(player.ants.rebornELO, 0, true)
+        x: format(reqELO),
+        y: format(player.ants.rebornELO)
       })
     }</span>`
 
     const reqParticleCost = antMasteryData[ant].particleCosts[level]
     const reqParticleCostHTML = `<span>${
       i18next.t('ants.mastery.particleCost', {
-        x: format(reqParticleCost, 0, true, undefined, undefined, true)
+        x: format(reqParticleCost)
       })
     }</span>`
 

--- a/src/Features/Ants/HTML/modals/producer-modal.ts
+++ b/src/Features/Ants/HTML/modals/producer-modal.ts
@@ -21,7 +21,7 @@ export const antProducerHTML = (ant: AntProducers) => {
   const producerCountHTML = `<span>${
     i18next.t('ants.producerCount', {
       x: format(player.ants.producers[ant].purchased, 0, true),
-      y: format(player.ants.producers[ant].generated, 2)
+      y: format(player.ants.producers[ant].generated, 2, false, false)
     })
   }</span>`
 
@@ -29,7 +29,7 @@ export const antProducerHTML = (ant: AntProducers) => {
   const antsToBeGenerated = calculateBaseAntsToBeGenerated(ant, antSpeedMult)
   const generationHTML = `<span>${
     i18next.t(`ants.producers.${ant}.generates`, {
-      x: format(antsToBeGenerated, 5, true)
+      x: format(antsToBeGenerated, 2, true, false)
     })
   }</span>`
 
@@ -38,8 +38,8 @@ export const antProducerHTML = (ant: AntProducers) => {
   if (player.ants.toggles.maxBuyProducers && maxBuy > player.ants.producers[ant].purchased) {
     const cost = getCostMaxAnts(ant)
     costHTML = i18next.t('ants.costMaxLevels', {
-      x: format(maxBuy - player.ants.producers[ant].purchased, 0, true),
-      y: format(cost, 2, true)
+      x: format(maxBuy - player.ants.producers[ant].purchased, 0, true, false),
+      y: format(cost, 2, true, false)
     })
   } else {
     const cost = getCostNextAnt(ant)

--- a/src/Features/Ants/HTML/modals/upgrade-modal.ts
+++ b/src/Features/Ants/HTML/modals/upgrade-modal.ts
@@ -53,8 +53,8 @@ export const antUpgradeHTML = (antUpgrade: AntUpgrades) => {
   if (player.ants.toggles.maxBuyUpgrades && maxBuy > player.ants.upgrades[antUpgrade]) {
     const cost = getCostMaxAntUpgrades(antUpgrade)
     costHTML = i18next.t('ants.costMaxLevels', {
-      x: format(maxBuy - player.ants.upgrades[antUpgrade], 0, true),
-      y: format(cost, 2, true)
+      x: format(maxBuy - player.ants.upgrades[antUpgrade], 0, true, false),
+      y: format(cost, 2, true, false)
     })
   } else {
     const cost = getCostNextAntUpgrade(antUpgrade)

--- a/src/Features/Ants/HTML/updates/sacrifice.ts
+++ b/src/Features/Ants/HTML/updates/sacrifice.ts
@@ -23,7 +23,7 @@ import { talismanItemRequiredELO } from '../../AntSacrifice/Rewards/TalismanCraf
 export const showLockedSacrifice = () => {
   const crumbs = player.ants.crumbsThisSacrifice
   DOMCacheGetOrSet('sacrificeLockedText').innerHTML = i18next.t('ants.altar.locked.crumbsMade', {
-    x: format(crumbs, 2, true, undefined, undefined, true)
+    x: format(crumbs, 2, true, false)
   })
 }
 
@@ -101,8 +101,8 @@ export const showSacrifice = () => {
     percentage: format((1 - calculateStageRebornSpeedMult()) * 100, 3, true)
   })
 
-  DOMCacheGetOrSet('antSacrificeOffering').textContent = `+${format(sacRewards.offerings)}`
-  DOMCacheGetOrSet('antSacrificeObtainium').textContent = `+${format(sacRewards.obtainium)}`
+  DOMCacheGetOrSet('antSacrificeOffering').textContent = `+${format(sacRewards.offerings, 0, false, false)}`
+  DOMCacheGetOrSet('antSacrificeObtainium').textContent = `+${format(sacRewards.obtainium, 0, false, false)}`
 
   DOMCacheGetOrSet('lotusStatus').innerHTML = i18next.t('pseudoCoins.lotus.status', {
     time: timeRemainingMinutes(getLotusTimeExpiresAt())
@@ -124,7 +124,7 @@ export const showSacrifice = () => {
 
       if (effectiveELO >= requirement) {
         // Unlocked: show reward amount, remove locked styling
-        element.textContent = i18next.t('ants.itemReward', { x: format(reward) })
+        element.textContent = i18next.t('ants.itemReward', { x: format(reward, 0, false, false) })
         parentElement?.classList.remove('antSacrificeRewardLocked')
         const img = parentElement?.querySelector('img')
         img?.classList.remove('antSacrificeRewardImageLocked')

--- a/src/Hepteracts.ts
+++ b/src/Hepteracts.ts
@@ -210,7 +210,7 @@ export const hepteracts: { [K in HepteractKeys]: HepteractData<K> } = {
     EFFECTSDESCRIPTION: (hept) => {
       const effects = hepteracts.abyss.EFFECTS(hept)
       return i18next.t('wowCubes.hepteractForge.descriptions.abyss.currentEffect', {
-        x: format(effects.salvage, 1, true)
+        x: format(effects.salvage, 2, true)
       })
     },
     DESCRIPTION: () => i18next.t('wowCubes.hepteractForge.descriptions.abyss.effect'),
@@ -239,7 +239,7 @@ export const hepteracts: { [K in HepteractKeys]: HepteractData<K> } = {
     EFFECTSDESCRIPTION: (hept) => {
       const effects = hepteracts.accelerator.EFFECTS(hept)
       return i18next.t('wowCubes.hepteractForge.descriptions.accelerator.currentEffect', {
-        x: format(effects.accelerators, 0, true),
+        x: format(effects.accelerators),
         y: formatAsPercentIncrease(effects.acceleratorMultiplier, 2)
       })
     },
@@ -297,7 +297,7 @@ export const hepteracts: { [K in HepteractKeys]: HepteractData<K> } = {
     EFFECTSDESCRIPTION: (hept) => {
       const effects = hepteracts.multiplier.EFFECTS(hept)
       return i18next.t('wowCubes.hepteractForge.descriptions.multiplier.currentEffect', {
-        x: format(effects.multiplier, 0, true),
+        x: format(effects.multiplier),
         y: formatAsPercentIncrease(effects.multiplierMultiplier, 2)
       })
     },
@@ -370,7 +370,7 @@ export const craftHepteracts = async (hept: HepteractKeys, max = false) => {
   const heptCap = getFinalHepteractCap(hept)
   if (heptCap - hepteracts[hept].BAL <= 0) {
     if (player.toggles[35]) {
-      return Alert(i18next.t('hepteracts.reachedCapacity', { x: format(heptCap, 0, true) }))
+      return Alert(i18next.t('hepteracts.reachedCapacity', { x: format(heptCap) }))
     }
   }
 
@@ -389,7 +389,7 @@ export const craftHepteracts = async (hept: HepteractKeys, max = false) => {
   // Prompt used here. Thank you Khafra for the already made code! -Platonic
   if (!max) {
     const craftingPrompt = await Prompt(i18next.t('hepteracts.craft', {
-      x: format(displayCraftableAmount, 0, true),
+      x: format(displayCraftableAmount),
       y: format(100 * displayCraftableAmount / heptCap, 2, true)
     }))
 
@@ -418,8 +418,8 @@ export const craftHepteracts = async (hept: HepteractKeys, max = false) => {
 
   if (max && player.toggles[35]) {
     const craftYesPlz = await Confirm(i18next.t('hepteracts.craftMax', {
-      x: format(preConfirmAmountToCraft, 0, true),
-      y: Math.floor(preConfirmAmountToCraft / heptCap * 10000) / 100
+      x: format(preConfirmAmountToCraft),
+      y: format(preConfirmAmountToCraft / heptCap * 100, 2, true)
     }))
 
     if (!craftYesPlz) {
@@ -468,7 +468,7 @@ export const craftHepteracts = async (hept: HepteractKeys, max = false) => {
   }
 
   if (player.toggles[35]) {
-    const craftText = i18next.t('hepteracts.craftedHepteracts', { x: format(amountToCraft, 0, true) })
+    const craftText = i18next.t('hepteracts.craftedHepteracts', { x: format(amountToCraft) })
 
     // I added a multiplier of 0.9999 for tolerance on floating point fuckery
     const lessText = (actualCraftableAmount < 0.9999 * requestedCraftAmount)
@@ -532,7 +532,7 @@ export const expandHepteracts = async (hept: HepteractKeys) => {
 
   if (player.toggles[35]) {
     return Alert(i18next.t('hepteracts.expandedInventory', {
-      x: format(heptCap * expandMultiplier, 0, true)
+      x: format(heptCap * expandMultiplier)
     }))
   }
 }
@@ -666,7 +666,7 @@ export const hepteractDescriptions = (hept: HepteractKeys) => {
   const multiplier = getHepteractCap(hept) / getFinalHepteractCap(hept)
   bonusCapacityText.innerHTML = (multiplier > 1)
     ? i18next.t('wowCubes.hepteractForge.multiplierText', {
-      multiplier: format(multiplier, 0, true)
+      multiplier: format(multiplier)
     })
     : ''
 
@@ -675,11 +675,11 @@ export const hepteractDescriptions = (hept: HepteractKeys) => {
 
   switch (hept) {
     case 'chronos':
-      oneCost = format(1e115 * craftCostMulti, 0, false)
+      oneCost = format(1e115 * craftCostMulti)
 
       break
     case 'hyperrealism':
-      oneCost = format(1e80 * craftCostMulti, 0, true)
+      oneCost = format(1e80 * craftCostMulti)
       break
     case 'quark':
       oneCost = '100'
@@ -708,12 +708,12 @@ export const hepteractDescriptions = (hept: HepteractKeys) => {
   currentEffectText.innerHTML = currentEffectRecord
 
   balanceText.textContent = i18next.t('wowCubes.hepteractForge.inventory', {
-    x: format(hepteracts[hept].BAL, 0, true),
-    y: format(getFinalHepteractCap(hept), 0, true)
+    x: format(hepteracts[hept].BAL),
+    y: format(getFinalHepteractCap(hept))
   })
   const record = typeof oneCost === 'string' ? { y: oneCost } : oneCost
   costText.textContent = i18next.t(`wowCubes.hepteractForge.descriptions.${hept}.oneCost`, {
-    x: format(hepteracts[hept].HEPTERACT_CONVERSION * craftCostMulti, 0, true),
+    x: format(hepteracts[hept].HEPTERACT_CONVERSION * craftCostMulti),
     ...record
   })
 
@@ -731,10 +731,10 @@ export const hepteractToOverfluxOrbDescription = () => {
   DOMCacheGetOrSet('hepteractCostText').style.display = 'block'
 
   DOMCacheGetOrSet('hepteractCurrentEffectText').textContent = i18next.t('hepteracts.orbEffect', {
-    x: format(100 * (-1 + calculateCubeQuarkMultiplier()), 2, true)
+    x: formatAsPercentIncrease(calculateCubeQuarkMultiplier(), 2)
   })
   DOMCacheGetOrSet('hepteractBalanceText').textContent = i18next.t('hepteracts.orbsPurchasedToday', {
-    x: format(player.overfluxOrbs, 0, true)
+    x: format(player.overfluxOrbs)
   })
   DOMCacheGetOrSet('hepteractEffectText').textContent = i18next.t('hepteracts.amalgamate')
   DOMCacheGetOrSet('hepteractCostText').textContent = i18next.t('hepteracts.cost250k')
@@ -750,14 +750,14 @@ export const tradeHepteractToOverfluxOrb = async (buyMax?: boolean) => {
 
   if (buyMax) {
     if (player.toggles[35]) {
-      const craftYesPlz = await Confirm(i18next.t('hepteracts.craftMaxOrbs', { x: format(maxBuy, 0, true) }))
+      const craftYesPlz = await Confirm(i18next.t('hepteracts.craftMaxOrbs', { x: format(maxBuy) }))
       if (!craftYesPlz) {
         return Alert(i18next.t('hepteracts.cancelled'))
       }
     }
     toUse = maxBuy
   } else {
-    const hepteractInput = await Prompt(i18next.t('hepteracts.hepteractInput', { x: format(maxBuy, 0, true) }))
+    const hepteractInput = await Prompt(i18next.t('hepteracts.hepteractInput', { x: format(maxBuy) }))
     if (hepteractInput === null) {
       if (player.toggles[35]) {
         return Alert(i18next.t('hepteracts.cancelled'))
@@ -791,10 +791,10 @@ export const tradeHepteractToOverfluxOrb = async (buyMax?: boolean) => {
     * buyAmount
   player.overfluxPowder += powderGain
 
-  const powderText = (powderGain > 0) ? i18next.t('hepteracts.gainedPowder', { x: format(powderGain, 2, true) }) : ''
+  const powderText = (powderGain > 0) ? i18next.t('hepteracts.gainedPowder', { x: format(powderGain, 2) }) : ''
   if (player.toggles[35]) {
     return Alert(i18next.t('hepteracts.purchasedOrbs', {
-      x: format(buyAmount, 0, true),
+      x: format(buyAmount),
       y: format(100 * (afterEffect - beforeEffect), 2, true),
       z: powderText
     }))
@@ -834,10 +834,10 @@ export const overfluxPowderDescription = () => {
   DOMCacheGetOrSet('hepteractUnlockedText').style.display = 'none'
   DOMCacheGetOrSet('hepteractCurrentEffectText').textContent = powderEffectText
   DOMCacheGetOrSet('hepteractBalanceText').textContent = i18next.t('hepteracts.powderLumps', {
-    x: format(player.overfluxPowder, 2, true)
+    x: format(player.overfluxPowder)
   })
   DOMCacheGetOrSet('hepteractEffectText').textContent = i18next.t('hepteracts.expiredOrbs', {
-    x: format(1 / calculatePowderConversion(), 1, true)
+    x: format(1 / calculatePowderConversion(), 3, true)
   })
   DOMCacheGetOrSet('hepteractCostText').style.display = 'none'
 

--- a/src/History.ts
+++ b/src/History.ts
@@ -143,9 +143,8 @@ const conditionalFormatPerSecond = (numOrStr: DecimalSource, data: ResetHistoryE
   }
 
   if (typeof numOrStr === 'number' && player.historyShowPerSecond && data.seconds !== 0) {
-    if (numOrStr === 0) { // work around format(0, 3) return 0 instead of 0.000, for consistency
-      return '0.000/s'
-    }
+    // A workaround is not needed anymore
+    // --
     // Use "long" display for smaller numbers, but once it exceeds 1000, use the "short" display.
     // This'll keep decimals intact until 1000 instead of 10 without creating unwieldy numbers between e6-e13.
     return `${format(numOrStr / data.seconds, 3, numOrStr < 1000)}/s`

--- a/src/ImportExport.ts
+++ b/src/ImportExport.ts
@@ -1078,7 +1078,7 @@ const dailyCodeFormatFreeLevelMessage = (
   const upgradeNiceName = upgradeKey in goldenQuarkUpgrades
     ? i18next.t(`singularity.data.${upgradeKey}.name`)
     : i18next.t(`octeract.data.${upgradeKey}.name`)
-  return `\n+${format(freeLevelAmount, 0, true)} extra levels of '${upgradeNiceName}'`
+  return `\n+${format(freeLevelAmount, 3, true)} extra levels of '${upgradeNiceName}'`
 }
 
 const dailyCodeReward = () => {

--- a/src/Octeracts.ts
+++ b/src/Octeracts.ts
@@ -1126,7 +1126,7 @@ export const upgradeOcteractToString = (upgradeKey: OcteractUpgrades): string =>
     : ''
 
   let freeLevelText = upgrade.freeLevel > 0
-    ? `<span style="color: orange"> [+${format(upgrade.freeLevel, 1, true)}${freeLevelMultText}]</span>`
+    ? `<span style="color: orange"> [+${format(upgrade.freeLevel, 3, true)}${freeLevelMultText}]</span>`
     : ''
 
   if (freeLevelsWithMult > upgrade.level) {
@@ -1138,7 +1138,7 @@ export const upgradeOcteractToString = (upgradeKey: OcteractUpgrades): string =>
   const effectiveLevelText = totalEffectiveLevels !== upgrade.level + upgrade.freeLevel
     ? `<br><b><span style="color: white">${
       i18next.t('general.effectiveLevel', {
-        level: format(totalEffectiveLevels, 2, true)
+        level: format(totalEffectiveLevels, 3, true)
       })
     }</span></b>`
     : ''
@@ -1169,14 +1169,14 @@ export const upgradeOcteractToString = (upgradeKey: OcteractUpgrades): string =>
     ? ''
     : `${
       i18next.t('octeract.toString.costNextLevel', {
-        amount: format(costNextLevel, 2, true, true, true)
+        amount: format(costNextLevel, 2)
       })
     } ${affordableInfo}`
 
   const investedOcteractsHTML = upgrade.octeractsInvested > 0
     ? `<br><span style="color: turquoise">${
       i18next.t('octeract.toString.spentOcteracts', {
-        spent: format(upgrade.octeractsInvested, 2, true, true, true)
+        spent: format(upgrade.octeractsInvested, 2)
       })
     }</span>`
     : ''

--- a/src/Platonic.ts
+++ b/src/Platonic.ts
@@ -381,8 +381,8 @@ export const createPlatonicDescription = (index: number) => {
   DOMCacheGetOrSet('platonicHepteractCost').textContent = i18next.t(
     'wowCubes.platonicUpgrades.descriptionBox.hepteractCost',
     {
-      a: format(hepteracts.abyss.BAL, 0, true),
-      b: format(Math.floor(platUpgradeBaseCosts[index].abyssals * priceMultiplier), 0, true)
+      a: format(hepteracts.abyss.BAL),
+      b: format(Math.floor(platUpgradeBaseCosts[index].abyssals * priceMultiplier))
     }
   )
 
@@ -484,8 +484,8 @@ export const platonicUpgradeModalHTML = (index: number, imageSrc?: string) => {
     },
     {
       text: i18next.t('wowCubes.platonicUpgrades.descriptionBox.hepteractCost', {
-        a: format(hepteracts.abyss.BAL, 0, true),
-        b: format(Math.floor(platUpgradeBaseCosts[index].abyssals * priceMultiplier), 0, true)
+        a: format(hepteracts.abyss.BAL),
+        b: format(Math.floor(platUpgradeBaseCosts[index].abyssals * priceMultiplier))
       }),
       affordable: resourceCheck.abyssals
     }

--- a/src/Plugins/NumberLocale.ts
+++ b/src/Plugins/NumberLocale.ts
@@ -1,12 +1,13 @@
-import type { Module } from 'i18next'
+import type { PostProcessorModule } from 'i18next'
 import { format } from '../Synergism'
 import Decimal from 'break_infinity.js'
 
 export default {
   type: 'postProcessor',
   name: 'NumberLocale',
-  process: (value: string): string => value.replace(
-    /num:\(\(([^e)]*(e?)[^e)]*)\)\)/g, //num:1e6 => 1e6; num:1e6L => 1,000,000; num:0.1% => 0.1%
+  process: (value: string): string => value.includes('num:') ? value.replace(
+    // Regex replacement is faster than doing it in a loop
+    /num:\(\(([^e)]*(e?)[^)]*)\)\)/g, //num:1e6000 => 1e6,000; num:1000000 => 1,000,000; num:0.1% => 0.1%
     (_, num, exp) => format(Decimal.fromString(num), 5, exp !== 'e', true)
-  )
-} as Module
+  ) : value
+} satisfies PostProcessorModule

--- a/src/Plugins/NumberLocale.ts
+++ b/src/Plugins/NumberLocale.ts
@@ -5,9 +5,17 @@ import Decimal from 'break_infinity.js'
 export default {
   type: 'postProcessor',
   name: 'NumberLocale',
-  process: (value: string): string => value.includes('num:') ? value.replace(
-    // Regex replacement is faster than doing it in a loop
-    /num:\(\(([^e)]*(e?)[^)]*)\)\)/g, //num:1e6000 => 1e6,000; num:1000000 => 1,000,000; num:0.1% => 0.1%
-    (_, num, exp) => format(Decimal.fromString(num), 5, exp !== 'e', true)
-  ) : value
+  process: (value: string): string => {
+    let result = ''
+    let start = 0, index = 0
+    while ((index = value.indexOf('num:((', start)) !== -1) {
+      const end = value.indexOf('))', index)
+      const num = value.slice(index + 6, end)
+      result += value.slice(start, index)
+      result += format(Decimal.fromString(num), 5, !num.includes('e'), true)
+      start = end + 2
+    }
+    result += value.slice(start)
+    return result
+  }
 } satisfies PostProcessorModule

--- a/src/Plugins/NumberLocale.ts
+++ b/src/Plugins/NumberLocale.ts
@@ -1,0 +1,12 @@
+import type { Module } from 'i18next'
+import { format } from '../Synergism'
+import Decimal from 'break_infinity.js'
+
+export default {
+  type: 'postProcessor',
+  name: 'NumberLocale',
+  process: (value: string): string => value.replace(
+    /num:\(\(([^e)]*(e?)[^e)]*)\)\)/g, //num:1e6 => 1e6; num:1e6L => 1,000,000; num:0.1% => 0.1%
+    (_, num, exp) => format(Decimal.fromString(num), 5, exp !== 'e', true)
+  )
+} as Module

--- a/src/Runes.ts
+++ b/src/Runes.ts
@@ -410,7 +410,7 @@ export const runes: { [K in RuneKeys]: RuneData<K, keyof RuneTypeMap[K]> } = {
         val: formatAsPercentIncrease(multiplicativeMultipliers, 2)
       })
       const taxReductionText = i18next.t('runes.duplication.taxReduction', {
-        val: format(100 * (1 - taxReduction), 3, true)
+        val: format(100 * (1 - taxReduction), 4, true)
       })
       return `${multiplierPowerBoostsText}<br>${multiplicativeMultipliersText}<br>${taxReductionText}`
     },
@@ -485,7 +485,7 @@ export const runes: { [K in RuneKeys]: RuneData<K, keyof RuneTypeMap[K]> } = {
       const costDelay = getRuneEffects('thrift', 'costDelay')
       const salvage = getRuneEffects('thrift', 'salvage')
       const taxReduction = getRuneEffects('thrift', 'taxReduction')
-      const costDelayText = i18next.t('runes.thrift.costDelay', { val: format(costDelay, 0, true) })
+      const costDelayText = i18next.t('runes.thrift.costDelay', { val: format(costDelay, 2, true) })
       const salvageText = i18next.t('runes.thrift.salvage', { val: format(salvage, 2, true) })
       const taxReductionText = i18next.t('runes.thrift.taxReduction', {
         val: format(100 * (1 - taxReduction), 3, true)

--- a/src/Statistics.ts
+++ b/src/Statistics.ts
@@ -169,12 +169,14 @@ interface StatLine<T> {
 interface NumberStatLineCategory {
   kind: 'number'
   type: StatLineTypes
+  acc?: number
   lines: StatLine<number>[]
 }
 
 interface DecimalStatLineCategory {
   kind: 'decimal'
   type: StatLineTypes
+  acc?: 0
   lines: StatLine<number | Decimal>[]
 }
 
@@ -924,61 +926,75 @@ export const allBaseOfferingStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 1 // Absolute Base
+      stat: () => 1, // Absolute Base,
+      acc: 0
     },
     {
       i18n: 'PseudoCoins',
       stat: () => PCoinUpgradeEffects.BASE_OFFERING_BUFF, // PseudoCoin Upgrade
       color: 'gold',
-      displayCriterion: () => true
+      displayCriterion: () => true,
+      acc: 0
     },
     {
       i18n: 'Prestige',
-      stat: () => player.prestigeCount > 0 ? 1 : 0 // Prestiged
+      stat: () => player.prestigeCount > 0 ? 1 : 0, // Prestiged
+      acc: 0
     },
     {
       i18n: 'Transcend',
-      stat: () => player.transcendCount > 0 ? 3 : 0 // Transcended
+      stat: () => player.transcendCount > 0 ? 3 : 0, // Transcended
+      acc: 0
     },
     {
       i18n: 'Reincarnate',
-      stat: () => player.reincarnationCount > 0 ? 5 : 0 // Reincarnated
+      stat: () => player.reincarnationCount > 0 ? 5 : 0, // Reincarnated
+      acc: 0
     },
     {
       i18n: 'Challenge1',
-      stat: () => (player.challengecompletions[2] > 0) ? 2 : 0 // Challenge 2x1
+      stat: () => (player.challengecompletions[2] > 0) ? 2 : 0, // Challenge 2x1
+      acc: 0
     },
     {
       i18n: 'ShopPotionBonus',
-      stat: () => calculateOfferingPotionBaseOfferings().amount // Potion Permanent Bonus
+      stat: () => calculateOfferingPotionBaseOfferings().amount, // Potion Permanent Bonus
+      acc: 0
     },
     {
       i18n: 'ReincarnationUpgrade2',
-      stat: () => (player.upgrades[62] > 0) ? Math.min(12, (1 / 50) * sumContents(player.challengecompletions)) : 0 // Reincarnation Upgrade 2
+      stat: () => (player.upgrades[62] > 0) ? Math.min(12, (1 / 50) * sumContents(player.challengecompletions)) : 0, // Reincarnation Upgrade 2
+      acc: 2
     },
     {
       i18n: 'Research1x24',
-      stat: () => 0.4 * player.researches[24] // Research 1x24
+      stat: () => 0.4 * player.researches[24], // Research 1x24
+      acc: 1
     },
     {
       i18n: 'Research1x25',
-      stat: () => 0.6 * player.researches[25] // Research 1x25
+      stat: () => 0.6 * player.researches[25], // Research 1x25
+      acc: 1
     },
     {
       i18n: 'Research4x20',
-      stat: () => (player.researches[95] > 0) ? 15 : 0 // Research 4x20
+      stat: () => (player.researches[95] > 0) ? 15 : 0, // Research 4x20,
+      acc: 0
     },
     {
       i18n: 'AmbrosiaBaseOffering1',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseOffering1', 'offering') // Ambrosia Base Offering 1
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseOffering1', 'offering'), // Ambrosia Base Offering 1
+      acc: 0
     },
     {
       i18n: 'AmbrosiaBaseOffering2',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseOffering2', 'offering') // Ambrosia Base Offering 2
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseOffering2', 'offering'), // Ambrosia Base Offering 2
+      acc: 0
     },
     {
       i18n: 'OfferingEX3',
-      stat: () => getShopUpgradeEffects('offeringEX3', 'baseOfferings') // Offering EX3 Shop Upgrade
+      stat: () => getShopUpgradeEffects('offeringEX3', 'baseOfferings'), // Offering EX3 Shop Upgrade
+      acc: 0
     }
   ]
 }
@@ -1456,13 +1472,11 @@ export const allQuarkStats: NumberStatLineCategory = {
     {
       i18n: 'GlobalSubscriber',
       stat: () => 1 + getGlobalBonus() / 100,
-      acc: 3,
       color: 'gold'
     },
     {
       i18n: 'AccountBonus',
       stat: () => 1 + getPersonalBonus() / 100,
-      acc: 3,
       color: 'gold'
     }
   ]
@@ -1474,41 +1488,50 @@ export const allBaseObtainiumStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 1 // Absolute base value
+      stat: () => 1, // Absolute base value
+      acc: 0
     },
     {
       i18n: 'PseudoCoins',
       stat: () => PCoinUpgradeEffects.BASE_OBTAINIUM_BUFF, // PseudoCoin Upgrade
       color: 'gold',
-      displayCriterion: () => true
+      displayCriterion: () => true,
+      acc: 0
     },
     {
       i18n: 'ShopPotionBonus',
-      stat: () => calculateObtainiumPotionBaseObtainium().amount // Potion Permanent Bonus
+      stat: () => calculateObtainiumPotionBaseObtainium().amount, // Potion Permanent Bonus
+      acc: 0
     },
     {
       i18n: 'Research3x13',
-      stat: () => (player.reincarnationcounter >= 2) ? player.researches[63] : 0 // Research 3x13
+      stat: () => (player.reincarnationcounter >= 2) ? player.researches[63] : 0, // Research 3x13
+      acc: 0
     },
     {
       i18n: 'Research3x14',
-      stat: () => (player.reincarnationcounter >= 5) ? 2 * player.researches[64] : 0 // Research 3x14
+      stat: () => (player.reincarnationcounter >= 5) ? 2 * player.researches[64] : 0, // Research 3x14
+      acc: 0
     },
     {
       i18n: 'FirstSingularity',
-      stat: () => (player.highestSingularityCount > 0) ? 3 : 0 // First Singularity Perk
+      stat: () => (player.highestSingularityCount > 0) ? 3 : 0, // First Singularity Perk
+      acc: 0
     },
     {
       i18n: 'SingularityCount',
-      stat: () => Math.floor(player.singularityCount / 10) // Singularity Count
+      stat: () => Math.floor(player.singularityCount / 10), // Singularity Count
+      acc: 1
     },
     {
       i18n: 'AmbrosiaBaseObtainium1',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseObtainium1', 'obtainium') // Ambrosia Base Obtainium 1
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseObtainium1', 'obtainium'), // Ambrosia Base Obtainium 1
+      acc: 0
     },
     {
       i18n: 'AmbrosiaBaseObtainium2',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseObtainium2', 'obtainium') // Ambrosia Base Obtainium 2
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaBaseObtainium2', 'obtainium'), // Ambrosia Base Obtainium 2
+      acc: 0
     }
   ]
 }
@@ -2138,13 +2161,11 @@ const allAscensionSpeedPowerStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'ExponentialScalingSlow',
-      stat: () => 1 - calculateAscensionSpeedExponentSpread(),
-      acc: 3
+      stat: () => 1 - calculateAscensionSpeedExponentSpread()
     },
     {
       i18n: 'ExponentialScalingFast',
-      stat: () => 1 + calculateAscensionSpeedExponentSpread(),
-      acc: 3
+      stat: () => 1 + calculateAscensionSpeedExponentSpread()
     }
   ]
 }
@@ -2175,8 +2196,7 @@ export const allAdditiveLuckMultStats: NumberStatLineCategory = {
     },
     {
       i18n: 'Cookie5',
-      stat: () => 0.001 * player.cubeUpgrades[77], // Cookie 5 (Cx27)
-      acc: 3
+      stat: () => 0.001 * player.cubeUpgrades[77] // Cookie 5 (Cx27)
     },
     {
       i18n: 'BlueberryUpgrade',
@@ -2205,7 +2225,8 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 100 // Base value of 100
+      stat: () => 100, // Base value of 100
+      acc: 0
     },
     {
       i18n: 'PseudoCoins',
@@ -2216,7 +2237,8 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
     {
       i18n: 'SynergismLevel',
       stat: () => getLevelReward('ambrosiaLuck'), // Synergism Level
-      color: 'green'
+      color: 'green',
+      acc: 0
     },
     {
       i18n: 'Campaign',
@@ -2224,23 +2246,28 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
     },
     {
       i18n: 'SingularityMilestones',
-      stat: () => calculateSingularityAmbrosiaLuckMilestoneBonus() // Ambrosia Luck Milestones
+      stat: () => calculateSingularityAmbrosiaLuckMilestoneBonus(), // Ambrosia Luck Milestones
+      acc: 0
     },
     {
       i18n: 'ShopUpgrade1',
-      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck1', 'ambrosiaLuck')
+      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck1', 'ambrosiaLuck'),
+      acc: 0
     },
     {
       i18n: 'ShopUpgrade2',
-      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck2', 'ambrosiaLuck')
+      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck2', 'ambrosiaLuck'),
+      acc: 0
     },
     {
       i18n: 'ShopUpgrade3',
-      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck3', 'ambrosiaLuck')
+      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck3', 'ambrosiaLuck'),
+      acc: 0
     },
     {
       i18n: 'ShopUpgrade4',
-      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck4', 'ambrosiaLuck')
+      stat: () => getShopUpgradeEffects('shopAmbrosiaLuck4', 'ambrosiaLuck'),
+      acc: 1
     },
     {
       i18n: 'Jack',
@@ -2248,23 +2275,28 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
     },
     {
       i18n: 'SingularityUpgrades',
-      stat: () => calculateAmbrosiaLuckSingularityUpgrade() // Ambrosia Luck from Singularity Upgrades (I-IV)
+      stat: () => calculateAmbrosiaLuckSingularityUpgrade(), // Ambrosia Luck from Singularity Upgrades (I-IV)
+      acc: 0
     },
     {
       i18n: 'OcteractUpgrades',
-      stat: () => calculateAmbrosiaLuckOcteractUpgrade() // Ambrosia Luck from Octeract Upgrades (I-IV)
+      stat: () => calculateAmbrosiaLuckOcteractUpgrade(), // Ambrosia Luck from Octeract Upgrades (I-IV)
+      acc: 0
     },
     {
       i18n: 'AmbrosiaLuck1',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck1', 'ambrosiaLuck') // Ambrosia Luck from Luck Module I
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck1', 'ambrosiaLuck'), // Ambrosia Luck from Luck Module I
+      acc: 0
     },
     {
       i18n: 'AmbrosiaLuck2',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck2', 'ambrosiaLuck') // Ambrosia Luck from Luck Module II
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck2', 'ambrosiaLuck'), // Ambrosia Luck from Luck Module II
+      acc: 0
     },
     {
       i18n: 'AmbrosiaLuck3',
-      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck3', 'ambrosiaLuck') // Ambrosia Luck from Luck Module III
+      stat: () => getAmbrosiaUpgradeEffects('ambrosiaLuck3', 'ambrosiaLuck'), // Ambrosia Luck from Luck Module III
+      acc: 0
     },
     {
       i18n: 'AmbrosiaCubeLuck1',
@@ -2276,36 +2308,44 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
     },
     {
       i18n: 'Singularity131',
-      stat: () => player.highestSingularityCount >= 131 ? 131 : 0 // Singularity Perk "One Hundred Thirty One!"
+      stat: () => player.highestSingularityCount >= 131 ? 131 : 0, // Singularity Perk "One Hundred Thirty One!"
+      acc: 0
     },
     {
       i18n: 'Singularity269',
-      stat: () => player.highestSingularityCount >= 269 ? 269 : 0 // Singularity Perk "Two Hundred Sixty Nine!"
+      stat: () => player.highestSingularityCount >= 269 ? 269 : 0, // Singularity Perk "Two Hundred Sixty Nine!"
+      acc: 0
     },
     {
       i18n: 'OcteractShop',
-      stat: () => getShopUpgradeEffects('shopOcteractAmbrosiaLuck', 'ambrosiaLuck') // Octeract -> Ambrosia Shop Upgrade
+      stat: () => getShopUpgradeEffects('shopOcteractAmbrosiaLuck', 'ambrosiaLuck'), // Octeract -> Ambrosia Shop Upgrade
+      acc: 0
     },
     {
       i18n: 'NoAmbrosiaUpgrades',
-      stat: () => getSingularityChallengeEffect('noAmbrosiaUpgrades', 'ambrosiaLuck') // No Ambrosia Challenge Reward
+      stat: () => getSingularityChallengeEffect('noAmbrosiaUpgrades', 'ambrosiaLuck'), // No Ambrosia Challenge Reward
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaUpgrade',
-      stat: () => getRedAmbrosiaUpgradeEffects('regularLuck', 'ambrosiaLuck') // Red Ambrosia Upgrade
+      stat: () => getRedAmbrosiaUpgradeEffects('regularLuck', 'ambrosiaLuck'), // Red Ambrosia Upgrade
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaUpgrade2',
-      stat: () => getRedAmbrosiaUpgradeEffects('regularLuck2', 'ambrosiaLuck') // Red Ambrosia Upgrade 2
+      stat: () => getRedAmbrosiaUpgradeEffects('regularLuck2', 'ambrosiaLuck'), // Red Ambrosia Upgrade 2
+      acc: 0
     },
     {
       i18n: 'Viscount',
       stat: () => getRedAmbrosiaUpgradeEffects('viscount', 'luckBonus'), // Viscount Red Ambrosia Upgrade
-      color: 'red'
+      color: 'red',
+      acc: 0
     },
     {
       i18n: 'Cookie5',
-      stat: () => 2 * player.cubeUpgrades[77] // Cookie 5 (Cx27)
+      stat: () => 2 * player.cubeUpgrades[77], // Cookie 5 (Cx27)
+      acc: 0
     },
     {
       i18n: 'RedBars',
@@ -2313,7 +2353,8 @@ export const allAmbrosiaLuckStats: NumberStatLineCategory = {
     },
     {
       i18n: 'AmbrosiaUltra',
-      stat: () => getShopUpgradeEffects('shopAmbrosiaUltra', 'ambrosiaLuck') // Ambrosia Ultra Shop Upgrade
+      stat: () => getShopUpgradeEffects('shopAmbrosiaUltra', 'ambrosiaLuck'), // Ambrosia Ultra Shop Upgrade
+      acc: 0
     },
     {
       i18n: 'HorseShoeRune',
@@ -2338,27 +2379,33 @@ export const allAmbrosiaBlueberryStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'E1x1Clear',
-      stat: () => +(player.singularityChallenges.noSingularityUpgrades.completions > 0) * 3 // E1x1 Clear!
+      stat: () => +(player.singularityChallenges.noSingularityUpgrades.completions > 0) * 3, // E1x1 Clear!
+      acc: 0
     },
     {
       i18n: 'SingBlueberries',
-      stat: () => getGQUpgradeEffect('blueberries', 'blueberries') // Singularity Blueberry Upgrade
+      stat: () => getGQUpgradeEffect('blueberries', 'blueberries'), // Singularity Blueberry Upgrade
+      acc: 0
     },
     {
       i18n: 'OcteractBlueberries',
-      stat: () => getOcteractUpgradeEffect('octeractBlueberries', 'blueberries') // Octeract Blueberry Upgrade
+      stat: () => getOcteractUpgradeEffect('octeractBlueberries', 'blueberries'), // Octeract Blueberry Upgrade
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaBlueberries',
-      stat: () => getRedAmbrosiaUpgradeEffects('blueberries', 'blueberries') // Red Ambrosia Blueberry Upgrade
+      stat: () => getRedAmbrosiaUpgradeEffects('blueberries', 'blueberries'), // Red Ambrosia Blueberry Upgrade
+      acc: 0
     },
     {
       i18n: 'ConglomerateBerries',
-      stat: () => calculateSingularityMilestoneBlueberries() // Singularity Milestones (Congealed Blueberries)
+      stat: () => calculateSingularityMilestoneBlueberries(), // Singularity Milestones (Congealed Blueberries)
+      acc: 0
     },
     {
       i18n: 'NoAmbrosiaUpgrades',
-      stat: () => getSingularityChallengeEffect('noAmbrosiaUpgrades', 'blueberries') // No Ambrosia Challenge Reward
+      stat: () => getSingularityChallengeEffect('noAmbrosiaUpgrades', 'blueberries'), // No Ambrosia Challenge Reward
+      acc: 0
     }
   ]
 }
@@ -2540,13 +2587,11 @@ export const allGoldenQuarkMultiplierStats: NumberStatLineCategory = {
     {
       i18n: 'GlobalSubscriber',
       stat: () => 1 + getGlobalBonus() / 100,
-      acc: 3,
       color: 'gold'
     },
     {
       i18n: 'AccountBonus',
       stat: () => 1 + getPersonalBonus() / 100,
-      acc: 3,
       color: 'gold'
     },
     {
@@ -2598,13 +2643,11 @@ export const allGoldenQuarkPurchaseCostStats: NumberStatLineCategory = {
     {
       i18n: 'GlobalSubscriber',
       stat: () => 1 / (1 + getGlobalBonus() / 100),
-      acc: 3,
       color: 'gold'
     },
     {
       i18n: 'AccountBonus',
       stat: () => 1 / (1 + getPersonalBonus() / 100),
-      acc: 3,
       color: 'gold'
     },
     {
@@ -2706,35 +2749,42 @@ export const allAddCodeTimerStats: NumberStatLineCategory = {
 export const allAddCodeCapacityStats: NumberStatLineCategory = {
   kind: 'number',
   type: StatLineTypes.Addition,
+  acc: 0,
   lines: [
     {
       i18n: 'Base',
-      stat: () => 24 // Base capacity (24 codes)
+      stat: () => 24, // Base capacity (24 codes)
+      acc: 0
     },
     {
       i18n: 'Calculator2',
       stat: () => getShopUpgradeEffects('calculator2', 'addCodeCapacity'), // PL-AT X (2 codes per level)
-      color: 'lime'
+      color: 'lime',
+      acc: 0
     },
     {
       i18n: 'Calculator4Max',
       stat: () => getShopUpgradeEffects('calculator4', 'addCodeCapacity'), // PL-AT δ Maxed (32 codes)
-      color: 'lime'
+      color: 'lime',
+      acc: 0
     },
     {
       i18n: 'Calculator5',
       stat: () => getShopUpgradeEffects('calculator5', 'addCodeCapacity'), // PL-AT Γ (1 code per 10 levels, +6 at max)
-      color: 'lime'
+      color: 'lime',
+      acc: 0
     },
     {
       i18n: 'Calculator6Max',
       stat: () => getShopUpgradeEffects('calculator6', 'addCodeCapacity'), // PL-AT _ Maxed (24 codes)
-      color: 'lime'
+      color: 'lime',
+      acc: 0
     },
     {
       i18n: 'Calculator7Max',
       stat: () => getShopUpgradeEffects('calculator7', 'addCodeCapacity'), // PL-AT ΩΩ Maxed (48 codes)
-      color: 'lime'
+      color: 'lime',
+      acc: 0
     }
   ]
 }
@@ -2742,16 +2792,19 @@ export const allAddCodeCapacityStats: NumberStatLineCategory = {
 export const allAddCodeCapacityMultiplierStats: NumberStatLineCategory = {
   kind: 'number',
   type: StatLineTypes.Multiplication,
+  acc: 0,
   lines: [
     {
       i18n: 'PseudoCoins',
       stat: () => PCoinUpgradeEffects.ADD_CODE_CAP_BUFF, // PseudoCoin Upgrade
       color: 'gold',
-      displayCriterion: () => true
+      displayCriterion: () => true,
+      acc: 0
     },
     {
       i18n: 'SingularityPerk',
-      stat: () => addCodeSingularityPerkBonus() // Singularity Perk bonus
+      stat: () => addCodeSingularityPerkBonus(), // Singularity Perk bonus
+      acc: 1
     }
   ]
 }
@@ -2762,31 +2815,38 @@ export const allLuckConversionStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 20 // Base value of 20.00
+      stat: () => 20, // Base value of 20.00
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaUpgrade1',
-      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement1', 'conversionImprovement') // Conversion Improvement I
+      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement1', 'conversionImprovement'), // Conversion Improvement I
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaUpgrade2',
-      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement2', 'conversionImprovement') // Conversion Improvement II
+      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement2', 'conversionImprovement'), // Conversion Improvement II
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaUpgrade3',
-      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement3', 'conversionImprovement') // Conversion Improvement III
+      stat: () => getRedAmbrosiaUpgradeEffects('conversionImprovement3', 'conversionImprovement'), // Conversion Improvement III
+      acc: 0
     },
     {
       i18n: 'ShopRedLuck1',
-      stat: () => getShopUpgradeEffects('shopRedLuck1', 'luckConversionRatio') // Shop Red Luck I
+      stat: () => getShopUpgradeEffects('shopRedLuck1', 'luckConversionRatio'), // Shop Red Luck I
+      acc: 2
     },
     {
       i18n: 'ShopRedLuck2',
-      stat: () => getShopUpgradeEffects('shopRedLuck2', 'luckConversionRatio') // Shop Red Luck II
+      stat: () => getShopUpgradeEffects('shopRedLuck2', 'luckConversionRatio'), // Shop Red Luck II
+      acc: 2
     },
     {
       i18n: 'ShopRedLuck3',
-      stat: () => getShopUpgradeEffects('shopRedLuck3', 'luckConversionRatio') // Shop Red Luck III
+      stat: () => getShopUpgradeEffects('shopRedLuck3', 'luckConversionRatio'), // Shop Red Luck III
+      acc: 2
     },
     {
       i18n: 'HorseShoeRune',
@@ -2893,6 +2953,7 @@ export const allRedAmbrosiaGenerationSpeedStats: NumberStatLineCategory = {
 export const allShopTablets: NumberStatLineCategory = {
   kind: 'number',
   type: StatLineTypes.Addition,
+  acc: 0,
   lines: [
     {
       i18n: 'Red',
@@ -3044,19 +3105,23 @@ export const positiveSalvageStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'AchievementBonus',
-      stat: () => +getAchievementReward('salvage')
+      stat: () => +getAchievementReward('salvage'),
+      acc: 0
     },
     {
       i18n: 'SynergismLevel',
-      stat: () => getLevelReward('salvage')
+      stat: () => getLevelReward('salvage'),
+      acc: 0
     },
     {
       i18n: 'SynergismLevelMilestone',
-      stat: () => getLevelMilestone('salvageChallengeBuff')
+      stat: () => getLevelMilestone('salvageChallengeBuff'),
+      acc: 0
     },
     {
       i18n: 'UpgradeBonus',
-      stat: () => 7 * player.upgrades[61] // Upgrade 61
+      stat: () => 7 * player.upgrades[61], // Upgrade 61
+      acc: 0
     },
     {
       i18n: 'RuneBonus',
@@ -3069,7 +3134,8 @@ export const positiveSalvageStats: NumberStatLineCategory = {
           + 0.3 * CalcECC('reincarnation', player.challengecompletions[7])
           + 0.4 * CalcECC('reincarnation', player.challengecompletions[8])
           + 0.5 * CalcECC('reincarnation', player.challengecompletions[9])
-      }
+      },
+      acc: 2
     },
     {
       i18n: 'AntUpgrade',
@@ -3081,15 +3147,18 @@ export const positiveSalvageStats: NumberStatLineCategory = {
     },
     {
       i18n: 'CubeUpgrade2',
-      stat: () => 3 * player.cubeUpgrades[2] // Cube Upgrade 2
+      stat: () => 3 * player.cubeUpgrades[2], // Cube Upgrade 2
+      acc: 0
     },
     {
       i18n: 'AbyssHepteract',
-      stat: () => getHepteractEffects('abyss').salvage // Abyss Hepteract
+      stat: () => getHepteractEffects('abyss').salvage, // Abyss Hepteract
+      acc: 1
     },
     {
       i18n: 'SingularityPerk',
-      stat: () => Math.min(50, 5 * player.highestSingularityCount)
+      stat: () => Math.min(50, 5 * player.highestSingularityCount),
+      acc: 0
     },
     {
       i18n: 'InfiniteAscentRune',
@@ -3097,7 +3166,8 @@ export const positiveSalvageStats: NumberStatLineCategory = {
     },
     {
       i18n: 'RedAmbrosiaYinYang',
-      stat: () => getRedAmbrosiaUpgradeEffects('salvageYinYang', 'positiveSalvage') // Red Ambrosia Upgrade: Yin Yang
+      stat: () => getRedAmbrosiaUpgradeEffects('salvageYinYang', 'positiveSalvage'), // Red Ambrosia Upgrade: Yin Yang
+      acc: 0
     }
   ]
 }
@@ -3108,11 +3178,13 @@ export const positiveSalvageStatMultiplier: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'BaseMultiplier',
-      stat: () => 1
+      stat: () => 1,
+      acc: 0
     },
     {
       i18n: 'SingularityPerk',
-      stat: () => posSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
+      stat: () => posSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100,
+      acc: 2
     },
     {
       i18n: 'AchievementTalisman',
@@ -3128,16 +3200,19 @@ export const negativeSalvageStats: NumberStatLineCategory = {
     {
       i18n: 'DroughtCorruption',
       stat: () => player.corruptions.used.corruptionEffects('drought'),
-      color: 'red'
+      color: 'red',
+      acc: 0
     },
     {
       i18n: 'SingularityDebuff',
       stat: () => calculateSingularityDebuff('Salvage'), // Singularity Debuff
-      color: 'red'
+      color: 'red',
+      acc: 0
     },
     {
       i18n: 'RedAmbrosiaYinYang',
-      stat: () => getRedAmbrosiaUpgradeEffects('salvageYinYang', 'negativeSalvage') // Red Ambrosia Upgrade: Yin Yang
+      stat: () => getRedAmbrosiaUpgradeEffects('salvageYinYang', 'negativeSalvage'), // Red Ambrosia Upgrade: Yin Yang
+      acc: 0
     }
   ]
 }
@@ -3148,11 +3223,13 @@ export const negativeSalvageStatMultiplier: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'BaseMultiplier',
-      stat: () => 1
+      stat: () => 1,
+      acc: 0
     },
     {
       i18n: 'SingularityPerk',
-      stat: () => -negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100
+      stat: () => -negSalvagePerkSings.filter((x) => x <= player.highestSingularityCount).length / 100,
+      acc: 2
     },
     {
       i18n: 'AchievementTalisman',
@@ -3237,8 +3314,7 @@ export const antSpeedStats: DecimalStatLineCategory = {
     },
     {
       i18n: 'SuperiorIntellect',
-      stat: () => getRuneEffects('superiorIntellect', 'antSpeed'), // Superior Intellect Rune
-      acc: 3
+      stat: () => getRuneEffects('superiorIntellect', 'antSpeed') // Superior Intellect Rune
     },
     {
       i18n: 'RuneBlessingBonus',
@@ -3385,7 +3461,8 @@ export const additiveAntELOMultStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 1
+      stat: () => 1,
+      acc: 0
     },
     {
       i18n: 'AchievementMultiplier',
@@ -3393,23 +3470,28 @@ export const additiveAntELOMultStats: NumberStatLineCategory = {
     },
     {
       i18n: 'AntQueens',
-      stat: () => player.ants.producers[AntProducers.Queens].purchased > 0 ? 0.01 : 0
+      stat: () => player.ants.producers[AntProducers.Queens].purchased > 0 ? 0.01 : 0,
+      acc: 2
     },
     {
       i18n: 'AntLordRoyals',
-      stat: () => player.ants.producers[AntProducers.LordRoyals].purchased > 0 ? 0.01 : 0
+      stat: () => player.ants.producers[AntProducers.LordRoyals].purchased > 0 ? 0.01 : 0,
+      acc: 2
     },
     {
       i18n: 'AntAlmighties',
-      stat: () => player.ants.producers[AntProducers.Almighties].purchased > 0 ? 0.01 : 0
+      stat: () => player.ants.producers[AntProducers.Almighties].purchased > 0 ? 0.01 : 0,
+      acc: 2
     },
     {
       i18n: 'AntDisciples',
-      stat: () => player.ants.producers[AntProducers.Disciples].purchased > 0 ? 0.02 : 0
+      stat: () => player.ants.producers[AntProducers.Disciples].purchased > 0 ? 0.02 : 0,
+      acc: 2
     },
     {
       i18n: 'AntHolySpirit',
-      stat: () => player.ants.producers[AntProducers.HolySpirit].purchased > 0 ? 0.02 : 0
+      stat: () => player.ants.producers[AntProducers.HolySpirit].purchased > 0 ? 0.02 : 0,
+      acc: 2
     },
     {
       i18n: 'PlatonicUpgrade12',
@@ -3418,8 +3500,7 @@ export const additiveAntELOMultStats: NumberStatLineCategory = {
     {
       i18n: 'SingularityDebuff',
       stat: () => calculateSingularityDebuff('Ant ELO'),
-      color: 'red',
-      acc: 3
+      color: 'red'
     },
     {
       i18n: 'SingularityPerk',
@@ -3451,8 +3532,7 @@ export const rebornELOCreationSpeedMultStats: NumberStatLineCategory = {
   lines: [
     {
       i18n: 'Base',
-      stat: () => 0.01,
-      acc: 3
+      stat: () => 0.01
     },
     {
       i18n: 'EffectiveELO',
@@ -3898,7 +3978,7 @@ const loadStatistics = (
         statLine.style.border = '1px solid red'
       }
       numberDisplayedLines++
-      const accuracy = line.acc ?? 2
+      const accuracy = line.acc ?? 3
       statNumber.textContent = format(num, accuracy, true)
     } else {
       statLine.style.display = 'none'
@@ -3931,7 +4011,8 @@ const loadStatistics = (
   if (hasSummative) {
     const statTotalNumber = DOMCacheGetOrSet(statNumTotalHTMLName)
     const total = calcTotalFunc()
-    statTotalNumber.textContent = format(total, 3, true)
+    const accuracy = statsObj.acc ?? 3
+    statTotalNumber.textContent = format(total, accuracy, true)
   }
 }
 

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2162,9 +2162,7 @@ export const format = (
     | undefined,
   accuracy = 0,
   long = false,
-  truncate = true,
-  fractional = false,
-  longExponent = false
+  truncate = true
 ): string => {
   if (input == null) {
     return '0 [null]'
@@ -2176,26 +2174,28 @@ export const format = (
 
   const inputType = typeof input
 
-  let power!: number
-  let mantissa!: number
-  if (inputType === 'number') {
-    if ((input as number) < 0) {
-      return `-${format(-(input as number), accuracy, long, truncate, fractional)}`
-    }
-    if (input === 0) {
-      return '0'
-    }
-
-    // Gets power and mantissa if input is of type number and isn't 0
-    power = Math.floor(Math.log10(input as number))
-    mantissa = (input as number) / Math.pow(10, power)
-  } else if (input instanceof Decimal) {
+  let power: number = 0
+  let mantissa: number = 0
+  if (input instanceof Decimal) {
     if (input.lessThan(0)) {
-      return `-${format(input.negated(), accuracy, long, truncate, fractional)}`
+      return `-${format(input.negated(), accuracy, long, truncate)}`
     }
     // Gets power and mantissa if input is of type decimal
     power = input.e
     mantissa = input.mantissa
+  } else if (input !== 0) {
+    if (input < 0) {
+      return `-${format(-input, accuracy, long, truncate)}`
+    }
+    // Gets power and mantissa if input is of type number and isn't 0
+    power = Math.floor(Math.log10(input))
+    mantissa = input / Math.pow(10, power)
+  }
+
+  if (power < -100) {
+    input = 0
+    mantissa = 0
+    power = 0
   }
 
   const threshold = 10 - Math.pow(10, long ? -13 : -7)
@@ -2205,6 +2205,7 @@ export const format = (
     ;++power
   }
 
+  // Rounds up if the number experiences a rounding error
   if (mantissa < 1 && mantissa > 0.9999999) {
     mantissa = 1
   }
@@ -2223,60 +2224,7 @@ export const format = (
 
   // Make the above code apply to Default notation as well
   // Also make the block below apply to Pure Scientific and Pure Engineering notations || rus9384
-  // This case handles numbers less than 1e-3 and greater than -1e-3
-  if (inputType === 'number' && Math.abs(input as number) < (!fractional ? 1e-3 : 1e-15)) { // Arbitrary number, don't change 1e-3
-    return input.toLocaleString(undefined, {
-      minimumSignificantDigits: 1 + accuracy,
-      maximumSignificantDigits: 1 + accuracy,
-      roundingMode: 'trunc' as const,
-      notation: player.notation === 'Pure Engineering' ? 'engineering' as const : 'scientific' as const
-    }).toLowerCase() // We want 'e' to be in lower case
-  }
-
-  // If the power is negative, then we will want to address that separately.
-  if (power < 0 && inputType === 'number' && fractional) {
-    if (power <= -15) {
-      return `${format(mantissa, accuracy, long)} / ${
-        Math.pow(
-          10,
-          -power - 15
-        )
-      }Qa`
-    }
-    if (power <= -12) {
-      return `${format(mantissa, accuracy, long)} / ${
-        Math.pow(
-          10,
-          -power - 12
-        )
-      }T`
-    }
-    if (power <= -9) {
-      return `${format(mantissa, accuracy, long)} / ${
-        Math.pow(
-          10,
-          -power - 9
-        )
-      }B`
-    }
-    if (power <= -6) {
-      return `${format(mantissa, accuracy, long)} / ${
-        Math.pow(
-          10,
-          -power - 6
-        )
-      }M`
-    }
-    if (power <= -3) {
-      return `${format(mantissa, accuracy, long)} / ${
-        Math.pow(
-          10,
-          -power - 3
-        )
-      }K`
-    }
-    return `${format(mantissa, accuracy, long)} / ${Math.pow(10, -power)}`
-  } else if (power < 6 || (long && power < 12)) {
+  if (power < 6 || (long && power < 12)) {
     // If the power is less than 6 or format long and less than 12 use standard formatting (1,234,567)
     // Gets the standard representation of the number, safe as power is guaranteed to be > -12 and < 12
     let standard: number
@@ -2285,30 +2233,36 @@ export const format = (
     } else {
       standard = mantissa * Math.pow(10, power)
     }
-    let standardString: string
-    let digits = accuracy
-    if (power >= 2 + (long ? 1 : 0)) {
-      digits = 0
-    } else if (power === 2 && accuracy > 2) {
-      digits = 2
-    }
 
+    let roundingMode: 'trunc' | 'expand' = 'trunc'
     // Rounds up if the number experiences a rounding error
-    if (standard - Math.floor(standard) > 0.9999999) {
-      standard = Math.ceil(standard)
+    const delta = Math.pow(10, (power < -3 ? power : 0) - accuracy)
+    if (delta - standard % delta < 1e-7) {
+      roundingMode = 'expand'
     }
 
-    standardString = standard.toLocaleString(undefined, {
-      minimumFractionDigits: digits,
+    // This case handles non-zero numbers less than 1e-3 and greater than -1e-3
+    if (power < -3) {
+      return standard.toLocaleString(undefined, {
+        minimumSignificantDigits: 1 + (truncate ? 0 : accuracy),
+        maximumSignificantDigits: 1 + accuracy,
+        roundingMode: roundingMode,
+        notation: player.notation === 'Pure Engineering' ? 'engineering' as const : 'scientific' as const
+      }).toLowerCase() // We want 'e' to be in lower case
+    }
+
+    const digits = Math.max(0, Math.min(accuracy, accuracy + (long ? 2 : 1) - power))
+    return standard.toLocaleString(undefined, {
+      minimumFractionDigits: truncate ? 0 : digits,
       maximumFractionDigits: digits,
-      roundingMode: 'trunc' as const
+      roundingMode: roundingMode,
+      signDisplay: 'never' // A fix for '-0'
     })
-    return standardString
   }
 
   accuracy = Math.max(3, accuracy + 1)
   // Only apply Engineering notation if we can see all digits of the exponent || rus9384
-  if (player.notation === 'Pure Engineering' && (power < 1e6 || longExponent && power < 1e12)) {
+  if (player.notation === 'Pure Engineering' && power < 1e6) {
     const powerOver = (power % 3 + 3) % 3
     power -= powerOver
     mantissa *= Math.pow(10, powerOver)
@@ -2316,28 +2270,26 @@ export const format = (
 
   // Number.toLocaleString opts for 'accuracy' decimal places
   const locOpts: Intl.NumberFormatOptions = {
-    minimumSignificantDigits: accuracy,
+    minimumSignificantDigits: truncate ? 1 : accuracy,
     maximumSignificantDigits: accuracy,
     roundingMode: 'trunc' as const
   }
 
-  if (power < 1e6 || (longExponent && power < 1e12)) {
+  if (power < 1e6) {
     // If the power is less than 1e6 then apply standard scientific/engineering notation
     // Makes mantissa be rounded down to 'accuracy' decimal places
     const mantissaLook = mantissa.toLocaleString(undefined, locOpts)
-    const powerLook = format(power, 0, longExponent)
+    const powerLook = format(power, 0)
     return `${mantissaLook}e${powerLook}` // Returns format (1.23e456,789)
   } else if (power >= 1e6) {
     // The only difference between Default and Pure Scientific is how it handles numbers larger than 1e1M / E1e6 || rus9384
     if (player.notation === 'Pure Scientific') {
-      return `E${format(power, 3)}`
+      return `E${format(power, 3, false, truncate)}`
     }
 
     // if the power is greater than 1e6 apply notation scientific notation
     // Makes mantissa be rounded down to 2 decimal places
-    const mantissaLook = testing && truncate
-      ? ''
-      : mantissa.toLocaleString(undefined, locOpts)
+    const mantissaLook = mantissa.toLocaleString(undefined, locOpts)
 
     // Drops the power down to 4 digits total but never greater than 1000 in increments that equate to notations, (1234000 -> 1.234) ( 12340000 -> 12.34) (123400000 -> 123.4) (1234000000 -> 1.234)
     const powerDigits = Math.ceil(Math.log10(power))
@@ -2388,8 +2340,8 @@ export const formatTimeShort = (
   )
 }
 
-export const formatAsPercentIncrease = (n: number, accuracy = 2) => {
-  return `${format((n - 1) * 100, accuracy, true)}%`
+export const formatAsPercentIncrease = (n: number, accuracy = 2, truncate = true) : string => {
+  return `${format((n - 1) * 100, accuracy, true, truncate)}%`
 }
 
 export const formatDecimalAsPercentIncrease = (n: Decimal, accuracy = 2) => {

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2151,7 +2151,7 @@ const formatters: Record<string, Intl.NumberFormat> = {}
 const getFormatter = (
   digits: number,
   truncate = true,
-  notation?: 'standard' | 'scientific' | 'engineering'
+  notation?: 'scientific' | 'engineering'
 ) => {
   let keyString = `${digits}${truncate ? '' : '+'}${notation?.charAt(0) ?? ''}`
   if (formatters[keyString] == undefined) {
@@ -2278,7 +2278,6 @@ export const format = (
     return getFormatter(digits, truncate).format(standard)
   }
 
-  accuracy = Math.max(2, accuracy)
   // Only apply Engineering notation if we can see all digits of the exponent || rus9384
   if (player.notation === 'Pure Engineering' && power < 1e6) {
     const powerOver = (power % 3 + 3) % 3
@@ -2287,7 +2286,7 @@ export const format = (
   }
 
   // Formatter for 'accuracy' decimal places
-  const formatter = getFormatter(accuracy, truncate, 'standard')
+  const formatter = getFormatter(Math.max(2, accuracy), truncate)
 
   if (power < 1e6) {
     // If the power is less than 1e6 then apply standard scientific/engineering notation

--- a/src/Synergism.ts
+++ b/src/Synergism.ts
@@ -2146,13 +2146,36 @@ const FormatList = [
   "Ce",
 ];
 
+// Caching different formatters to not initialize them every time
+const formatters: Record<string, Intl.NumberFormat> = {}
+const getFormatter = (
+  digits: number,
+  truncate = true,
+  notation?: 'standard' | 'scientific' | 'engineering'
+) => {
+  let keyString = `${digits}${truncate ? '' : '+'}${notation?.charAt(0) ?? ''}`
+  if (formatters[keyString] == undefined) {
+    formatters[keyString] = new Intl.NumberFormat(undefined, {
+      minimumFractionDigits: notation === undefined ? (truncate ? 0 : digits) : undefined,
+      maximumFractionDigits: notation === undefined ? digits : undefined,
+      minimumSignificantDigits: notation !== undefined ? 1 + (truncate ? 0 : digits) : undefined,
+      maximumSignificantDigits: notation !== undefined ? 1 + digits : undefined,
+      notation: notation,
+      roundingMode: 'trunc',
+      signDisplay: 'never' // A fix for '-0'
+    })
+  }
+  return formatters[keyString]
+}
+
 /**
  * This function displays the numbers such as 1,234 or 1.00e1234 or 1.00e1.234M.
  * @param input value to format
  * @param accuracy
- * how many decimal points that are to be displayed (Values <10 if !long, <1000 if long).
+ * how many decimal points that are to be displayed (Past 100 if !long, or 1000 if long starts reducing accuracy).
  * only works up to 305 (308 - 3), however it only worked up to ~14 due to rounding errors regardless
- * @param long dictates whether or not a given number displays as scientific at 1,000,000. This auto defaults to short if input >= 1e7
+ * @param long dictates whether or not a given number displays as scientific at 1,000,000. This auto defaults to short if input >= 1e6
+ * @param truncate truncates insignificant digits if true
  */
 export const format = (
   input:
@@ -2174,22 +2197,26 @@ export const format = (
 
   const inputType = typeof input
 
-  let power: number = 0
-  let mantissa: number = 0
-  if (input instanceof Decimal) {
+  let power = 0
+  let mantissa = 0
+  if (inputType === 'number') {
+    const num = input as number
+    if (num < 0) {
+      return `-${format(-num, accuracy, long, truncate)}`
+    } else if (num > 0) {
+      // Gets power and mantissa if input is of type number and isn't 0
+      power = Math.floor(Math.log10(num))
+      mantissa = num / Math.pow(10, power)
+    }
+  } else if (input instanceof Decimal) {
     if (input.lessThan(0)) {
       return `-${format(input.negated(), accuracy, long, truncate)}`
     }
     // Gets power and mantissa if input is of type decimal
     power = input.e
     mantissa = input.mantissa
-  } else if (input !== 0) {
-    if (input < 0) {
-      return `-${format(-input, accuracy, long, truncate)}`
-    }
-    // Gets power and mantissa if input is of type number and isn't 0
-    power = Math.floor(Math.log10(input))
-    mantissa = input / Math.pow(10, power)
+  } else { // Neither number nor Decimal
+    return '0 [und.]'
   }
 
   if (power < -100) {
@@ -2234,33 +2261,24 @@ export const format = (
       standard = mantissa * Math.pow(10, power)
     }
 
-    let roundingMode: 'trunc' | 'expand' = 'trunc'
     // Rounds up if the number experiences a rounding error
-    const delta = Math.pow(10, (power < -3 ? power : 0) - accuracy)
+    const powerDelta = (power < -3 ? power : 0)
+    const delta = Math.pow(10, powerDelta - accuracy)
     if (delta - standard % delta < 1e-7) {
-      roundingMode = 'expand'
+      standard += 1e-7 * Math.pow(10, powerDelta)
     }
 
     // This case handles non-zero numbers less than 1e-3 and greater than -1e-3
     if (power < -3) {
-      return standard.toLocaleString(undefined, {
-        minimumSignificantDigits: 1 + (truncate ? 0 : accuracy),
-        maximumSignificantDigits: 1 + accuracy,
-        roundingMode: roundingMode,
-        notation: player.notation === 'Pure Engineering' ? 'engineering' as const : 'scientific' as const
-      }).toLowerCase() // We want 'e' to be in lower case
+      const notation = player.notation === 'Pure Engineering' ? 'engineering' as const : 'scientific' as const
+      return getFormatter(accuracy, truncate, notation).format(standard).toLowerCase() // We want 'e' to be in lower case
     }
 
     const digits = Math.max(0, Math.min(accuracy, accuracy + (long ? 2 : 1) - power))
-    return standard.toLocaleString(undefined, {
-      minimumFractionDigits: truncate ? 0 : digits,
-      maximumFractionDigits: digits,
-      roundingMode: roundingMode,
-      signDisplay: 'never' // A fix for '-0'
-    })
+    return getFormatter(digits, truncate).format(standard)
   }
 
-  accuracy = Math.max(3, accuracy + 1)
+  accuracy = Math.max(2, accuracy)
   // Only apply Engineering notation if we can see all digits of the exponent || rus9384
   if (player.notation === 'Pure Engineering' && power < 1e6) {
     const powerOver = (power % 3 + 3) % 3
@@ -2268,17 +2286,13 @@ export const format = (
     mantissa *= Math.pow(10, powerOver)
   }
 
-  // Number.toLocaleString opts for 'accuracy' decimal places
-  const locOpts: Intl.NumberFormatOptions = {
-    minimumSignificantDigits: truncate ? 1 : accuracy,
-    maximumSignificantDigits: accuracy,
-    roundingMode: 'trunc' as const
-  }
+  // Formatter for 'accuracy' decimal places
+  const formatter = getFormatter(accuracy, truncate, 'standard')
 
   if (power < 1e6) {
     // If the power is less than 1e6 then apply standard scientific/engineering notation
     // Makes mantissa be rounded down to 'accuracy' decimal places
-    const mantissaLook = mantissa.toLocaleString(undefined, locOpts)
+    const mantissaLook = formatter.format(mantissa)
     const powerLook = format(power, 0)
     return `${mantissaLook}e${powerLook}` // Returns format (1.23e456,789)
   } else if (power >= 1e6) {
@@ -2289,7 +2303,7 @@ export const format = (
 
     // if the power is greater than 1e6 apply notation scientific notation
     // Makes mantissa be rounded down to 2 decimal places
-    const mantissaLook = mantissa.toLocaleString(undefined, locOpts)
+    const mantissaLook = formatter.format(mantissa)
 
     // Drops the power down to 4 digits total but never greater than 1000 in increments that equate to notations, (1234000 -> 1.234) ( 12340000 -> 12.34) (123400000 -> 123.4) (1234000000 -> 1.234)
     const powerDigits = Math.ceil(Math.log10(power))
@@ -2300,10 +2314,7 @@ export const format = (
       powerFront = 1
     }
 
-    const powerLookF = powerLook.toLocaleString(undefined, {
-      minimumFractionDigits: 4 - powerFront,
-      maximumFractionDigits: 4 - powerFront
-    })
+    const powerLookF = getFormatter(4 - powerFront, false).format(powerLook)
     const powerLodge = Math.floor(Math.log10(power) / 3)
     // Return relevant notations alongside the "look" power based on what the power actually is
     if (typeof FormatList[powerLodge] === 'string') {

--- a/src/Talismans.ts
+++ b/src/Talismans.ts
@@ -293,7 +293,6 @@ const mortuusInscriptValues = [1, 1.05, 1.1, 1.15, 1.2, 1.3, 1.4, 1.5, 1.65, 1.8
 const plasticInscriptValues = [1, 1.005, 1.01, 1.015, 1.02, 1.025, 1.03, 1.04, 1.045, 1.05, 1.0666]
 const wowSquareInscriptValues = [1, 1.025, 1.05, 1.075, 1.1, 1.125, 1.15, 1.2, 1.225, 1.25, 1.30]
 const achievementEffectInscriptValues = [0, 0.001, 0.002, 0.003, 0.004, 0.006, 0.008, .01, .015, .02, .03]
-const achievementDescInscriptValues = [1, 1, 1, 1, 1, 1, 1, 1.01, 1.015, 1.02, 1.03]
 const cookieGrandmaInscriptValues = [0, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09, 0.10]
 const horseShoeInscriptValues = [0, 0.001, 0.002, 0.003, 0.004, 0.005, 0.007, 0.01, 0.012, 0.015, 0.02]
 
@@ -360,7 +359,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.chronos.inscription', {
-        val: formatAsPercentIncrease(chronosInscriptValues[n] ?? 1, 0)
+        val: formatAsPercentIncrease(chronosInscriptValues[n] ?? 1, 1)
       })
     },
     signatureDesc: (n) => {
@@ -405,7 +404,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.midas.inscription', {
-        val: formatAsPercentIncrease(midasInscriptValues[n] ?? 1, 0)
+        val: formatAsPercentIncrease(midasInscriptValues[n] ?? 1, 1)
       })
     },
     signatureDesc: (n) => {
@@ -497,7 +496,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.polymath.inscription', {
-        val: formatAsPercentIncrease(polymathInscriptValues[n] ?? 1, 0)
+        val: formatAsPercentIncrease(polymathInscriptValues[n] ?? 1, 1)
       })
     },
     signatureDesc: (n) => {
@@ -542,7 +541,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.mortuus.inscription', {
-        val: formatAsPercentIncrease(mortuusInscriptValues[n] ?? 1, 0)
+        val: formatAsPercentIncrease(mortuusInscriptValues[n] ?? 1, 1)
       })
     },
     signatureDesc: (n) => {
@@ -626,7 +625,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.wowSquare.inscription', {
-        val: formatAsPercentIncrease(wowSquareInscriptValues[n] ?? 1, 0)
+        val: formatAsPercentIncrease(wowSquareInscriptValues[n] ?? 1, 1)
       })
     },
     signatureDesc: () => i18next.t('runes.talismans.wowSquare.signature'),
@@ -666,7 +665,7 @@ export const talismans: { [K in TalismanKeys]: TalismanData<K> } = {
     },
     inscriptionDesc: (n) => {
       return i18next.t('runes.talismans.achievement.inscription', {
-        val: formatAsPercentIncrease(achievementDescInscriptValues[n] ?? 1, 1)
+        val: formatAsPercentIncrease(1 + (achievementEffectInscriptValues[n] ?? 1), 1)
       })
     },
     signatureDesc: (n) => {
@@ -2360,7 +2359,7 @@ export const updateTalismanInventory = () => {
   for (const item of talismanCraftItems) {
     const spanId = talismanResourceData[item].spanId
     const playerKey = talismanResourceData[item].playerKey
-    DOMCacheGetOrSet(spanId).textContent = format(player[playerKey] as Decimal, 0, true)
+    DOMCacheGetOrSet(spanId).textContent = format(player[playerKey] as Decimal)
   }
 }
 

--- a/src/UpdateHTML.ts
+++ b/src/UpdateHTML.ts
@@ -689,7 +689,7 @@ export const htmlInserts = () => {
   // ALWAYS Update these, for they are the most important resources
   for (let i = 0; i < htmlInsertPlayerRequirements.length; i++) {
     const value = player[htmlInsertPlayerRequirements[i]]
-    const text = format(value instanceof Decimal ? value : value.valueOf())
+    const text = format(value instanceof Decimal ? value : value.valueOf(), 0, false, false)
     const dom = DOMCacheGetOrSet(htmlInsertDomRequirements[i])
     if (dom.textContent !== text) {
       dom.textContent = text
@@ -1070,7 +1070,7 @@ export const updateChallengeLevel = (k: number) => {
   const maxChallenges = getMaxChallenges(k)
 
   if (k === 15) {
-    el.textContent = format(player.challenge15Exponent, 0, false)
+    el.textContent = format(player.challenge15Exponent, 0, false, false)
   } else {
     el.textContent = `${player.challengecompletions[k]}/${maxChallenges}`
   }
@@ -1126,14 +1126,14 @@ const updateAscensionStats = () => {
   const addedAsteriskOneMind = getGQUpgradeEffect('oneMind', 'unlocked')
   const fillers: Record<string, string> = {
     ascLen: formatTimeShort(player.ascStatToggles[6] ? player.ascensionCounter : player.ascensionCounterReal, 0),
-    ascCubes: format(ascensionRewards.wowCubes * (player.ascStatToggles[1] ? 1 : 1 / t), 2),
-    ascTess: format(ascensionRewards.wowTesseracts * (player.ascStatToggles[2] ? 1 : 1 / t), 2),
-    ascHyper: format(ascensionRewards.wowHypercubes * (player.ascStatToggles[3] ? 1 : 1 / t), 2),
-    ascPlatonic: format(ascensionRewards.wowPlatonicCubes * (player.ascStatToggles[4] ? 1 : 1 / t), 2),
-    ascHepteract: format(ascensionRewards.wowHepteracts * (player.ascStatToggles[5] ? 1 : 1 / t), 2),
+    ascCubes: format(ascensionRewards.wowCubes * (player.ascStatToggles[1] ? 1 : 1 / t), 2, false, false),
+    ascTess: format(ascensionRewards.wowTesseracts * (player.ascStatToggles[2] ? 1 : 1 / t), 2, false, false),
+    ascHyper: format(ascensionRewards.wowHypercubes * (player.ascStatToggles[3] ? 1 : 1 / t), 2, false, false),
+    ascPlatonic: format(ascensionRewards.wowPlatonicCubes * (player.ascStatToggles[4] ? 1 : 1 / t), 2, false, false),
+    ascHepteract: format(ascensionRewards.wowHepteracts * (player.ascStatToggles[5] ? 1 : 1 / t), 2, false, false),
     ascC10: format(player.challengecompletions[10]),
-    ascTimeAccel: `${format(calculateGlobalSpeedMult(), 3)}x${addedAsteriskHalfMind ? '*' : ''}`,
-    ascAscensionTimeAccel: `${format(calculateAscensionSpeedMult(), 3)}x${addedAsteriskOneMind ? '*' : ''}`,
+    ascTimeAccel: `${format(calculateGlobalSpeedMult(), 3, false, false)}x${addedAsteriskHalfMind ? '*' : ''}`,
+    ascAscensionTimeAccel: `${format(calculateAscensionSpeedMult(), 3, false, false)}x${addedAsteriskOneMind ? '*' : ''}`,
     ascSingularityCount: format(player.singularityCount),
     ascSingLen: formatTimeShort(player.singularityCounter),
     ascSingChallengeLen: formatTimeShort(player.singChallengeTimer)

--- a/src/UpdateVisuals.ts
+++ b/src/UpdateVisuals.ts
@@ -225,16 +225,17 @@ export const visualUpdateBuildings = () => {
     }
 
     DOMCacheGetOrSet('coinInformation').innerHTML = i18next.t('buildings.coinInformation', {
-      coins: format(player.coins, 2, false),
+      coins: format(player.coins, 0, false, false),
       coinsPerSecond: format(
         Decimal.min(
           G.producePerSecond.dividedBy(G.taxdivisor),
           Decimal.pow(10, G.maxexponent - Decimal.log(G.taxdivisorcheck, 10))
         ),
-        0,
+        2,
+        false,
         false
       ),
-      totalGenerated: format(player.coinsTotal, 0, true)
+      totalGenerated: format(player.coinsTotal, 0, false, false)
     })
 
     let vanityIndex = 0
@@ -256,15 +257,15 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`buildtext${2 * i - 1}`).textContent = i18next.t(
         `buildings.names.${coinNames[i - 1]}`,
         {
-          amount: format(player[`${ith}OwnedCoin` as const], 0, true),
-          gain: format(player[`${ith}GeneratedCoin` as const])
+          amount: format(player[`${ith}OwnedCoin` as const], 0, true, false),
+          gain: format(player[`${ith}GeneratedCoin` as const], 0, false, false)
         }
       )
 
       getBuildingCostElement(`buycoin${i}`).textContent = i18next.t(
         'buildings.costCoins',
         {
-          coins: format(player[`${ith}CostCoin` as const])
+          coins: format(player[`${ith}CostCoin` as const], 0, false, false)
         }
       )
 
@@ -276,8 +277,8 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`buildtext${2 * i}`).textContent = i18next.t(
         'buildings.coinsPerSecond',
         {
-          coins: format(place.dividedBy(G.taxdivisor).times(40), 0),
-          percent: format(percentage, 2)
+          coins: format(place.dividedBy(G.taxdivisor).times(40), 2, false, false),
+          percent: format(percentage, 2, true, false)
         }
       )
     }
@@ -285,40 +286,40 @@ export const visualUpdateBuildings = () => {
     DOMCacheGetOrSet('buildtext11').textContent = i18next.t(
       'buildings.names.accelerators',
       {
-        amount: format(player.acceleratorBought, 0, true),
-        gain: format(G.freeAccelerator, 0, true)
+        amount: format(player.acceleratorBought, 0, true, false),
+        gain: format(G.freeAccelerator, 0, true, false)
       }
     )
 
     DOMCacheGetOrSet('buildtext12').textContent = i18next.t(
       'buildings.acceleratorPower',
       {
-        power: format((G.acceleratorPower - 1) * 100, 2),
-        mult: format(G.acceleratorEffect, 2)
+        power: format((G.acceleratorPower - 1) * 100, 2, false, false),
+        mult: format(G.acceleratorEffect, 2, false, false)
       }
     )
 
     DOMCacheGetOrSet('buildtext13').textContent = i18next.t(
       'buildings.names.multipliers',
       {
-        amount: format(player.multiplierBought, 0, true),
-        gain: format(G.freeMultiplier, 0, true)
+        amount: format(player.multiplierBought, 0, true, false),
+        gain: format(G.freeMultiplier, 0, true, false)
       }
     )
 
     DOMCacheGetOrSet('buildtext14').textContent = i18next.t(
       'buildings.multiplierPower',
       {
-        power: format(G.multiplierPower, 2),
-        mult: format(G.multiplierEffect, 2)
+        power: format(G.multiplierPower, 2, false, false),
+        mult: format(G.multiplierEffect, 2, false, false)
       }
     )
 
     DOMCacheGetOrSet('buildtext15').textContent = i18next.t(
       'buildings.names.acceleratorBoost',
       {
-        amount: format(player.acceleratorBoostBought, 0, true),
-        gain: format(G.freeAcceleratorBoost, 0, false)
+        amount: format(player.acceleratorBoostBought, 0, true, false),
+        gain: format(G.freeAcceleratorBoost, 0, false, false)
       }
     )
 
@@ -327,7 +328,9 @@ export const visualUpdateBuildings = () => {
       {
         amount: format(
           100 * (0.01 * G.tuSevenMulti * (1 + CalcECC('transcend', player.challengecompletions[2]) / 20)),
-          2
+          2,
+          false,
+          false
         ),
         accelsPerBoost: format(
           5
@@ -336,7 +339,8 @@ export const visualUpdateBuildings = () => {
             + 3 * player.researches[20]
             + (calculateAcceleratorCubeBlessing()),
           0,
-          true
+          true,
+          false
         )
       }
     )
@@ -344,19 +348,19 @@ export const visualUpdateBuildings = () => {
     getBuildingCostElement('buyaccelerator').textContent = i18next.t(
       'buildings.costCoins',
       {
-        coins: format(player.acceleratorCost)
+        coins: format(player.acceleratorCost, 0, false, false)
       }
     )
     getBuildingCostElement('buymultiplier').textContent = i18next.t(
       'buildings.costCoins',
       {
-        coins: format(player.multiplierCost)
+        coins: format(player.multiplierCost, 0, false, false)
       }
     )
     getBuildingCostElement('buyacceleratorboost').textContent = i18next.t(
       'buildings.costDiamonds',
       {
-        diamonds: format(player.acceleratorBoostCost)
+        diamonds: format(player.acceleratorBoostCost, 0, false, false)
       }
     )
 
@@ -365,14 +369,17 @@ export const visualUpdateBuildings = () => {
     if (player.reincarnationCount > 0.5) {
       warning = i18next.t('buildings.taxWarning', {
         gain: format(
-          Decimal.pow(10, G.maxexponent - Decimal.log(G.taxdivisorcheck, 10))
+          Decimal.pow(10, G.maxexponent - Decimal.log(G.taxdivisorcheck, 10)),
+          2,
+          false,
+          false
         )
       })
     }
     DOMCacheGetOrSet('taxinfo').textContent = i18next.t(
       'buildings.excessiveWealth',
       {
-        div: format(G.taxdivisor, 2),
+        div: format(G.taxdivisor, 2, false, false),
         warning
       }
     )
@@ -382,9 +389,9 @@ export const visualUpdateBuildings = () => {
     DOMCacheGetOrSet('prestigeshardinfo').innerHTML = i18next.t(
       'buildings.crystalMult',
       {
-        crystals: format(player.prestigeShards, 2),
-        gain: format(crystalCoinMult, 2),
-        exponent: format(crystalExponent, 2, true)
+        crystals: format(player.prestigeShards, 2, false, false),
+        gain: format(crystalCoinMult, 2, false, false),
+        exponent: format(crystalExponent, 2, true, false)
       }
     )
 
@@ -395,22 +402,22 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`prestigetext${2 * i - 1}`).textContent = i18next.t(
         `buildings.names.${diamondNames[i - 1]}`,
         {
-          amount: format(player[`${ith}OwnedDiamonds` as const], 0, true),
-          gain: format(player[`${ith}GeneratedDiamonds` as const], 2)
+          amount: format(player[`${ith}OwnedDiamonds` as const], 0, true, false),
+          gain: format(player[`${ith}GeneratedDiamonds` as const], 2, false, false)
         }
       )
 
       DOMCacheGetOrSet(`prestigetext${2 * i}`).textContent = i18next.t(
         `buildings.per.${diamondPerSecNames[i - 1]}`,
         {
-          amount: format(place.times(40), 2)
+          amount: format(place.times(40), 2, false, false)
         }
       )
 
       getBuildingCostElement(`buydiamond${i}`).textContent = i18next.t(
         'buildings.costDiamonds',
         {
-          diamonds: format(player[`${ith}CostDiamonds` as const], 2)
+          diamonds: format(player[`${ith}CostDiamonds` as const], 2, false, false)
         }
       )
     }
@@ -424,10 +431,11 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet('autoprestige').textContent = i18next.t(
         'buildings.autoPrestige',
         {
+          // TODO: make separate i18n for 'Prestige', 'Transcend', etc.
           name: 'Diamonds',
           action: 'Prestige',
-          factor: format(Decimal.pow(10, player.prestigeamount)),
-          mult: format(p)
+          factor: format(Decimal.pow(10, player.prestigeamount), 0, false, false),
+          mult: format(p, 0, false, false)
         }
       )
     } else if (player.resetToggleModes.prestige === AutoResetModes.time) {
@@ -435,8 +443,8 @@ export const visualUpdateBuildings = () => {
         'buildings.autoReincarnate',
         {
           name: 'Prestige',
-          amount: player.prestigeamount,
-          timer: format(G.autoResetTimers.prestige, 1)
+          amount: format(player.prestigeamount, 0, false, false),
+          timer: format(G.autoResetTimers.prestige, 1, false, false)
         }
       )
     }
@@ -444,8 +452,8 @@ export const visualUpdateBuildings = () => {
     DOMCacheGetOrSet('transcendshardinfo').textContent = i18next.t(
       'buildings.mythosYouHave',
       {
-        shards: format(player.transcendShards, 2),
-        mult: format(G.totalMultiplierBoost, 0, true)
+        shards: format(player.transcendShards, 2, false, false),
+        mult: format(G.totalMultiplierBoost, 0, true, false)
       }
     )
 
@@ -456,22 +464,22 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`transcendtext${2 * i - 1}`).textContent = i18next.t(
         `buildings.names.${mythosNames[i - 1]}`,
         {
-          amount: format(player[`${ith}OwnedMythos` as const], 0, true),
-          gain: format(player[`${ith}GeneratedMythos` as const], 2)
+          amount: format(player[`${ith}OwnedMythos` as const], 0, true, false),
+          gain: format(player[`${ith}GeneratedMythos` as const], 2, false, false)
         }
       )
 
       DOMCacheGetOrSet(`transcendtext${2 * i}`).textContent = i18next.t(
         `buildings.per.${mythosPerSecNames[i - 1]}`,
         {
-          amount: format(place.times(40), 2)
+          amount: format(place.times(40), 2, false, false)
         }
       )
 
       getBuildingCostElement(`buymythos${i}`).textContent = i18next.t(
         'buildings.costMythos',
         {
-          mythos: format(player[`${ith}CostMythos` as const], 2)
+          mythos: format(player[`${ith}CostMythos` as const], 2, false, false)
         }
       )
     }
@@ -481,30 +489,30 @@ export const visualUpdateBuildings = () => {
         'buildings.autoPrestige',
         {
           name: 'Mythos',
-          action: 'Prestige',
-          factor: format(Decimal.pow(10, player.transcendamount)),
+          action: 'Transcend',
+          factor: format(Decimal.pow(10, player.transcendamount), 0, false, false),
           mult: format(
             Decimal.pow(
               10,
               Decimal.log(G.transcendPointGain.add(1), 10)
                 - Decimal.log(player.transcendPoints.add(1), 10)
             ),
-            2
+            2,
+            false,
+            false
           )
         }
       )
     }
     if (player.resetToggleModes.transcend === AutoResetModes.time) {
-      // TODO(@KhafraDev): i18n this
-      DOMCacheGetOrSet(
-        'autotranscend'
-      ).textContent =
-        `Transcend when the autotimer is at least ${player.transcendamount} real-life seconds. [Toggle number above]. Current timer: ${
-          format(
-            G.autoResetTimers.transcension,
-            1
-          )
-        }s.`
+      DOMCacheGetOrSet('autotranscend').textContent = i18next.t(
+        'buildings.autoReincarnate',
+        {
+          name: 'Transcend',
+          amount: format(player.transcendamount, 0, false, false),
+          timer: format(G.autoResetTimers.transcension, 1, false, false)
+        }
+      )
     }
   } else if (G.buildingSubTab === 'particle') {
     for (let i = 1; i <= 5; i++) {
@@ -514,20 +522,20 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`reincarnationtext${i}`).textContent = i18next.t(
         `buildings.names.${particleNames[i - 1]}`,
         {
-          amount: format(player[`${ith}OwnedParticles` as const], 0, true),
-          gain: format(player[`${ith}GeneratedParticles` as const], 2)
+          amount: format(player[`${ith}OwnedParticles` as const], 0, true, false),
+          gain: format(player[`${ith}GeneratedParticles` as const], 2, false, false)
         }
       )
       DOMCacheGetOrSet(`reincarnationtext${i + 5}`).textContent = i18next.t(
         `buildings.per.${particlePerSecNames[i - 1]}`,
         {
-          amount: format(place.times(40), 2)
+          amount: format(place.times(40), 2, false, false)
         }
       )
       getBuildingCostElement(`buyparticles${i}`).textContent = i18next.t(
         'buildings.costParticles',
         {
-          particles: format(player[`${ith}CostParticles` as const], 2)
+          particles: format(player[`${ith}CostParticles` as const], 2, false, false)
         }
       )
     }
@@ -538,23 +546,23 @@ export const visualUpdateBuildings = () => {
     DOMCacheGetOrSet('reincarnationshardinfo').innerHTML = i18next.t(
       'buildings.atomsYouHave',
       {
-        atoms: format(player.reincarnationShards, 2),
-        power: format(buildingPower, 4, true),
-        mult: format(buildingPowerMult, 2, true)
+        atoms: format(player.reincarnationShards, 2, false, false),
+        power: format(buildingPower, 4, true, false),
+        mult: format(buildingPowerMult, 2, true, false)
       }
     )
 
     DOMCacheGetOrSet('reincarnationCrystalInfo').textContent = i18next.t(
       'buildings.thanksR2x14',
       {
-        mult: format(Decimal.pow(buildingPowerMult, 1 / 50), 3, false)
+        mult: format(Decimal.pow(buildingPowerMult, 1 / 50), 3, false, false)
       }
     )
 
     DOMCacheGetOrSet('reincarnationMythosInfo').textContent = i18next.t(
       'buildings.thanksR2x15',
       {
-        mult: format(Decimal.pow(buildingPowerMult, 1 / 250), 3, false)
+        mult: format(Decimal.pow(buildingPowerMult, 1 / 250), 3, false, false)
       }
     )
 
@@ -564,14 +572,16 @@ export const visualUpdateBuildings = () => {
         {
           name: 'Particles',
           action: 'Reincarnate',
-          factor: format(Decimal.pow(10, player.reincarnationamount)),
+          factor: format(Decimal.pow(10, player.reincarnationamount), 0, false, false),
           mult: format(
             Decimal.pow(
               10,
               Decimal.log(G.reincarnationPointGain.add(1), 10)
                 - Decimal.log(player.reincarnationPoints.add(1), 10)
             ),
-            2
+            2,
+            false,
+            false
           )
         }
       )
@@ -580,8 +590,8 @@ export const visualUpdateBuildings = () => {
         'buildings.autoReincarnate',
         {
           name: 'Reincarnate',
-          amount: player.reincarnationamount,
-          timer: format(G.autoResetTimers.reincarnation, 1)
+          amount: format(player.reincarnationamount, 0, false, false),
+          timer: format(G.autoResetTimers.reincarnation, 1, false, false)
         }
       )
     }
@@ -592,8 +602,8 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet(`ascendText${i}`).textContent = i18next.t(
         `buildings.names.${tesseractNames[i - 1]}`,
         {
-          amount: format(player[ascendBuildingI].owned, 0, true),
-          gain: format(player[ascendBuildingI].generated, 2)
+          amount: format(player[ascendBuildingI].owned, 0, true, false),
+          gain: format(player[ascendBuildingI].generated, 2, false, false)
         }
       )
 
@@ -604,7 +614,9 @@ export const visualUpdateBuildings = () => {
             (G.ascendBuildingProduction as Record<string, Decimal>)[
               G.ordinals[i - 1]
             ],
-            2
+            2,
+            false,
+            false
           )
         }
       )
@@ -612,7 +624,7 @@ export const visualUpdateBuildings = () => {
       getBuildingCostElement(`buyTesseracts${i}`).textContent = i18next.t(
         'buildings.costTesseracts',
         {
-          tesseracts: format(player[ascendBuildingI].cost, 0)
+          tesseracts: format(player[ascendBuildingI].cost, 0, false, false)
         }
       )
     }
@@ -620,14 +632,14 @@ export const visualUpdateBuildings = () => {
     DOMCacheGetOrSet('tesseractInfo').textContent = i18next.t(
       'buildings.tesseractsYouHave',
       {
-        tesseracts: format(player.wowTesseracts.valueOf())
+        tesseracts: format(player.wowTesseracts.valueOf(), 0, false, false)
       }
     )
 
     DOMCacheGetOrSet('ascendShardInfo').textContent = i18next.t(
       'buildings.constantYouHave',
       {
-        const: format(player.ascendShards, 2),
+        const: format(player.ascendShards, 2, false, false),
         amount: format(
           Math.pow(
             Decimal.log(player.ascendShards.add(1), 10) + 1,
@@ -640,7 +652,8 @@ export const visualUpdateBuildings = () => {
               + calculateTaxPlatonicBlessing()
           ),
           4,
-          true
+          true,
+          false
         )
       }
     )
@@ -649,14 +662,14 @@ export const visualUpdateBuildings = () => {
       DOMCacheGetOrSet('autotessbuyeramount').textContent = i18next.t(
         'buildings.autoTesseract',
         {
-          tesseracts: format(player.tesseractAutoBuyerAmount)
+          tesseracts: format(player.tesseractAutoBuyerAmount, 0, false, false)
         }
       )
     } else if (player.resetToggleModes.ascension === AutoAscensionModes.percentage) {
       DOMCacheGetOrSet('autotessbuyeramount').textContent = i18next.t(
         'buildings.autoAscensionTesseract',
         {
-          percent: format(Math.min(100, player.tesseractAutoBuyerAmount))
+          percent: format(Math.min(100, player.tesseractAutoBuyerAmount), 0, false, false)
         }
       )
     }
@@ -706,7 +719,7 @@ const updateOfferingAndSalvageText = () => {
   DOMCacheGetOrSet('offeringCount').textContent = i18next.t(
     'runes.offeringsYouHave',
     {
-      offerings: format(player.offerings, 0, true)
+      offerings: format(player.offerings, 0, true, false)
     }
   )
 
@@ -784,7 +797,7 @@ export const visualUpdateChallenges = () => {
     DOMCacheGetOrSet('autoIncrementerAmount').innerHTML = i18next.t(
       'challenges.autoTimer',
       {
-        time: format(timeSinceLastStateChange, 2)
+        time: format(timeSinceLastStateChange, 2, false, false)
       }
     )
   }
@@ -802,7 +815,8 @@ export const visualUpdateResearch = () => {
         x: format(
           calculateResearchAutomaticObtainium(1),
           3,
-          true
+          true,
+          false
         )
       }
     )
@@ -818,14 +832,14 @@ export const visualUpdateAnts = () => {
   DOMCacheGetOrSet('crumbcount').textContent = i18next.t(
     'ants.galacticCrumbCount',
     {
-      x: format(player.ants.crumbs, 2, true, undefined, undefined, true)
+      x: format(player.ants.crumbs, 2, true, false)
     }
   )
 
   DOMCacheGetOrSet('crumbsPerSecond').textContent = i18next.t(
     'ants.crumbsPerSecond',
     {
-      x: format(firstTierProduction, 2, true, undefined, undefined, true)
+      x: format(firstTierProduction, 2, true, false)
     }
   )
   DOMCacheGetOrSet('crumbCoinMultiplier').textContent = i18next.t(
@@ -837,14 +851,14 @@ export const visualUpdateAnts = () => {
 
   autoAntSacrificeModeDescHTML(player.ants.toggles.autoSacrificeMode)
   DOMCacheGetOrSet('sacrificeSecondsElapsed').innerHTML = i18next.t('ants.timeElapsed', {
-    x: format(player.antSacrificeTimerReal, 2, true)
+    x: format(player.antSacrificeTimerReal, 2, true, false)
   })
 
   if (player.ants.crumbsThisSacrifice.gte(MINIMUM_CRUMBS_FOR_SACRIFICE)) {
     DOMCacheGetOrSet('antSacrificeRequired').innerHTML = i18next.t('ants.altar.sacrificeReady.unlocked')
   } else {
     DOMCacheGetOrSet('antSacrificeRequired').innerHTML = i18next.t('ants.altar.sacrificeReady.locked', {
-      x: format(player.ants.crumbsThisSacrifice, 0, true),
+      x: format(player.ants.crumbsThisSacrifice, 0, true, false),
       y: format(MINIMUM_CRUMBS_FOR_SACRIFICE, 0, true)
     })
   }
@@ -1459,7 +1473,7 @@ export const visualUpdateCorruptions = () => {
   } else if (player.autoAscendMode === AutoAscensionResetModes.realAscensionTime) {
     autoAscendDOM.innerHTML = i18next.t('corruptions.autoAscend.realTime', {
       input: format(player.autoAscendThreshold),
-      time: format(player.ascensionCounterRealReal)
+      time: format(player.ascensionCounterRealReal, 2, false, false)
     })
   }
 
@@ -1563,7 +1577,9 @@ export const visualUpdateSettings = () => {
         x: format(
           3600 / quarkData.perHour
             - (player.quarkstimer % (3600.00001 / quarkData.perHour)),
-          2
+          2,
+          false,
+          false
         ),
         // eslint-disable-next-line number-arg-out-of-range
         y: player.worlds.toString(1)
@@ -1591,7 +1607,10 @@ export const visualUpdateSettings = () => {
                 / Math.max(
                   1,
                   getGQUpgradeEffect('goldenQuarks3', 'exportGQPerHour')
-                )))
+                ))),
+          0,
+          false,
+          false
         ),
         y: format(goldenQuarkMultiplier, 2, true)
       }
@@ -1613,7 +1632,8 @@ export const visualUpdateSettings = () => {
             168
               * getGQUpgradeEffect('goldenQuarks3', 'exportGQPerHour')
               * goldenQuarkMultiplier
-          )
+          ),
+          2
         )
       }
     )
@@ -1630,7 +1650,7 @@ export const visualUpdateSingularity = () => {
     DOMCacheGetOrSet('goldenQuarkamount').textContent = i18next.t(
       'singularity.goldenQuarkAmount',
       {
-        goldenQuarks: format(player.goldenQuarks, 0, true)
+        goldenQuarks: format(player.goldenQuarks, 0, true, false)
       }
     )
 
@@ -1695,7 +1715,7 @@ export const visualUpdateOcteracts = () => {
     return
   }
   DOMCacheGetOrSet('octeractAmount').innerHTML = i18next.t('octeract.amount', {
-    octeracts: format(player.wowOcteracts, 2, true, true, true)
+    octeracts: format(player.wowOcteracts, 2, true, false)
   })
 
   const perSecond = calculateOcteractMultiplier()
@@ -1722,7 +1742,7 @@ export const visualUpdateOcteracts = () => {
   DOMCacheGetOrSet('totalOcteractAmount').innerHTML = i18next.t(
     'octeract.totalGenerated',
     {
-      octeracts: format(player.totalWowOcteracts, 2, true, true, true)
+      octeracts: format(player.totalWowOcteracts, 2, true, false)
     }
   )
   DOMCacheGetOrSet('totalOcteractCubeBonus').style.display = cTOCB >= 0.001 ? 'block' : 'none'
@@ -1732,25 +1752,25 @@ export const visualUpdateOcteracts = () => {
   DOMCacheGetOrSet('totalOcteractCubeBonus').innerHTML = i18next.t(
     'octeract.generatedCubeBonus',
     {
-      cubeBonus: format(cTOCB, 3, true)
+      cubeBonus: format(cTOCB, 3, true, false)
     }
   )
   DOMCacheGetOrSet('totalOcteractQuarkBonus').innerHTML = i18next.t(
     'octeract.generatedQuarkBonus',
     {
-      quarkBonus: format(cTOQB, 3, true)
+      quarkBonus: format(cTOQB, 3, true, false)
     }
   )
   DOMCacheGetOrSet('totalOcteractOfferingBonus').innerHTML = i18next.t(
     'octeract.generatedOfferingBonus',
     {
-      offeringBonus: format(cTOOB, 3, true)
+      offeringBonus: format(cTOOB, 3, true, false)
     }
   )
   DOMCacheGetOrSet('totalOcteractObtainiumBonus').innerHTML = i18next.t(
     'octeract.generatedObtainiumBonus',
     {
-      obtainiumBonus: format(cTOOOB, 3, true)
+      obtainiumBonus: format(cTOOOB, 3, true, false)
     }
   )
 }
@@ -1791,7 +1811,7 @@ export const visualUpdateAmbrosia = () => {
   DOMCacheGetOrSet('ambrosiaProgress').style.width = `${barWidth}%`
 
   if (player.singularityChallenges.noSingularityUpgrades.completions > 0) {
-    DOMCacheGetOrSet('ambrosiaProgressText').textContent = `${format(player.blueberryTime, 0, true)} / ${
+    DOMCacheGetOrSet('ambrosiaProgressText').textContent = `${format(player.blueberryTime, 0, true, false)} / ${
       format(requiredTime, 0, true)
     } [+${format(totalTimePerSecond, 0, true)}/s]`
   } else {
@@ -1801,7 +1821,7 @@ export const visualUpdateAmbrosia = () => {
   DOMCacheGetOrSet('pixelProgress').style.width = `${pixelBarWidth}%`
 
   if (player.singularityChallenges.noAmbrosiaUpgrades.completions > 0) {
-    DOMCacheGetOrSet('pixelProgressText').textContent = `${format(player.redAmbrosiaTime, 0, true)} / ${
+    DOMCacheGetOrSet('pixelProgressText').textContent = `${format(player.redAmbrosiaTime, 0, true, false)} / ${
       format(requiredTimeRed, 0, true)
     } [+${format(totalTimePerSecondRed, 2, true)}/s]`
   } else {
@@ -1929,7 +1949,7 @@ export const visualUpdateShop = () => {
   }
   DOMCacheGetOrSet('quarkamount').textContent = i18next.t(
     'shop.youHaveQuarks',
-    { x: format(player.worlds.valueOf(), 0, true) }
+    { x: format(player.worlds.valueOf(), 0, true, false) }
   )
   DOMCacheGetOrSet('offeringpotionowned').textContent = format(
     player.shopUpgrades.offeringPotion,
@@ -2079,7 +2099,7 @@ export const visualUpdateShop = () => {
 
   DOMCacheGetOrSet('buySingularityQuarksAmount').textContent = player.goldenQuarks < 1000
     ? i18next.t('shop.singularityQuarkAmount', { amount: format(player.goldenQuarks) })
-    : format(player.goldenQuarks)
+    : format(player.goldenQuarks, 0, false, false)
 
   DOMCacheGetOrSet('buySingularityQuarksButton').textContent = i18next.t('shop.singularityQuarkCost', {
     cost: format(getGoldenQuarkCost().cost)

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,7 @@ import i18next, { type Resource } from 'i18next'
 import { DOMCacheGetOrSet } from './Cache/DOM'
 import { storageGetItem, storageSetItem } from './events/storage-events'
 import ColorTextPlugin from './Plugins/ColorText'
+import NumberLocale from './Plugins/NumberLocale'
 import StatSymbolsPlugin from './Plugins/StatSymbols'
 import { Confirm } from './UpdateHTML'
 
@@ -43,12 +44,12 @@ export const init = async (): Promise<void> => {
     resources.en = { translation: englishTranslations }
   }
 
-  await i18next.use(StatSymbolsPlugin).use(ColorTextPlugin).init({
+  await i18next.use(StatSymbolsPlugin).use(ColorTextPlugin).use(NumberLocale).init({
     lng: language,
     fallbackLng: 'en',
     debug: !PROD,
     resources,
-    postProcess: ['StatSymbols', 'ColorText'],
+    postProcess: ['StatSymbols', 'ColorText', 'NumberLocale'],
     // crowdin returns an empty string when a translation for
     // a language isn't present
     returnEmptyString: false,

--- a/translations/en.json
+++ b/translations/en.json
@@ -5268,7 +5268,7 @@
       "12": "Your wealth is equal to the number of atoms in the universe, raised to the power of <<gold | num:((1250000))>>...",
       "13": "You see the ants from down here. However, do you see the ants from <<orange | up there>>?",
       "14": "If you had a dollar for every digit in your wealth, you would be the richest person on this thing one would call <<lightblue|\"Earth\">>...",
-      "15": "10^num:((1000000000000000)) Coins! If the exponent were multiplied by 9, in some alternative <<grey | Realities>> you would overflow the universe with coins.",
+      "15": "10^1,000,000,000,000,000 Coins! If the exponent were multiplied by 9, in some alternative <<grey | Realities>> you would overflow the universe with coins.",
       "16": "An exponent so large, many wouldn't know it by name.",
       "17": "Have you ever questioned why the <<gray | Tax Man>> divides your coins? The ultimate creator of this reality, which you believe to be a <<cyan | Platonic>> (ideal) being, instructed as much.",
       "18": "Octillions of digits in your wealth! What if there were other <<green | Octagonal>> objects in this reality? That would be silly.",
@@ -5276,7 +5276,7 @@
       "20": "I think you are long past the point where the <<gray | Tax Man>> is the only thing holding you back. Right?",
       "21": "Sometimes you wonder if the Ant God is better off just feeding off your Coins. You surely have enough.",
       "22": "Ant God, Derpsmith, the Gold Guy, <<cyan | Platonic>>... who are all of these entities anyway?",
-      "23": "10 to the <<gold|num:((10000000000000000000))>><<orange|,num:((000000000000000000))>><<brown|,num:((000000000000000000))>><<<grey|,num:((000000000000000))>>",
+      "23": "10 to the <<gold|10,000,000,000,000,000,000>><<orange|,000,000,000,000,000,000>><<brown|,000,000,000,000,000,000>><<<grey|,000,000,000,000,000>>",
       "24": "They should write stories about your wealth. It only suffices that an <<grey | Ultimate Pen>> will do.",
       "25": "No one will know my name, but the bards' songs will remain.",
       "26": "That's a lot of coins lol"

--- a/translations/en.json
+++ b/translations/en.json
@@ -49,7 +49,7 @@
       },
       "ambrosiaCubes1": {
         "name": "Ambrosia Cube Module I",
-        "description": "Congrats on completing the Tutorial module. You need to have it maxxed to buy levels of this. +5% Cubes per level. Every 5 levels give 1.1x Cubes.",
+        "description": "Congrats on completing the Tutorial module. You need to have it maxxed to buy levels of this. +5% Cubes per level. Every 5 levels give num:((1.1))x Cubes.",
         "effect": "This Cube module increases Cube gain by {{amount}}%"
       },
       "ambrosiaLuck1": {
@@ -59,47 +59,47 @@
       },
       "ambrosiaCubeQuark1": {
         "name": "Ambrosia Cube-Quark Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.01% Quarks per level per digit in the values of all cube types.",
+        "description": "A first generation hybrid module. Gain +num:((0.01))% Quarks per level per digit in the values of all cube types.",
         "effect": "This first generation hybrid module increases Quark gain by {{amount}}%"
       },
       "ambrosiaLuckQuark1": {
         "name": "Ambrosia Luck-Quark Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.01% more Quarks per level per 1 Ambrosia Luck! Diminishing returns after 1,000 Luck.",
+        "description": "A first generation hybrid module. Gain +num:((0.01))% more Quarks per level per 1 Ambrosia Luck! Diminishing returns after num:((1000)) Luck.",
         "effect": "This first generation hybrid module increases Quark gain by {{amount}}%"
       },
       "ambrosiaQuarkCube1": {
         "name": "Ambrosia Quark-Cube Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.1% more Cubes per level per digit in your Quark balance, squared!",
+        "description": "A first generation hybrid module. Gain +num:((0.1))% more Cubes per level per digit in your Quark balance, squared!",
         "effect": "This first generation hybrid module increases Cube gain by {{amount}}%"
       },
       "ambrosiaLuckCube1": {
         "name": "Ambrosia Luck-Cube Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.05% more Cubes per level per 1 Ambrosia Luck!",
+        "description": "A first generation hybrid module. Gain +num:((0.05))% more Cubes per level per 1 Ambrosia Luck!",
         "effect": "This first generation hybrid module increases Cube gain by {{amount}}%"
       },
       "ambrosiaCubeLuck1": {
         "name": "Ambrosia Cube-Luck Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.02 Ambrosia Luck per level per digit in the values of all cube types.",
+        "description": "A first generation hybrid module. Gain +num:((0.02)) Ambrosia Luck per level per digit in the values of all cube types.",
         "effect": "This first generation hybrid module increases Ambrosia Luck by {{amount}}"
       },
       "ambrosiaQuarkLuck1": {
         "name": "Ambrosia Quark-Luck Hybrid Module I",
-        "description": "A first generation hybrid module. Gain +0.02 Ambrosia Luck per level per digit in your Quark balance, squared.",
+        "description": "A first generation hybrid module. Gain +num:((0.02)) Ambrosia Luck per level per digit in your Quark balance, squared.",
         "effect": "This first generation hybrid module increases Ambrosia Luck by {{amount}}"
       },
       "ambrosiaQuarks2": {
         "name": "Ambrosia Quark Module II",
-        "description": "Self-Synergies! Gain +1% Quarks per level, +0.1% for every 10 levels in Ambrosia Quark Module I.",
+        "description": "Self-Synergies! Gain +1% Quarks per level, +num:((0.1))% for every 10 levels in Ambrosia Quark Module I.",
         "effect": "This second generation Quark module increases Quark gain by {{amount}}%"
       },
       "ambrosiaCubes2": {
         "name": "Ambrosia Cube Module II",
-        "description": "Self-Synergies! Gain +10% cubes per level, +1% for every 10 levels in Ambrosia Cube Module I. Every 5 levels give 1.15x Cubes.",
+        "description": "Self-Synergies! Gain +10% cubes per level, +1% for every 10 levels in Ambrosia Cube Module I. Every 5 levels give num:((1.15))x Cubes.",
         "effect": "This second generation Cube module increases Cube gain by {{amount}}%"
       },
       "ambrosiaLuck2": {
         "name": "Ambrosia Luck Module II",
-        "description": "Self-Synergies! Gain +3 Ambrosia Luck per level, +0.3 for every 10 levels in Ambrosia Luck Module I. Every 10 levels give +40 more!",
+        "description": "Self-Synergies! Gain +3 Ambrosia Luck per level, +num:((0.3)) for every 10 levels in Ambrosia Luck Module I. Every 10 levels give +40 more!",
         "effect": "This second generation Luck module increases Ambrosia Luck by {{amount}}"
       },
       "ambrosiaQuarks3": {
@@ -109,7 +109,7 @@
       },
       "ambrosiaCubes3": {
         "name": "Ambrosia Cube Module III",
-        "description": "A darkness emboldens this module. +20% Cubes per level, and the effect is 3% stronger per level of Ambrosia Cube Module II. Every 5 levels give 1.2x Cubes.",
+        "description": "A darkness emboldens this module. +20% Cubes per level, and the effect is 3% stronger per level of Ambrosia Cube Module II. Every 5 levels give num:((1.2))x Cubes.",
         "effect": "This third generation Cube module increases Cube gain by {{amount}}%"
       },
       "ambrosiaLuck3": {
@@ -119,7 +119,7 @@
       },
       "ambrosiaLuck4": {
         "name": "The Eight Leaf Clover",
-        "description": "<span class=\"rainbowText\">My magical lucky charms!</span> +0.01% Ambrosia Luck per level, multiplied by the number of total digits in your Lifetime Ambrosia and Red Ambrosia!",
+        "description": "<span class=\"rainbowText\">My magical lucky charms!</span> +num:((0.01))% Ambrosia Luck per level, multiplied by the number of total digits in your Lifetime Ambrosia and Red Ambrosia!",
         "effect": "This fourth generation Luck module increases Ambrosia Luck by <span class=\"rainbowText\">{{amount}}</span>"
       },
       "ambrosiaPatreon": {
@@ -129,12 +129,12 @@
       },
       "ambrosiaObtainium1": {
         "name": "RNG-based Obtainium Booster",
-        "description": "Gain +0.1% Obtainium per Ambrosia Luck!",
+        "description": "Gain +num:((0.1))% Obtainium per Ambrosia Luck!",
         "effect": "This module increases Obtainium gain by {{amount}}%!"
       },
       "ambrosiaOffering1": {
         "name": "RNG-based Offerings Booster",
-        "description": "Gain +0.1% Offerings per Ambrosia Luck!",
+        "description": "Gain +num:((0.1))% Offerings per Ambrosia Luck!",
         "effect": "This module increases Offerings gain by {{amount}}%!"
       },
       "ambrosiaHyperflux": {
@@ -184,12 +184,12 @@
       },
       "ambrosiaTalismanBonusRuneLevel": {
         "name": "Talisman Ambrosia Embedding Module",
-        "description": "With the power of a lot of Ambrosia, grant +0.5% Talisman Power per level! Additive with other bonuses.",
+        "description": "With the power of a lot of Ambrosia, grant +num:((0.5))% Talisman Power per level! Additive with other bonuses.",
         "effect": "Talisman Power is increased by {{amount}}"
       },
       "ambrosiaRuneOOMBonus": {
         "name": "Rune Coefficient Module",
-        "description": "For each of the first five runes, add 1 to their Rune Coefficient per level! For Infinite Ascent, add +0.001 to the Rune Coefficient per level.",
+        "description": "For each of the first five runes, add 1 to their Rune Coefficient per level! For Infinite Ascent, add +num:((0.001)) to the Rune Coefficient per level.",
         "effect": "Runes 1-5 have +{{amount}} Rune Coefficient; IA Rune has +{{amount2}} Rune Coefficient"
       },
       "ambrosiaBrickOfLead": {
@@ -214,7 +214,7 @@
       },
       "ambrosiaFreeQuarkUpgrades": {
         "name": "Mechanical - the 1981 Cut",
-        "description": "For all 'Quark' type Quark Upgrades, gain +0.1 free levels per level! These will have a corresponding icon.",
+        "description": "For all 'Quark' type Quark Upgrades, gain +num:((0.1)) free levels per level! These will have a corresponding icon.",
         "effect": "+{{amount}} free levels for 'Quark' type Quark Upgrades"
       }
     },
@@ -247,7 +247,7 @@
     "data": {
       "tutorial": {
         "name": "A beginners guide to Red Ambrosia",
-        "description": "Much like Ambrosia is the life force of the Gods, Red Ambrosia is the life force of your soul. But you don't really care about that... 1.01x Cubes, Obtainium and Offerings per level!",
+        "description": "Much like Ambrosia is the life force of the Gods, Red Ambrosia is the life force of your soul. But you don't really care about that... num:((1.01))x Cubes, Obtainium and Offerings per level!",
         "effect": "Cubes, Obtainium and Offerings are increased by <<lime | {{amount}}>>!"
       },
       "conversionImprovement1": {
@@ -292,7 +292,7 @@
       },
       "blueberryGenerationSpeed": {
         "name": "The Sands of Time",
-        "description": "+0.2% Ambrosia Bar Point gain per level. They say this hourglass has the benediction of Chronos himself.",
+        "description": "+num:((0.2))% Ambrosia Bar Point gain per level. They say this hourglass has the benediction of Chronos himself.",
         "effect": "This upgrade increases Ambrosia Bar Point gain by <<lightblue|{{amount}}>>!"
       },
       "regularLuck": {
@@ -302,7 +302,7 @@
       },
       "redGenerationSpeed": {
         "name": "Millennium-Aged Red Ambrosia",
-        "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +0.3% more Red Bar Points per level.",
+        "description": "Surely, with how long this Ambrosia is left to sit, it knows something about time. +num:((0.3))% more Red Bar Points per level.",
         "effect": "This upgrade increases Red Bar Point gain by <<red|{{amount}}>>!"
       },
       "redLuck": {
@@ -319,19 +319,19 @@
       "redAmbrosiaObtainium": {
         "name": "Obtainium \"\"made\"\" of Red Ambrosia",
         "description": "I don't know why you can make a blue object from a red object. But you can.",
-        "effect": "When purchased, multiply your Obtainium by 1 + (Lifetime)^0.6 / 100.",
-        "effectEnabled": "Multiplies your Obtainium gain by 1 + (Lifetime)^0.6 / 100. <br> [Currently: <<pink|+{{amount}}>>]"
+        "effect": "When purchased, multiply your Obtainium by 1 + (Lifetime)^num:((0.6)) / 100.",
+        "effectEnabled": "Multiplies your Obtainium gain by 1 + (Lifetime)^num:((0.6)) / 100. <br> [Currently: <<pink|+{{amount}}>>]"
       },
       "redAmbrosiaOffering": {
         "name": "Offerings \"\"\"made\"\"\" of Red Ambrosia",
         "description": "Wait, this one kinda makes sense.",
-        "effect": "When purchased, multiply your Offerings by 1 + (Lifetime)^0.6 / 100.",
-        "effectEnabled": "Multiplies your Offerings gain by 1 + (Lifetime)^0.6 / 100. <br> [Currently: <<orange|+{{amount}}>>]"
+        "effect": "When purchased, multiply your Offerings by 1 + (Lifetime)^num:((0.6)) / 100.",
+        "effectEnabled": "Multiplies your Offerings gain by 1 + (Lifetime)^num:((0.6)) / 100. <br> [Currently: <<orange|+{{amount}}>>]"
       },
       "redAmbrosiaCubeImprover": {
         "name": "Hire Red Ambrosia Artisans",
-        "description": "They are better at making cubes out of Red Ambrosia for you, depending on how many you have. +0.01 exponent to \"Cubes 'made' of Red Ambrosia\" per level.",
-        "effect": "Exponent for that Red Ambrosia Upgrade: <<white|0.40 → {{newExponent}}>>"
+        "description": "They are better at making cubes out of Red Ambrosia for you, depending on how many you have. +num:((0.01)) exponent to \"Cubes 'made' of Red Ambrosia\" per level.",
+        "effect": "Exponent for that Red Ambrosia Upgrade: <<white|num:((0.40)) → {{newExponent}}>>"
       },
       "viscount": {
         "name": "Viscount of Ruby Guy",
@@ -345,7 +345,7 @@
       },
       "redAmbrosiaAccelerator": {
         "name": "Red-Blue Ultrafusion",
-        "description": "When you gain a Red Ambrosia, you gain a bit of progress toward regular Ambrosia! +0.02 real-life seconds of Ambrosia Bar Points per level, per Red Ambrosia generated, with the first level giving +1!",
+        "description": "When you gain a Red Ambrosia, you gain a bit of progress toward regular Ambrosia! +num:((0.02)) real-life seconds of Ambrosia Bar Points per level, per Red Ambrosia generated, with the first level giving +1!",
         "effect": "Each Red Ambrosia generated grants <<white|{{amount}}>> real-life seconds of Ambrosia Bar Points."
       },
       "regularLuck2": {
@@ -355,7 +355,7 @@
       },
       "blueberryGenerationSpeed2": {
         "name": "The Sands of Time II",
-        "description": "This gives +0.1% Ambrosia Bar Point gain per level, but you can purchase a ton of levels of this!",
+        "description": "This gives +num:((0.1))% Ambrosia Bar Point gain per level, but you can purchase a ton of levels of this!",
         "effect": "This upgrade increases Ambrosia Bar Point gain by <<lightblue|{{amount}}>>!"
       },
       "salvageYinYang": {
@@ -402,66 +402,66 @@
       "1": "A Loyal Employee: Hire your first Worker.",
       "2": "Small Business: Hire 10 Workers.",
       "3": "Now we're synergizing!: Hire 100 Workers.",
-      "4": "Gaining Redundancies: Hire 1,000 Workers.",
-      "5": "A cog in the machine: Hire 5,000 Workers.",
-      "6": "A nail in the machine: Hire 10,000 Workers.",
-      "7": "Are we even in the machine anymore?: Hire 20,000 Workers.",
+      "4": "Gaining Redundancies: Hire num:((1000)) Workers.",
+      "5": "A cog in the machine: Hire num:((5000)) Workers.",
+      "6": "A nail in the machine: Hire num:((10000)) Workers.",
+      "7": "Are we even in the machine anymore?: Hire num:((20000)) Workers.",
       "8": "STONKS!!!: Purchase 1 Investment.",
       "9": "Planning ahead: Purchase 10 Investments.",
       "10": "Inside Trading: Purchase 100 Investments.",
       "11": "Outside Trading?: Purchase 500 Investments.",
-      "12": "Market Takeover: Purchase 5,000 Investments.",
-      "13": "Trickle-Down Economics: Purchase 10,000 Investments.",
-      "14": "Eliminated Regulation: Purchase 20,000 Investments.",
+      "12": "Market Takeover: Purchase num:((5000)) Investments.",
+      "13": "Trickle-Down Economics: Purchase num:((10000)) Investments.",
+      "14": "Eliminated Regulation: Purchase num:((20000)) Investments.",
       "15": "Stationery!: Build 1 Printer.",
       "16": "Printing Press: Build 10 Printers.",
       "17": "It prints free money!: Build 100 Printers.",
       "18": "Solving Our Debts: Build 333 Printers.",
-      "19": "Monopolizing the market: Build 5,000 Printers.",
-      "20": "We're running out of Ink!: Build 10,000 Printers.",
-      "21": "3D-printing the universe: Build 20,000 Printers.",
+      "19": "Monopolizing the market: Build num:((5000)) Printers.",
+      "20": "We're running out of Ink!: Build num:((10000)) Printers.",
+      "21": "3D-printing the universe: Build num:((20000)) Printers.",
       "22": "A national treasure: Establish 1 Coin Mint.",
       "23": "Now with competition!: Establish 10 Coin Mints.",
       "24": "Counterfeiting with Style!: Establish 100 Coin Mints.",
       "25": "Why do we need all these?: Establish 333 Coin Mints.",
-      "26": "No really, why??: Establish 5,000 Coin Mints.",
-      "27": "Is no one to stop us???: Establish 10,000 Coin Mints.",
-      "28": "Oh well, time to mint: Establish 20,000 Coin Mints.",
+      "26": "No really, why??: Establish num:((5000)) Coin Mints.",
+      "27": "Is no one to stop us???: Establish num:((10000)) Coin Mints.",
+      "28": "Oh well, time to mint: Establish num:((20000)) Coin Mints.",
       "29": "Newton's Apprentice: Create 1 Alchemy.",
       "30": "Lab Work: Create 10 Alchemies.",
       "31": "Satanic Becomings: Create 66 Alchemies.",
       "32": "Beelzebub Grinned: Create 200 Alchemies.",
-      "33": "Is this more demonic?: Create 6,666 Alchemies.",
-      "34": "Golden Paradise: Create 17,777 Alchemies.",
-      "35": "Unlocking secrets to the world: Create 42,777 Alchemies.",
+      "33": "Is this more demonic?: Create num:((6666)) Alchemies.",
+      "34": "Golden Paradise: Create num:((17777)) Alchemies.",
+      "35": "Unlocking secrets to the world: Create num:((42777)) Alchemies.",
       "36": "Leveling up: Prestige for at least 1 Diamond.",
-      "37": "High-Tiered: Prestige for at least 1e6 Diamonds.",
-      "38": "Highly Regarded: Prestige for at least 1e100 Diamonds.",
-      "39": "Prestigious: Prestige for at least 1e1,000 Diamonds.",
-      "40": "Legendary: Prestige for at least 1e10,000 Diamonds.",
-      "41": "Divine: Prestige for at least 1e77,777 Diamonds.",
-      "42": "Perfectly Respected: Prestige for at least 1e250,000 Diamonds.",
+      "37": "High-Tiered: Prestige for at least num:((1e6)) Diamonds.",
+      "38": "Highly Regarded: Prestige for at least num:((1e100)) Diamonds.",
+      "39": "Prestigious: Prestige for at least num:((1e1000)) Diamonds.",
+      "40": "Legendary: Prestige for at least num:((1e10000)) Diamonds.",
+      "41": "Divine: Prestige for at least num:((1e77777)) Diamonds.",
+      "42": "Perfectly Respected: Prestige for at least num:((1e250000)) Diamonds.",
       "43": "A Simple Detour: Transcend for at least 1 Mythos.",
-      "44": "Tunnel Vision: Transcend for at least 1e6 Mythos.",
-      "45": "Risen from the Ashes: Transcend for at least 1e50 Mythos.",
-      "46": "Paradigm Shift: Transcend for at least 1e308 Mythos.",
-      "47": "Preparation: Transcend for at least 1e1,500 Mythos.",
-      "48": "Revising the Plan: Transcend for at least 1e25,000 Mythos.",
-      "49": "Leaving the Universe: Transcend for at least 1e100,000 Mythos.",
+      "44": "Tunnel Vision: Transcend for at least num:((1e6)) Mythos.",
+      "45": "Risen from the Ashes: Transcend for at least num:((1e50)) Mythos.",
+      "46": "Paradigm Shift: Transcend for at least num:((1e308)) Mythos.",
+      "47": "Preparation: Transcend for at least num:((1e1500)) Mythos.",
+      "48": "Revising the Plan: Transcend for at least num:((1e25000)) Mythos.",
+      "49": "Leaving the Universe: Transcend for at least num:((1e100000)) Mythos.",
       "50": "Going Quantum: Reincarnate for at least 1 Particle.",
-      "51": "Tunneling Vision: Reincarnate for at least 100,000 Particles.",
-      "52": "Simulating the World: Reincarnate for at least 1e30 Particles.",
-      "53": "Multidimensional Creation: Reincarnate for at least 1e200 Particles.",
-      "54": "Lepton Dance: Reincarnate for at least 1e1,500 Particles.",
-      "55": "Do we have enough yet?: Reincarnate for at least 1e5,000 Particles.",
-      "56": "I Feel Luck in My Cells: Reincarnate for at least 1e7,777 Particles.",
+      "51": "Tunneling Vision: Reincarnate for at least num:((100000)) Particles.",
+      "52": "Simulating the World: Reincarnate for at least num:((1e30)) Particles.",
+      "53": "Multidimensional Creation: Reincarnate for at least num:((1e200)) Particles.",
+      "54": "Lepton Dance: Reincarnate for at least num:((1e1500)) Particles.",
+      "55": "Do we have enough yet?: Reincarnate for at least num:((1e5000)) Particles.",
+      "56": "I Feel Luck in My Cells: Reincarnate for at least num:((1e7777)) Particles.",
       "57": "One Way Only: Prestige without buying Multipliers.",
       "58": "Authentic Shifting: Transcend without having bought a Multiplier.",
       "59": "The [REDACTED]: Reincarnate without having bought a Multiplier.",
       "60": "Gotta go SLOW!: Prestige without buying Accelerators.",
       "61": "I'm really going slow: Transcend without having bought Accelerators or Boosts.",
       "62": "Are we there yet?: Reincarnate without having bought Accelerators or Boosts.",
-      "63": "A careful search for Diamonds: Get 1e120,000 Coins in [Reduced Diamonds] without buying Accelerators or Boosts.",
+      "63": "A careful search for Diamonds: Get num:((1e120000)) Coins in [Reduced Diamonds] without buying Accelerators or Boosts.",
       "64": "Very Based: Prestige without purchasing Coin Upgrades.",
       "65": "Miser: Transcend without purchasing Coin Upgrades.",
       "66": "True Miser: Transcend without purchasing Coin or Diamond Upgrades.",
@@ -473,9 +473,9 @@
       "72": "More Out of Order: Buy Generator Upgrade Row 1, #3 first in a Transcension (III -> II)",
       "73": "Four's a Company: Buy Generator Upgrade Row 1, #4 first in a Transcension (II -> I)",
       "74": "Five's a Croud: Buy Generator Upgrade Row 1, #5 first in a Transcension (I -> V)",
-      "75": "Vaseline without the Machine: Exit [No Multiplier] with at least 1e1000 coins and without any of the row 1 generator upgrades.",
-      "76": "Rage against the Machine: Exit [No Accelerator] with at least 1e1000 coins and without any of the row 1 generator upgrades.",
-      "77": "Amish Paradise: Exit [No Shards] with at least 1e99,999 coins and without any of the row 1 generator upgrades.",
+      "75": "Vaseline without the Machine: Exit [No Multiplier] with at least num:((1e1000)) coins and without any of the row 1 generator upgrades.",
+      "76": "Rage against the Machine: Exit [No Accelerator] with at least num:((1e1000)) coins and without any of the row 1 generator upgrades.",
+      "77": "Amish Paradise: Exit [No Shards] with at least num:((1e99999)) coins and without any of the row 1 generator upgrades.",
       "78": "Single-Cell: Complete [No Multiplier] once.",
       "79": "Solidarity: Complete [No Multiplier] three times.",
       "80": "Duplication-Free!: Complete [No Multiplier] five times.",
@@ -550,51 +550,51 @@
       "149": "0 to 25: Purchase 25 Accelerators.",
       "150": "0 to 100: Purchase 100 Accelerators",
       "151": "Highway to Hell: Purchase 666 Accelerators.",
-      "152": "Perhaps you should brake: Purchase 2,000 Accelerators.",
-      "153": "Exit the vehicle now!: Purchase 12,500 Accelerators.",
-      "154": "Faster than light: Purchase 100,000 Accelerators.",
+      "152": "Perhaps you should brake: Purchase num:((2000)) Accelerators.",
+      "153": "Exit the vehicle now!: Purchase num:((12500)) Accelerators.",
+      "154": "Faster than light: Purchase num:((100000)) Accelerators.",
       "155": "I've been duped!: Purchase 2 Multipliers.",
       "156": "Funhouse Mirrors: Purchase 20 Multipliers.",
       "157": "Friend of binary: Purchase 100 Multipliers.",
       "158": "Feeling the cost growth yet?: Purchase 500 Multipliers.",
-      "159": "Perhaps you'll feel the cost now: Purchase 2,000 Multipliers.",
-      "160": "Exponential Synergy: Purchase 12,500 Multipliers.",
-      "161": "Cloned: Purchase 100,000 Multipliers.",
+      "159": "Perhaps you'll feel the cost now: Purchase num:((2000)) Multipliers.",
+      "160": "Exponential Synergy: Purchase num:((12500)) Multipliers.",
+      "161": "Cloned: Purchase num:((100000)) Multipliers.",
       "162": "Jerk > 0: Purchase 2 Accelerator Boosts.",
       "163": "Can't the speedometer move any faster?: Purchase 10 Accelerator Boosts.",
       "164": "50 G rotations: Purchase 50 Accelerator Boosts.",
       "165": "Dematerialize: Purchase 200 Accelerator Boosts.",
-      "166": "Breaking the laws of Physics: Purchase 1,000 Accelerator Boosts.",
-      "167": "Decayed Realism: Purchase 5,000 Accelerator Boosts.",
-      "168": "Kinda fast: Purchase 15,000 Accelerator Boosts.",
+      "166": "Breaking the laws of Physics: Purchase num:((1000)) Accelerator Boosts.",
+      "167": "Decayed Realism: Purchase num:((5000)) Accelerator Boosts.",
+      "168": "Kinda fast: Purchase num:((15000)) Accelerator Boosts.",
       "169": "The Galactic Feast: Obtain 3 Galactic Crumbs.",
-      "170": "Only the finest: Obtain 100,000 Galactic Crumbs.",
-      "171": "Six-Course Meal: Obtain 666,666,666 Galactic Crumbs.",
-      "172": "Accumulation of Food: Obtain 1e20 Galactic Crumbs.",
-      "173": "Cookie Clicking: Obtain 1e40 Galactic Crumbs.",
-      "174": "Unlimited Bread Sticks!: Obtain 1e250 Galactic Crumbs.",
-      "175": "Restaurant at the end of the Universe: Obtain 1e2500 Galactic Crumbs.",
+      "170": "Only the finest: Obtain num:((100000)) Galactic Crumbs.",
+      "171": "Six-Course Meal: Obtain num:((666666666)) Galactic Crumbs.",
+      "172": "Accumulation of Food: Obtain num:((1e20)) Galactic Crumbs.",
+      "173": "Cookie Clicking: Obtain num:((1e40)) Galactic Crumbs.",
+      "174": "Unlimited Bread Sticks!: Obtain num:((1e250)) Galactic Crumbs.",
+      "175": "Restaurant at the end of the Universe: Obtain num:((1e2500)) Galactic Crumbs.",
       "176": "Ant-icipation!: Reach 50 Immortal ELO and own a Tier 2 Ant.",
       "177": "Ant-ecedent: Reach 200 Immortal ELO and own a Tier 3 Ant.",
       "178": "Ants are friends, not food!: Reach 500 Immortal ELO and own a Tier 4 Ant.",
-      "179": "Ant Devil?: Reach 1,000 Immortal ELO and own a Tier 5 Ant.",
-      "180": "The world's best chef: Reach 2,500 Immortal ELO and own a Tier 6 Ant.",
-      "181": "6 Michelin Stars: Reach 20,000 Immortal ELO and own a Tier 7 Ant.",
-      "182": "Keys to the Restaurant at the end of the Universe: Reach 100,000 Immortal ELO and own a Tier 8 Ant.",
+      "179": "Ant Devil?: Reach num:((1000)) Immortal ELO and own a Tier 5 Ant.",
+      "180": "The world's best chef: Reach num:((2500)) Immortal ELO and own a Tier 6 Ant.",
+      "181": "6 Michelin Stars: Reach num:((20000)) Immortal ELO and own a Tier 7 Ant.",
+      "182": "Keys to the Restaurant at the end of the Universe: Reach num:((100000)) Immortal ELO and own a Tier 8 Ant.",
       "183": "Up: Ascend Once.",
       "184": "Double-Up: Ascend Twice.",
       "185": "Give me Ten!: Ascend Ten Times.",
       "186": "Give me a Hundred: Ascend 100 Times.",
-      "187": "Give me a Thousand: Ascend 1,000 Times.",
-      "188": "Give me some arbitrary number I: Ascend 14,142 Times.",
-      "189": "Give me some arbitrary number II: Ascend 141,421 Times.",
-      "190": "Now that's what I call getting some Pi!: Attain a constant of 3.14.",
-      "191": "One in a million: Attain a constant of 1,000,000 [1e6].",
-      "192": "A number: Attain a constant of 4.32e10.",
-      "193": "The coolest of numbers: Attain a constant of 6.9e21.",
-      "194": "Planck^(-1): Attain a constant of 1.509e33.",
-      "195": "Epsilon > a lot: Attain a constant of 1e66.",
-      "196": "NUM_MAX: Attain a constant of 1.8e308.",
+      "187": "Give me a Thousand: Ascend num:((1000)) Times.",
+      "188": "Give me some arbitrary number I: Ascend num:((14142)) Times.",
+      "189": "Give me some arbitrary number II: Ascend num:((141421)) Times.",
+      "190": "Now that's what I call getting some Pi!: Attain a constant of num:((3.14)).",
+      "191": "One in a million: Attain a constant of num:((1000000)).",
+      "192": "A number: Attain a constant of num:((4.32e10)).",
+      "193": "The coolest of numbers: Attain a constant of num:((6.9e21)).",
+      "194": "Planck^(-1): Attain a constant of num:((1.509e33)).",
+      "195": "Epsilon > a lot: Attain a constant of num:((1e66)).",
+      "196": "NUM_MAX: Attain a constant of num:((1.8e308)).",
       "197": "Casualties: Clear 'Reduced Ants' challenge once.",
       "198": "Fatalities: Clear 'Reduced Ants' challenge twice.",
       "199": "Destruction: Clear 'Reduced Ants' challenge three times.",
@@ -623,7 +623,7 @@
       "222": "It's like: Clear 'No Research' ten times.",
       "223": "It's: Clear 'No Research' twenty times.",
       "224": "It: Clear 'No Research' thirty times.",
-      "225": "Pretty Corrupt: Clear an Ascension with above 100,000 score.",
+      "225": "Pretty Corrupt: Clear an Ascension with above num:((100000)) score.",
       "226": "Bought out: Clear an Ascension with above 1 million score.",
       "227": "Utterly Corrupt: Clear an Ascension with above 10 million score.",
       "228": "Antitrust: Clear an Ascension with above 100 million score.",
@@ -651,13 +651,13 @@
       "250": "The Thousand Moons: [Hint: You need to fully research into becoming GOD]",
       "251": "The Thousand Suns: [Hint: You may need to cube yourself up]",
       "252": "Ultimate: [Hint: a good enough score from the second Sadistic challenge shall do]",
-      "253": "Platonicism: Clear an Ascension with 1e12 score.",
-      "254": "That's a handful!: Clear an Ascension with 1e14 score.",
-      "255": "The game where everything is made up: Clear an Ascension with 1e17 score.",
-      "256": "... and the points don't matter: Clear an Ascension with 2e18 score.",
-      "257": "Arguably moral: Clear an Ascension with 4e19 score.",
-      "258": "Khafra's Personal Best: Clear an Ascension with 1e21 score.",
-      "259": "100 million million million!: Clear an Ascension with 1e23 score.",
+      "253": "Platonicism: Clear an Ascension with num:((1e12)) score.",
+      "254": "That's a handful!: Clear an Ascension with num:((1e14)) score.",
+      "255": "The game where everything is made up: Clear an Ascension with num:((1e17)) score.",
+      "256": "... and the points don't matter: Clear an Ascension with num:((2e18)) score.",
+      "257": "Arguably moral: Clear an Ascension with num:((4e19)) score.",
+      "258": "Khafra's Personal Best: Clear an Ascension with num:((1e21)) score.",
+      "259": "100 million million million!: Clear an Ascension with num:((1e23)) score.",
       "260": "Highly Dimensional Being: Ascend a total of 10 million times.",
       "261": "Ant God's upheaval: Ascend a total of 100 million times.",
       "262": "Did you forget about Ant God?: Ascend a total of 2 billion times.",
@@ -665,13 +665,13 @@
       "264": "I hope you're happy with yourself: Ascend a total of 800 billion times.",
       "265": "Oh well: Ascend a total of 16 trillion times.",
       "266": "Keep up the gradual numerical increase: Ascend a total of 100 trillion times.",
-      "267": "Eigenvalued: Achieve a constant of 1e1,000.",
-      "268": "Achieve Mathematics: Achieve a constant of 1e5,000.",
-      "269": "Ramsay (5,5): Achieve a constant of 1e15,000.",
-      "270": "What comes after this?: Achieve a constant of 1e50,000.",
-      "271": "LARGE BOY: Achieve a constant of 1e100,000.",
-      "272": "LARGER BOY: Achieve a constant of 1e300,000.",
-      "273": "LARGEST BOY: Achieve a constant of 1e1,000,000.",
+      "267": "Eigenvalued: Achieve a constant of num:((1e1000)).",
+      "268": "Achieve Mathematics: Achieve a constant of num:((1e5000)).",
+      "269": "Ramsay (5,5): Achieve a constant of num:((1e15000)).",
+      "270": "What comes after this?: Achieve a constant of num:((1e50000)).",
+      "271": "LARGE BOY: Achieve a constant of num:((1e100000)).",
+      "272": "LARGER BOY: Achieve a constant of num:((1e300000)).",
+      "273": "LARGEST BOY: Achieve a constant of num:((1e1000000)).",
       "274": "Power Creep: Singularity 1 time.",
       "275": "Have you enough cubes?: Singularity 2 times.",
       "276": "Singularity: Singularity 3 times.",
@@ -679,45 +679,45 @@
       "278": "SiINguLaRrRity: Singularity 5 times.",
       "279": "SiIINGuLArRrIiTyY: Singularity 7 times.",
       "280": "Inception: Singularity 10 times.",
-      "281": "The 100,000 Worker March: Hire 100,000 Workers.",
-      "282": "An Amazonian-sized workforce: Hire 1,000,000 Workers.",
-      "283": "A feudal economy: Hire 100,000,000 Workers.",
-      "284": "Too big to fail: Purchase 1,000,000 Investments.",
-      "285": "Why play the market: Purchase 100,000,000 Investments.",
+      "281": "The num:((100000)) Worker March: Hire num:((100000)) Workers.",
+      "282": "An Amazonian-sized workforce: Hire num:((1000000)) Workers.",
+      "283": "A feudal economy: Hire num:((100000000)) Workers.",
+      "284": "Too big to fail: Purchase num:((1000000)) Investments.",
+      "285": "Why play the market: Purchase num:((100000000)) Investments.",
       "286": "... when you ARE the market: Purchase 1 Billion Investments.",
-      "287": "Office Space: Purchase 10,000,000 Printers.",
-      "288": "I'm going to need that by Saturday: Purchase 100,000,000 Printers.",
+      "287": "Office Space: Purchase num:((10000000)) Printers.",
+      "288": "I'm going to need that by Saturday: Purchase num:((100000000)) Printers.",
       "289": "If you could do that, it'd be greaaaat: Purchase 5 Billion Printers.",
-      "290": "Mint Condition: Purchase 100,000,000 Coin Mints.",
+      "290": "Mint Condition: Purchase num:((100000000)) Coin Mints.",
       "291": "Chocolate Mints, anyone?: Purchase 1 Billion Coin Mints.",
       "292": "A good clean feeling, no matter what: Purchase 20 Billion Coin Mints.",
       "293": "Alpha Regeneration: Create 1 Billion Alchemies.",
       "294": "Citrinitas Synthesis: Create 20 Billion Alchemies.",
       "295": "The Philosopher's Stone: Create 1 Trillion Alchemies.",
-      "296": "Prestige...?: Prestige for at least 1e10,000,000 Diamonds.",
-      "297": "Shine bright like a ...: Prestige for at least 1e10,000,000,000 [1e1e10] Diamonds.",
-      "298": "Diamonds are forever: Prestige for at least 1e10,000,000,000,000 [1e1e13] Diamonds.",
-      "299": "Transcend...?: Transcend for at least 1e2,500,000 Mythos.",
-      "300": "Mythos is not really a good name: Transcend for at least 1e2,500,000,000 [1e2.5e9] Mythos.",
-      "301": "Too Transcendent: Transcend for at least 1e2,500,000,000,000 [1e2.5e12] Mythos.",
-      "302": "Reincarnate...?: Reincarnate for at least 1e100,000 Particles.",
-      "303": "One Hundred Million Dollars.: Reincarnate for at least 1e100,000,000 [1e1e8] Particles.",
-      "304": "12 figure log-salary: Reincarnate for at least 1e100,000,000,000 [1e1e11] Particles.",
-      "305": "Mononucleic: Clear [No Multiplier] 1,000 times.",
-      "306": "Solo Leveled: Clear [No Multiplier] 9,000 times.",
-      "307": "Power of One: Clear [No Multiplier] 9,001 times.",
-      "308": "TREE^-1(n): Clear [No Accelerators] 1,000 times.",
-      "309": "TREE^-1(TREE^-1(n)): Clear [No Accelerators] 9,000 times.",
-      "310": "O(1): Clear [No Accelerators] 9,001 times.",
-      "311": "I saw this in a movie once: Clear [No Shards] 1,000 times.",
-      "312": "Achievement 312: Clear [No Shards] 9,000 times.",
-      "313": "Achievement 313: Clear [No Shards] 9,001 times.",
-      "314": "The consequences of economy: Clear [Cost+] 1,000 times.",
-      "315": "Have been a disaster: Clear [Cost+] 9,000 times.",
-      "316": "For the ant race: Clear [Cost+] 9,001 times.",
-      "317": "491 karats: Clear [Reduced Diamonds] 1,000 times.",
-      "318": "Lab-shrunk diamonds: Clear [Reduced Diamonds] 9,000 times.",
-      "319": "Diamond is not breakable: Clear [Reduced Diamonds] 9,001 times.",
+      "296": "Prestige...?: Prestige for at least num:((1e10000000)) Diamonds.",
+      "297": "Shine bright like a ...: Prestige for at least num:((1e10000000000)) Diamonds.",
+      "298": "Diamonds are forever: Prestige for at least num:((1e10000000000000)) Diamonds.",
+      "299": "Transcend...?: Transcend for at least num:((1e2500000)) Mythos.",
+      "300": "Mythos is not really a good name: Transcend for at least num:((1e2500000000)) Mythos.",
+      "301": "Too Transcendent: Transcend for at least num:((1e2500000000000)) Mythos.",
+      "302": "Reincarnate...?: Reincarnate for at least num:((1e100000)) Particles.",
+      "303": "One Hundred Million Dollars.: Reincarnate for at least num:((1e100000000)) Particles.",
+      "304": "12 figure log-salary: Reincarnate for at least num:((1e100000000000)) Particles.",
+      "305": "Mononucleic: Clear [No Multiplier] num:((1000)) times.",
+      "306": "Solo Leveled: Clear [No Multiplier] num:((9000)) times.",
+      "307": "Power of One: Clear [No Multiplier] num:((9001)) times.",
+      "308": "TREE^-1(n): Clear [No Accelerators] num:((1000)) times.",
+      "309": "TREE^-1(TREE^-1(n)): Clear [No Accelerators] num:((9000)) times.",
+      "310": "O(1): Clear [No Accelerators] num:((9001)) times.",
+      "311": "I saw this in a movie once: Clear [No Shards] num:((1000)) times.",
+      "312": "Achievement 312: Clear [No Shards] num:((9000)) times.",
+      "313": "Achievement 313: Clear [No Shards] num:((9001)) times.",
+      "314": "The consequences of economy: Clear [Cost+] num:((1000)) times.",
+      "315": "Have been a disaster: Clear [Cost+] num:((9000)) times.",
+      "316": "For the ant race: Clear [Cost+] num:((9001)) times.",
+      "317": "491 karats: Clear [Reduced Diamonds] num:((1000)) times.",
+      "318": "Lab-shrunk diamonds: Clear [Reduced Diamonds] num:((9000)) times.",
+      "319": "Diamond is not breakable: Clear [Reduced Diamonds] num:((9001)) times.",
       "320": "Tariffs: Clear {[Tax+]} 40 times.",
       "321": "Council Taxes: Clear {[Tax+]} 80 times.",
       "322": "Death and Taxes: Clear {[Tax+]} 120 times.",
@@ -733,33 +733,33 @@
       "332": "The ender of the universe: Clear {[Sadistic I]} 40 times.",
       "333": "The endest of the universe: Clear {[Sadistic I]} 80 times.",
       "334": "The more endest of the universe: Clear {[Sadistic I]} 140 times.",
-      "335": "I would go fast: Purchase 1,000,000 Accelerators",
-      "336": "The journey of 10,000,000 miles: Purchase 10,000,000 Accelerators",
-      "337": "Starts with a single mile: Purchase 100,000,000 Accelerators",
-      "338": "I think I'm a clone now: Purchase 3,000,000 Multipliers",
-      "339": "Variety platters: Purchase 30,000,000 Multipliers",
-      "340": "Every taste and talent: Purchase 300,000,000 Multipliers",
-      "341": "Booster Seats: Purchase 100,000 Accelerator Boosts",
-      "342": "A brief history of time: Purchase 1,000,000 Accelerator Boosts",
-      "343": "Vivace: Purchase 10,000,000 Accelerator Boosts",
-      "344": "A crumby achievement: Obtain 1e25,000 Galactic Crumbs.",
-      "345": "Get it? Crumbs?: Obtain 1e125,000 Galactic Crumbs.",
-      "346": "You clearly do: Obtain 1e1,000,000 Galactic Crumbs.",
-      "347": "Gordon Ramses: Reach 400,000 Immortal ELO.",
-      "348": "Wolfgang Pluck: Reach 1,500,000 Immortal ELO.",
-      "349": "Marco Pierre Blanco: Reach 5,000,000 Immortal ELO, and purchase a Tier IX Ant.",
-      "350": "Ascensions are suggestions: Ascend 1e16 times.",
-      "351": "Nothing promised, no regrets: Ascend 1e20 times.",
-      "352": "Immaculate Ascensions: Ascend 1e25 times.",
-      "353": "That's almost 100: Ascend 1e35 times.",
-      "354": "Here's another 95 AP: Ascend 1e50 times.",
-      "355": "Digital Ascension Enjoyer: Ascend 1e75 times.",
-      "356": "Let's name some more numbers: Achieve a constant of 1e2,000,000",
-      "357": "Threeve: Achieve a constant of 1e5,000,000",
-      "358": "Eleventy Billion: Achieve a constant of 1e10,000,000",
-      "359": "A number so unremarkable it becomes remarkable: Achieve a constant of 1e25,000,000",
-      "360": "I love large numbers: Achieve a constant of 1e50,000,000",
-      "361": "There are 10 Million Million Million...: Achieve a constant of 1e100,000,000",
+      "335": "I would go fast: Purchase num:((1000000)) Accelerators",
+      "336": "The journey of num:((10000000)) miles: Purchase num:((10000000)) Accelerators",
+      "337": "Starts with a single mile: Purchase num:((100000000)) Accelerators",
+      "338": "I think I'm a clone now: Purchase num:((3000000)) Multipliers",
+      "339": "Variety platters: Purchase num:((30000000)) Multipliers",
+      "340": "Every taste and talent: Purchase num:((300000000)) Multipliers",
+      "341": "Booster Seats: Purchase num:((100000)) Accelerator Boosts",
+      "342": "A brief history of time: Purchase num:((1000000)) Accelerator Boosts",
+      "343": "Vivace: Purchase num:((10000000)) Accelerator Boosts",
+      "344": "A crumby achievement: Obtain num:((1e25000)) Galactic Crumbs.",
+      "345": "Get it? Crumbs?: Obtain num:((1e125000)) Galactic Crumbs.",
+      "346": "You clearly do: Obtain num:((1e1000000)) Galactic Crumbs.",
+      "347": "Gordon Ramses: Reach num:((400000)) Immortal ELO.",
+      "348": "Wolfgang Pluck: Reach num:((1500000)) Immortal ELO.",
+      "349": "Marco Pierre Blanco: Reach num:((5000000)) Immortal ELO, and purchase a Tier IX Ant.",
+      "350": "Ascensions are suggestions: Ascend num:((1e16)) times.",
+      "351": "Nothing promised, no regrets: Ascend num:((1e20)) times.",
+      "352": "Immaculate Ascensions: Ascend num:((1e25)) times.",
+      "353": "That's almost 100: Ascend num:((1e35)) times.",
+      "354": "Here's another 95 AP: Ascend num:((1e50)) times.",
+      "355": "Digital Ascension Enjoyer: Ascend num:((1e75)) times.",
+      "356": "Let's name some more numbers: Achieve a constant of num:((1e2000000))",
+      "357": "Threeve: Achieve a constant of num:((1e5000000))",
+      "358": "Eleventy Billion: Achieve a constant of num:((1e10000000))",
+      "359": "A number so unremarkable it becomes remarkable: Achieve a constant of num:((1e25000000))",
+      "360": "I love large numbers: Achieve a constant of num:((1e50000000))",
+      "361": "There are 10 Million Million Million...: Achieve a constant of num:((1e100000000))",
       "362": "Ant-i Peace: Clear 'Reduced Ants' challenge 40 times.",
       "363": "The great Ant War of '25: Clear 'Reduced Ants' challenge 50 times.",
       "364": "Ambivalent to Life: Clear 'Reduced Ants' challenge 60 times.",
@@ -783,115 +783,115 @@
       "382": "Quick to be square: Level your Speed Blessing to 200.",
       "383": "400 Newtons: Level your Speed Blessing to 400.",
       "384": "800 Newtons: Level your Speed Blessing to 800.",
-      "385": "Going at the speed of now: Level your Speed Blessing to 1,000.",
-      "386": "Short-term long-term: Level your Speed Blessing to 1,200.",
-      "387": "Chasing shadows: Level your Speed Blessing to 1,500.",
-      "388": "The immaculate sacrifice: Level your Speed Blessing to 2,000.",
+      "385": "Going at the speed of now: Level your Speed Blessing to num:((1000)).",
+      "386": "Short-term long-term: Level your Speed Blessing to num:((1200)).",
+      "387": "Chasing shadows: Level your Speed Blessing to num:((1500)).",
+      "388": "The immaculate sacrifice: Level your Speed Blessing to num:((2000)).",
       "389": "Spirit IV: Level your Speed Spirit to 160.",
       "390": "Spirit V: Level your Speed Spirit to 320.",
       "391": "Spirit VI: Level your Speed Spirit to 640.",
       "392": "Spirit VII: Level your Speed Spirit to 960.",
-      "393": "Spirit VIII: Level your Speed Spirit to 1,280.",
-      "394": "Spirit IX: Level your Speed Spirit to 1,600.",
-      "395": "Spirit X: Level your Speed Spirit to 2,000.",
+      "393": "Spirit VIII: Level your Speed Spirit to num:((1280)).",
+      "394": "Spirit IX: Level your Speed Spirit to num:((1600)).",
+      "395": "Spirit X: Level your Speed Spirit to num:((2000)).",
       "396": "A minor sacrifice: Level your Speed Rune to 100.",
       "397": "A snack for the gods: Level your Speed Rune to 250.",
       "398": "For your consideration: Level your Speed Rune to 500.",
-      "399": "Hints of shine in these rocks: Level your Speed Rune to 1,000.",
-      "400": "Like throwing offerings into a fire: Level your Speed Rune to 2,000.",
-      "401": "Atlas Shirked: Level your Speed Rune to 5,000.",
-      "402": "Platonic Sacrifice: Level your Speed Rune to 10,000.",
-      "403": "Boots of power: Level your Speed Rune to 20,000.",
-      "404": "An amount of Offerings you cannot fathom: Level your Speed Rune to 50,000.",
-      "405": "Salvaged to oblivion: Level your Speed Rune to 100,000.",
-      "406": "Level 98 Runecrafting: Level your Speed Rune to 200,000.",
-      "407": "Level 99 Runecrafting: Level your Speed Rune to 300,000.",
-      "408": "Halfway to cap: Level your Speed Rune to 500,000",
-      "409": "Just kidding, there is no cap: Level your Speed Rune to 750,000.",
-      "410": "I want to be a millionaire: Level your Speed Rune to 1,000,000.",
+      "399": "Hints of shine in these rocks: Level your Speed Rune to num:((1000)).",
+      "400": "Like throwing offerings into a fire: Level your Speed Rune to num:((2000)).",
+      "401": "Atlas Shirked: Level your Speed Rune to num:((5000)).",
+      "402": "Platonic Sacrifice: Level your Speed Rune to num:((10000)).",
+      "403": "Boots of power: Level your Speed Rune to num:((20000)).",
+      "404": "An amount of Offerings you cannot fathom: Level your Speed Rune to num:((50000)).",
+      "405": "Salvaged to oblivion: Level your Speed Rune to num:((100000)).",
+      "406": "Level 98 Runecrafting: Level your Speed Rune to num:((200000)).",
+      "407": "Level 99 Runecrafting: Level your Speed Rune to num:((300000)).",
+      "408": "Halfway to cap: Level your Speed Rune to num:((500000))",
+      "409": "Just kidding, there is no cap: Level your Speed Rune to num:((750000)).",
+      "410": "I want to be a millionaire: Level your Speed Rune to num:((1000000)).",
       "411": "Simulated Tithe: Obtain 10 free levels of the Speed Rune.",
       "412": "Simulated Tithe II: Obtain 40 free levels of the Speed Rune.",
       "413": "Simulated Tithe III: Obtain 125 free levels of the Speed Rune.",
       "414": "Simulated Tithe IV: Obtain 250 free levels of the Speed Rune.",
       "415": "Simulated Tithe V: Obtain 500 free levels of the Speed Rune.",
-      "416": "Simulated Tithe VI: Obtain 1,000 free levels of the Speed Rune.",
-      "417": "Simulated Tithe VII: Obtain 2,000 free levels of the Speed Rune.",
-      "418": "Simulated Tithe VIII: Obtain 4,000 free levels of the Speed Rune.",
-      "419": "Simulated Tithe IX: Obtain 7,500 free levels of the Speed Rune.",
-      "420": "Simulated Tithe X: Obtain 12,500 free levels of the Speed Rune.",
-      "421": "Simulated Tithe XI: Obtain 25,000 free levels of the Speed Rune.",
-      "422": "Simulated Tithe XII: Obtain 37,500 free levels of the Speed Rune.",
-      "423": "Simulated Tithe XIII: Obtain 50,000 free levels of the Speed Rune.",
-      "424": "Simulated Tithe XIV: Obtain 75,000 free levels of the Speed Rune.",
-      "425": "God needs better names: Obtain 100,000 free levels of the Speed Rune.",
+      "416": "Simulated Tithe VI: Obtain num:((1000)) free levels of the Speed Rune.",
+      "417": "Simulated Tithe VII: Obtain num:((2000)) free levels of the Speed Rune.",
+      "418": "Simulated Tithe VIII: Obtain num:((4000)) free levels of the Speed Rune.",
+      "419": "Simulated Tithe IX: Obtain num:((7500)) free levels of the Speed Rune.",
+      "420": "Simulated Tithe X: Obtain num:((12500)) free levels of the Speed Rune.",
+      "421": "Simulated Tithe XI: Obtain num:((25000)) free levels of the Speed Rune.",
+      "422": "Simulated Tithe XII: Obtain num:((37500)) free levels of the Speed Rune.",
+      "423": "Simulated Tithe XIII: Obtain num:((50000)) free levels of the Speed Rune.",
+      "424": "Simulated Tithe XIV: Obtain num:((75000)) free levels of the Speed Rune.",
+      "425": "God needs better names: Obtain num:((100000)) free levels of the Speed Rune.",
       "426": "Proof of Work: Gain 10 Campaign Tokens from Campaigns.",
       "427": "Insert tokens: Gain 20 Campaign Tokens from Campaigns.",
       "428": "Novice Corruptor: Gain 40 Campaign Tokens from Campaigns.",
       "429": "A Roll of Campaign Tokens: Gain 80 Campaign Tokens from Campaigns.",
       "430": "Relative Campaign Expert: Gain 160 Campaign Tokens from Campaigns.",
       "431": "Five Stacks: Gain 320 Campaign Tokens from Campaigns.",
-      "432": "Thousandaire: Gain 1,000 Campaign Tokens from Campaigns.",
-      "433": "Question 6 of a possible 15: Gain 2,000 Campaign Tokens from Campaigns.",
-      "434": "Platonic Campaigns: Gain 4,000 Campaign Tokens from Campaigns.",
-      "435": "Campaign Master: Gain 9,000 Campaign Tokens from Campaigns.",
+      "432": "Thousandaire: Gain num:((1000)) Campaign Tokens from Campaigns.",
+      "433": "Question 6 of a possible 15: Gain num:((2000)) Campaign Tokens from Campaigns.",
+      "434": "Platonic Campaigns: Gain num:((4000)) Campaign Tokens from Campaigns.",
+      "435": "Campaign Master: Gain num:((9000)) Campaign Tokens from Campaigns.",
       "436": "Baby's first Prestige: Prestige for the first time.",
       "437": "Ten Reputation: Prestige 10 times.",
       "438": "Duplicating yourself: Prestige 100 times.",
-      "439": "Number? Go UP!: Prestige 1,000 times.",
-      "440": "Pretend to be a god: Prestige 10,000 times.",
-      "441": "The now-idolized: Prestige 100,000 times.",
-      "442": "One. Million. Prestige.: Prestige 1,000,000 times.",
-      "443": "Powers of Ten: Prestige 10,000,000 times.",
-      "444": "Now that's what I call Prestige!: Prestige 100,000,000 times.",
-      "445": "Billionaire I: Prestige 1,000,000,000 times.",
-      "446": "Powers of a Hundred: Prestige 100,000,000,000 times.",
-      "447": "Numbers as large as they are wide: Prestige 10,000,000,000,000 times.",
-      "448": "That's a quadrillion to you: Prestige 1e15 times.",
-      "449": "Prestige ad nauseum: Prestige 1e17 times.",
-      "450": "Prestige so Prestigious, it becomes ordinary: Prestige 1e20 times.",
+      "439": "Number? Go UP!: Prestige num:((1000)) times.",
+      "440": "Pretend to be a god: Prestige num:((10000)) times.",
+      "441": "The now-idolized: Prestige num:((100000)) times.",
+      "442": "One. Million. Prestige.: Prestige num:((1000000)) times.",
+      "443": "Powers of Ten: Prestige num:((10000000)) times.",
+      "444": "Now that's what I call Prestige!: Prestige num:((100000000)) times.",
+      "445": "Billionaire I: Prestige num:((1000000000)) times.",
+      "446": "Powers of a Hundred: Prestige num:((100000000000)) times.",
+      "447": "Numbers as large as they are wide: Prestige num:((10000000000000)) times.",
+      "448": "That's a quadrillion to you: Prestige num:((1e15)) times.",
+      "449": "Prestige ad nauseum: Prestige num:((1e17)) times.",
+      "450": "Prestige so Prestigious, it becomes ordinary: Prestige num:((1e20)) times.",
       "451": "Transcendental: Transcend for the first time.",
       "452": "Ten degrees of separation: Transcend 10 times.",
       "453": "Polychroma: Transcend 100 times.",
-      "454": "Absent further instructions: Transcend 1,000 times.",
-      "455": "The visage of godliness: Transcend 10,000 times.",
-      "456": "Post-human: Transcend 100,000 times.",
-      "457": "The Million Transcension Man: Transcend 1,000,000 times.",
-      "458": "Why not another?: Transcend 10,000,000 times.",
-      "459": "The average AI Salary in 2025: Transcend 100,000,000 times.",
-      "460": "Billionaire II: Transcend 1,000,000,000 times.",
-      "461": "Powers of thirty: Transcend 30,000,000,000 times.",
-      "462": "Wheel turning round and round: Transcend 900,000,000,000 times.",
-      "463": "The pursuit of numbers: Transcend 2.7e13 times.",
-      "464": "42 Achievement Points: Transcend 8.1e14 times.",
-      "465": "How to Transcend your Dragon: Transcend 1e17 times.",
+      "454": "Absent further instructions: Transcend num:((1000)) times.",
+      "455": "The visage of godliness: Transcend num:((10000)) times.",
+      "456": "Post-human: Transcend num:((100000)) times.",
+      "457": "The Million Transcension Man: Transcend num:((1000000)) times.",
+      "458": "Why not another?: Transcend num:((10000000)) times.",
+      "459": "The average AI Salary in 2025: Transcend num:((100000000)) times.",
+      "460": "Billionaire II: Transcend num:((1000000000)) times.",
+      "461": "Powers of thirty: Transcend num:((30000000000)) times.",
+      "462": "Wheel turning round and round: Transcend num:((900000000000)) times.",
+      "463": "The pursuit of numbers: Transcend num:((2.7e13)) times.",
+      "464": "42 Achievement Points: Transcend num:((8.1e14)) times.",
+      "465": "How to Transcend your Dragon: Transcend num:((1e17)) times.",
       "466": "Particle Man: Reincarnate for the first time.",
       "467": "Some giants, possibly: Reincarnate 10 times.",
       "468": "Atomic Discounts: Reincarnate 100 times.",
-      "469": "The nuclear option: Reincarnate 1,000 times.",
-      "470": "Reinvent yourself: Reincarnate 10,000 times.",
-      "471": "Your mind is software: Reincarnate 100,000 times.",
-      "472": "Bioethical: Reincarnate 1,000,000 times.",
-      "473": "Can you count to 10 million: Reincarnate 10,000,000 times.",
-      "474": "Reincarnated Grandmas... wait: Reincarnate 100,000,000 times.",
-      "475": "Billionaire III: Reincarnate 1,000,000,000 times.",
-      "476": "Out of bodies: Reincarnate 8,000,000,000 times",
-      "477": "Become the unsmith: Reincarnate 100,000,000,000 times.",
-      "478": "One trillion reincarnations later: Reincarnate 1,000,000,000,000 times.",
-      "479": "Log-triskaidekaphobia: Reincarnate 13,131,313,131,313 times.",
-      "480": "M2: Reincarnate 2e14 times.",
+      "469": "The nuclear option: Reincarnate num:((1000)) times.",
+      "470": "Reinvent yourself: Reincarnate num:((10000)) times.",
+      "471": "Your mind is software: Reincarnate num:((100000)) times.",
+      "472": "Bioethical: Reincarnate num:((1000000)) times.",
+      "473": "Can you count to 10 million: Reincarnate num:((10000000)) times.",
+      "474": "Reincarnated Grandmas... wait: Reincarnate num:((100000000)) times.",
+      "475": "Billionaire III: Reincarnate num:((1000000000)) times.",
+      "476": "Out of bodies: Reincarnate num:((8000000000)) times",
+      "477": "Become the unsmith: Reincarnate num:((100000000000)) times.",
+      "478": "One trillion reincarnations later: Reincarnate num:((1000000000000)) times.",
+      "479": "Log-triskaidekaphobia: Reincarnate num:((13131313131313)) times.",
+      "480": "M2: Reincarnate num:((2e14)) times.",
       "481": "The Sacrificial Ant: Sacrifice your Anthill once.",
       "482": "Building back better: Sacrifice your Anthill 10 times.",
       "483": "A feast for a god: Sacrifice your Anthill 50 times.",
       "484": "Quartering: Sacrifice your Anthill 250 times.",
-      "485": "Blemished Altar: Sacrifice your Anthill 1,250 times.",
-      "486": "Formicae Caedem: Sacrifice your Anthill 5,000 times.",
-      "487": "King of Kings: Sacrifice your Anthill 20,000 times.",
-      "488": "Lord of Lords: Sacrifice your Anthill 80,000 times.",
-      "489": "Why are we here?: Sacrifice your Anthill 250,000 times.",
-      "490": "Just to suffer?: Sacrifice your Anthill 1,000,000 times.",
-      "491": "Scorched Earth: Sacrifice your Anthill 3,000,000 times.",
-      "492": "It's so clear that all we have now: Sacrifice your Anthill 10,000,000 times.",
-      "493": "Are our thoughts of yesterday: Sacrifice your Anthill 100,000,000 times.",
+      "485": "Blemished Altar: Sacrifice your Anthill num:((1250)) times.",
+      "486": "Formicae Caedem: Sacrifice your Anthill num:((5000)) times.",
+      "487": "King of Kings: Sacrifice your Anthill num:((20000)) times.",
+      "488": "Lord of Lords: Sacrifice your Anthill num:((80000)) times.",
+      "489": "Why are we here?: Sacrifice your Anthill num:((250000)) times.",
+      "490": "Just to suffer?: Sacrifice your Anthill num:((1000000)) times.",
+      "491": "Scorched Earth: Sacrifice your Anthill num:((3000000)) times.",
+      "492": "It's so clear that all we have now: Sacrifice your Anthill num:((10000000)) times.",
+      "493": "Are our thoughts of yesterday: Sacrifice your Anthill num:((100000000)) times.",
       "494": "Elementary Math: Use Code 'add' 10 times.",
       "495": "It adds up: Use Code 'add' 20 times.",
       "496": "The power of addition: Use Code 'add' 50 times.",
@@ -900,17 +900,17 @@
       "499": "Triplet act: Use Code 'add' 300 times.",
       "500": "Half a thousand Achievements!: Use Code 'add' 500 times.",
       "501": "A Numerical Calculation: Use Code 'add' 750 times.",
-      "502": "Succ it in, succ it in, succ it in: Use Code 'add' 1,000 times.",
-      "503": "If you're Rin Tin Tin, or Anne Boleyn: Use Code 'add' 2,000 times.",
-      "504": "It's so PC it's killing me: Use Code 'add' 3,000 times.",
-      "505": "V bar: Use Code 'add' 5,000 times.",
-      "506": "Make a Desperate Move: Use Code 'add' 6,000 times.",
-      "507": "Or Else You'll Win: Use Code 'add' 7,500 times.",
-      "508": "The Hook Brings Me Back: Use Code 'add' 10,000 times."
+      "502": "Succ it in, succ it in, succ it in: Use Code 'add' num:((1000)) times.",
+      "503": "If you're Rin Tin Tin, or Anne Boleyn: Use Code 'add' num:((2000)) times.",
+      "504": "It's so PC it's killing me: Use Code 'add' num:((3000)) times.",
+      "505": "V bar: Use Code 'add' num:((5000)) times.",
+      "506": "Make a Desperate Move: Use Code 'add' num:((6000)) times.",
+      "507": "Or Else You'll Win: Use Code 'add' num:((7500)) times.",
+      "508": "The Hook Brings Me Back: Use Code 'add' num:((10000)) times."
     },
     "achievementRewards": {
       "3": {
-        "acceleratorPower": "+0.1% Accelerator Power"
+        "acceleratorPower": "+num:((0.1))% Accelerator Power"
       },
       "4": {
         "workerAutobuyer": "Start with the Worker Autobuyer unlocked!"
@@ -919,13 +919,13 @@
         "accelerators": "+1 Free Accelerator per 500 Workers owned"
       },
       "6": {
-        "multipliers": "+1 Free Multiplier per 1,000 Workers owned"
+        "multipliers": "+1 Free Multiplier per num:((1000)) Workers owned"
       },
       "7": {
-        "accelBoosts": "+1 Free Accelerator Boost per 2,000 Workers owned"
+        "accelBoosts": "+1 Free Accelerator Boost per num:((2000)) Workers owned"
       },
       "10": {
-        "acceleratorPower": "+0.15% Accelerator Power"
+        "acceleratorPower": "+num:((0.15))% Accelerator Power"
       },
       "11": {
         "investmentAutobuyer": "Start with the Investment Autobuyer unlocked!"
@@ -934,13 +934,13 @@
         "accelerators": "+1 Free Accelerator per 500 Investments owned"
       },
       "13": {
-        "multipliers": "+1 Free Multiplier per 1,000 Investments owned"
+        "multipliers": "+1 Free Multiplier per num:((1000)) Investments owned"
       },
       "14": {
-        "accelBoosts": "+1 Free Accelerator Boost per 2,000 Investments owned"
+        "accelBoosts": "+1 Free Accelerator Boost per num:((2000)) Investments owned"
       },
       "17": {
-        "acceleratorPower": "+0.2% Accelerator Power"
+        "acceleratorPower": "+num:((0.2))% Accelerator Power"
       },
       "18": {
         "printerAutobuyer": "Start with the Printer Autobuyer unlocked!"
@@ -949,13 +949,13 @@
         "accelerators": "+1 Free Accelerator per 500 Printers owned"
       },
       "20": {
-        "multipliers": "+1 Free Multiplier per 1,000 Printers owned"
+        "multipliers": "+1 Free Multiplier per num:((1000)) Printers owned"
       },
       "21": {
-        "accelBoosts": "+1 Free Accelerator Boost per 2,000 Printers owned"
+        "accelBoosts": "+1 Free Accelerator Boost per num:((2000)) Printers owned"
       },
       "24": {
-        "acceleratorPower": "+0.2% Accelerator Power"
+        "acceleratorPower": "+num:((0.2))% Accelerator Power"
       },
       "25": {
         "mintAutobuyer": "Start with the Mint Autobuyer unlocked!"
@@ -964,13 +964,13 @@
         "accelerators": "+1 Free Accelerator per 500 Coin Mints owned"
       },
       "27": {
-        "multipliers": "+1 Free Multiplier per 1,000 Coin Mints owned"
+        "multipliers": "+1 Free Multiplier per num:((1000)) Coin Mints owned"
       },
       "28": {
-        "accelBoosts": "+1 Free Accelerator Boost per 2,000 Coin Mints owned"
+        "accelBoosts": "+1 Free Accelerator Boost per num:((2000)) Coin Mints owned"
       },
       "31": {
-        "acceleratorPower": "+0.3% Accelerator Power"
+        "acceleratorPower": "+num:((0.3))% Accelerator Power"
       },
       "32": {
         "alchemyAutobuyer": "Start with the Alchemy Autobuyer unlocked!"
@@ -979,10 +979,10 @@
         "accelerators": "+1 Free Accelerator per 500 Alchemies owned"
       },
       "34": {
-        "multipliers": "+1 Free Multiplier per 1,000 Alchemies owned"
+        "multipliers": "+1 Free Multiplier per num:((1000)) Alchemies owned"
       },
       "35": {
-        "accelBoosts": "+1 Free Accelerator Boost per 2,000 Alchemies owned"
+        "accelBoosts": "+1 Free Accelerator Boost per num:((2000)) Alchemies owned"
       },
       "36": {
         "offeringPrestigeTimer": "Prestige gives more Offerings based on time spent! (+100% per 10 seconds)"
@@ -1012,7 +1012,7 @@
         "particleGain": "Permanently double your Particle Gain!"
       },
       "53": {
-        "multiplicativeObtainium": "Obtainium gain is increased by +0.125% for each Rune level"
+        "multiplicativeObtainium": "Obtainium gain is increased by +num:((0.125))% for each Rune level"
       },
       "57": {
         "multipliers": "+1 free Multiplier"
@@ -1067,7 +1067,7 @@
         "taxReduction": "Tax scaling reduced by 4%"
       },
       "84": {
-        "multiplicativeObtainium": "Obtainium x1.05"
+        "multiplicativeObtainium": "Obtainium xnum:((1.05))"
       },
       "85": {
         "coalPlantAutobuy": "Unlock the Coal Plant Autobuyer!"
@@ -1083,7 +1083,7 @@
         "taxReduction": "Tax scaling reduced by 4%"
       },
       "91": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "92": {
         "coalRigAutobuy": "Unlock the Coal Rig Autobuyer!"
@@ -1098,7 +1098,7 @@
         "taxReduction": "Tax scaling reduced by 4%"
       },
       "98": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "99": {
         "pickaxeAutobuy": "Unlock the Pickaxe Autobuyer!"
@@ -1116,7 +1116,7 @@
         "taxReduction": "Tax scaling reduced by 4%"
       },
       "105": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "106": {
         "pandorasBoxAutobuy": "Unlock the Pandora's Box Autobuyer!"
@@ -1131,7 +1131,7 @@
         "taxReduction": "Tax scaling reduced by 4%"
       },
       "112": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "115": {
         "salvage": "+5 Salvage"
@@ -1140,7 +1140,7 @@
         "taxReduction": "Tax scaling reduced by 5%"
       },
       "118": {
-        "taxReduction": "Tax scaling reduced by 0.5% per Reincarnation Challenge clear (multiplicative)"
+        "taxReduction": "Tax scaling reduced by num:((0.5))% per Reincarnation Challenge clear (multiplicative)"
       },
       "119": {
         "exemptionTalisman": "Unlock the Exemption Talisman!"
@@ -1155,7 +1155,7 @@
         "taxReduction": "Tax scaling reduced by 5%"
       },
       "125": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "126": {
         "chronosTalisman": "Unlock the Chronos Talisman!"
@@ -1171,7 +1171,7 @@
         "taxReduction": "Tax scaling reduced by 5%"
       },
       "132": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "133": {
         "midasTalisman": "Unlock the Midas Talisman!"
@@ -1189,11 +1189,11 @@
         "salvage": "+7 Salvage"
       },
       "137": {
-        "sacrificeMult": "x1.25 Sacrifice Rewards!",
+        "sacrificeMult": "xnum:((1.25)) Sacrifice Rewards!",
         "experientiaAutobuy": "Unlock the <i>Experientia</i> Ant Upgrade Autobuyer!"
       },
       "139": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "140": {
         "metaphysicsTalisman": "Unlock the Metaphysics Talisman!"
@@ -1205,13 +1205,13 @@
         "salvage": "+7 Salvage"
       },
       "144": {
-        "talismanPower": "+2.5% Talisman Power"
+        "talismanPower": "+num:((2.5))% Talisman Power"
       },
       "145": {
-        "talismanPower": "+2.5% Talisman Power"
+        "talismanPower": "+num:((2.5))% Talisman Power"
       },
       "146": {
-        "multiplicativeObtainium": "Obtainium gain x1.05"
+        "multiplicativeObtainium": "Obtainium gain xnum:((1.05))"
       },
       "147": {
         "polymathTalisman": "Unlock the Polymath Talisman!"
@@ -1250,18 +1250,18 @@
         "antSpeed": "Ant Speed is multiplied by logarithm of Galactic Crumbs"
       },
       "171": {
-        "antSpeed": "Ant Speed x1.2"
+        "antSpeed": "Ant Speed xnum:((1.2))"
       },
       "172": {
-        "antSpeed": "Ant Speed x1.25"
+        "antSpeed": "Ant Speed xnum:((1.25))"
       },
       "173": {
-        "antSpeed": "Ant Speed x1.4",
+        "antSpeed": "Ant Speed xnum:((1.4))",
         "antSacrificeUnlock": "Unlock Ant Sacrifice!",
         "antAutobuyers": "Unlock an Ant Autobuyer!"
       },
       "174": {
-        "antSpeed": "+0.1% Ant Speed per Immortal ELO!",
+        "antSpeed": "+num:((0.1))% Ant Speed per Immortal ELO!",
         "scientiaAutobuy": "Unlock the <i>Scientia</i> Ant Upgrade Autobuyer!"
       },
       "176": {
@@ -1314,30 +1314,30 @@
         "wowCubeGain": "Cube gain multiplier based on Ascension Count"
       },
       "193": {
-        "wowCubeGain": "Gain more Cubes based on your Constant [+0.25% per digit of Constant]"
+        "wowCubeGain": "Gain more Cubes based on your Constant [+num:((0.25))% per digit of Constant]"
       },
       "195": {
-        "wowCubeGain": "Gain more Cubes based on your Constant [up to x250 at 1e100,000 Constant]",
-        "wowTesseractGain": "Gain more Tesseracts based on your Constant [up to x250 at 1e100,000 Constant]"
+        "wowCubeGain": "Gain more Cubes based on your Constant [up to x250 at num:((1e100000)) Constant]",
+        "wowTesseractGain": "Gain more Tesseracts based on your Constant [up to x250 at num:((1e100000)) Constant]"
       },
       "196": {
-        "wowPlatonicGain": "Gain more Platonic Cubes based on your Constant [up to x20 at 1e100,000 Constant]"
+        "wowPlatonicGain": "Gain more Platonic Cubes based on your Constant [up to x20 at num:((1e100000)) Constant]"
       },
       "197": {
         "statTracker": "Unlock a Stat Tracker at the top of your screen!",
         "tesseractUnlock": "Unlock gaining Tesseracts from Ascending!"
       },
       "198": {
-        "wowCubeGain": "Cube gain x1.02"
+        "wowCubeGain": "Cube gain xnum:((1.02))"
       },
       "199": {
-        "wowCubeGain": "Cube gain x1.02"
+        "wowCubeGain": "Cube gain xnum:((1.02))"
       },
       "200": {
-        "wowCubeGain": "Cube gain x1.02"
+        "wowCubeGain": "Cube gain xnum:((1.02))"
       },
       "201": {
-        "wowCubeGain": "Cube gain x1.02"
+        "wowCubeGain": "Cube gain xnum:((1.02))"
       },
       "202": {
         "ascensionCountAdditive": "Add +2 Base Ascension Count per second of Ascension time"
@@ -1350,16 +1350,16 @@
         "spiritUnlock": "Unlock Spirits, in the Runes tab!"
       },
       "205": {
-        "wowTesseractGain": "Tesseract gain x1.02"
+        "wowTesseractGain": "Tesseract gain xnum:((1.02))"
       },
       "206": {
-        "wowTesseractGain": "Tesseract gain x1.02"
+        "wowTesseractGain": "Tesseract gain xnum:((1.02))"
       },
       "207": {
-        "wowTesseractGain": "Tesseract gain x1.02"
+        "wowTesseractGain": "Tesseract gain xnum:((1.02))"
       },
       "208": {
-        "wowTesseractGain": "Tesseract gain x1.02"
+        "wowTesseractGain": "Tesseract gain xnum:((1.02))"
       },
       "209": {
         "ascensionCountAdditive": "Add +2 Base Ascension Count per second of Ascension time"
@@ -1368,20 +1368,20 @@
         "talismanPower": "+1% Talisman Power"
       },
       "211": {
-        "wowHypercubeGain": "Hypercube gain x1.05",
+        "wowHypercubeGain": "Hypercube gain xnum:((1.05))",
         "hypercubeUnlock": "Unlock gaining Hypercubes from Ascending!"
       },
       "212": {
-        "wowHypercubeGain": "Hypercube gain x1.02"
+        "wowHypercubeGain": "Hypercube gain xnum:((1.02))"
       },
       "213": {
-        "wowHypercubeGain": "Hypercube gain x1.02"
+        "wowHypercubeGain": "Hypercube gain xnum:((1.02))"
       },
       "214": {
-        "wowHypercubeGain": "Hypercube gain x1.02"
+        "wowHypercubeGain": "Hypercube gain xnum:((1.02))"
       },
       "215": {
-        "wowHypercubeGain": "Hypercube gain x1.02"
+        "wowHypercubeGain": "Hypercube gain xnum:((1.02))"
       },
       "216": {
         "ascensionCountAdditive": "Add +2 Base Ascension Count per second of Ascension time"
@@ -1390,24 +1390,24 @@
         "talismanPower": "+1% Talisman Power"
       },
       "218": {
-        "wowPlatonicGain": "Platonic Cubes x1.05",
+        "wowPlatonicGain": "Platonic Cubes xnum:((1.05))",
         "platonicUnlock": "Unlock gaining Platonic Cubes from Ascending!"
       },
       "219": {
-        "wowPlatonicGain": "Platonic Cube gain x1.02"
+        "wowPlatonicGain": "Platonic Cube gain xnum:((1.02))"
       },
       "220": {
-        "wowPlatonicGain": "Platonic Cubes gain x1.02"
+        "wowPlatonicGain": "Platonic Cubes gain xnum:((1.02))"
       },
       "221": {
-        "wowPlatonicGain": "Platonic Cubes gain x1.02"
+        "wowPlatonicGain": "Platonic Cubes gain xnum:((1.02))"
       },
       "222": {
-        "wowPlatonicGain": "Platonic Cubes gain x1.02"
+        "wowPlatonicGain": "Platonic Cubes gain xnum:((1.02))"
       },
       "223": {
         "ascensionCountAdditive": "Add +2 Base Ascension Count per second of Ascension time",
-        "wowPlatonicGain": "Gain more Platonic Cubes based on Ascension Count [up to x3 at 2.674e9 Ascension Count]"
+        "wowPlatonicGain": "Gain more Platonic Cubes based on Ascension Count [up to x3 at num:((2.674e9)) Ascension Count]"
       },
       "233": {
         "salvage": "+2 Salvage"
@@ -1419,77 +1419,77 @@
         "salvage": "+3 Salvage"
       },
       "240": {
-        "allCubeGain": "All Cube Gain x1.2"
+        "allCubeGain": "All Cube Gain xnum:((1.2))"
       },
       "245": {
         "salvage": "+3 Salvage"
       },
       "250": {
-        "allCubeGain": "All Cube Gain x1.05",
-        "multiplicativeObtainium": "Obtainium x1.1",
-        "multiplicativeOffering": "Offerings x1.5",
-        "quarkGain": "Quark Gain x1.05"
+        "allCubeGain": "All Cube Gain xnum:((1.05))",
+        "multiplicativeObtainium": "Obtainium xnum:((1.1))",
+        "multiplicativeOffering": "Offerings xnum:((1.5))",
+        "quarkGain": "Quark Gain xnum:((1.05))"
       },
       "251": {
-        "allCubeGain": "All Cube Gain x1.05",
-        "multiplicativeObtainium": "Obtainium x1.5",
-        "multiplicativeOffering": "Offerings x1.1",
-        "quarkGain": "Quark Gain x1.05"
+        "allCubeGain": "All Cube Gain xnum:((1.05))",
+        "multiplicativeObtainium": "Obtainium xnum:((1.5))",
+        "multiplicativeOffering": "Offerings xnum:((1.1))",
+        "quarkGain": "Quark Gain xnum:((1.05))"
       },
       "253": {
-        "wowHypercubeGain": "Hypercube gain x1.1"
+        "wowHypercubeGain": "Hypercube gain xnum:((1.1))"
       },
       "254": {
-        "wowCubeGain": "Cube gain x1.1"
+        "wowCubeGain": "Cube gain xnum:((1.1))"
       },
       "255": {
-        "wowTesseractGain": "Tesseract gain x1.1"
+        "wowTesseractGain": "Tesseract gain xnum:((1.1))"
       },
       "256": {
-        "wowPlatonicGain": "Platonic Cubes x1.1",
-        "overfluxConversionRate": "Overflux Powder conversion x1.05"
+        "wowPlatonicGain": "Platonic Cubes xnum:((1.1))",
+        "overfluxConversionRate": "Overflux Powder conversion xnum:((1.05))"
       },
       "257": {
-        "allCubeGain": "All Cube Gain x1.1",
-        "overfluxConversionRate": "Overflux Powder conversion x1.05"
+        "allCubeGain": "All Cube Gain xnum:((1.1))",
+        "overfluxConversionRate": "Overflux Powder conversion xnum:((1.05))"
       },
       "258": {
-        "wowHepteractGain": "Hepteract gain x1.1"
+        "wowHepteractGain": "Hepteract gain xnum:((1.1))"
       },
       "259": {
-        "ascensionScore": "Ascension Score multiplier based on Abyss Hepteract expansions [x1.01 per expansion]"
+        "ascensionScore": "Ascension Score multiplier based on Abyss Hepteract expansions [xnum:((1.01)) per expansion]"
       },
       "260": {
-        "ascensionCountMultiplier": "Ascension Count x1.1"
+        "ascensionCountMultiplier": "Ascension Count xnum:((1.1))"
       },
       "261": {
-        "ascensionCountMultiplier": "Ascension Count x1.1"
+        "ascensionCountMultiplier": "Ascension Count xnum:((1.1))"
       },
       "262": {
-        "allCubeGain": "All Cube Gain x1.1"
+        "allCubeGain": "All Cube Gain xnum:((1.1))"
       },
       "263": {
-        "allCubeGain": "All Cube Gain x1.1"
+        "allCubeGain": "All Cube Gain xnum:((1.1))"
       },
       "264": {
-        "allCubeGain": "All Cube Gain multiplier based on Ascension Count [up to x1.2 at 8e12 Ascension Count]"
+        "allCubeGain": "All Cube Gain multiplier based on Ascension Count [up to xnum:((1.2)) at num:((8e12)) Ascension Count]"
       },
       "265": {
-        "allCubeGain": "All Cube Gain multiplier based on Ascension Count [up to x1.2 at 1.6e14 Ascension Count]"
+        "allCubeGain": "All Cube Gain multiplier based on Ascension Count [up to xnum:((1.2)) at num:((1.6e14)) Ascension Count]"
       },
       "266": {
-        "quarkGain": "Quark gain multiplier based on Ascension Count [up to x1.1 at 1e15 Ascension Count]"
+        "quarkGain": "Quark gain multiplier based on Ascension Count [up to xnum:((1.1)) at num:((1e15)) Ascension Count]"
       },
       "267": {
-        "ascensionScore": "Ascension Score multiplier based on constants [up to x2 at 1e100,000 Constant]"
+        "ascensionScore": "Ascension Score multiplier based on constants [up to x2 at num:((1e100000)) Constant]"
       },
       "270": {
-        "wowHepteractGain": "Hepteract gain multiplier based on constants [up to x2 at 1e1,000,000 Constant]",
-        "constUpgrade1Buff": "Constant Upgrade 1 boosted to 1.06",
-        "constUpgrade2Buff": "Constant Upgrade 2 boosted to 1.11"
+        "wowHepteractGain": "Hepteract gain multiplier based on constants [up to x2 at num:((1e1000000)) Constant]",
+        "constUpgrade1Buff": "Constant Upgrade 1 boosted to num:((1.06))",
+        "constUpgrade2Buff": "Constant Upgrade 2 boosted to num:((1.11))"
       },
       "271": {
-        "platonicToHypercubes": "Platonic Cubes grant Hypercubes when opened [up to +1 at 1e1,000,000 Constant]"
+        "platonicToHypercubes": "Platonic Cubes grant Hypercubes when opened [up to +1 at num:((1e1000000)) Constant]"
       },
       "349": {
         "antAutobuyers": "Automatically buy HOLY SPIRIT OF ANT GOD Ants!"
@@ -1597,7 +1597,7 @@
         "reincarnationToTranscend": "For each Reincarnation Count you gain, you get 1 Transcension Count (subject to Transcension Count multipliers)"
       },
       "459": {
-        "reincarnationCountMultiplier": "Gain up to 4x the Reincarnation Count based on your Prestige Timer (maxes at 1,000s)"
+        "reincarnationCountMultiplier": "Gain up to 4x the Reincarnation Count based on your Prestige Timer (maxes at num:((1000))s)"
       },
       "467": {
         "reincarnationCountMultiplier": "Gain +100% more Reincarnation Count per digit in your Reincarnation Count (additive)!"
@@ -1609,8 +1609,8 @@
         "thriftRuneUnlock": "Permanently unlock the Thrift Rune!"
       },
       "474": {
-        "prestigeCountMultiplier": "Gain up to 4x the Prestige Count based on your Prestige Timer (maxes at 1,000,000s)",
-        "ascensionCountMultiplier": "Gain up to 1.25x the Ascension Count based on your Ascension Timer (maxes at 1,000,000s)"
+        "prestigeCountMultiplier": "Gain up to 4x the Prestige Count based on your Prestige Timer (maxes at num:((1000000))s)",
+        "ascensionCountMultiplier": "Gain up to num:((1.25))x the Ascension Count based on your Ascension Timer (maxes at num:((1000000))s)"
       },
       "481": {
         "freeAntUpgrades": "Gain +1 free Ant Upgrade level!"
@@ -1644,28 +1644,28 @@
       "3": "Gain +.10% to Accelerator Power.",
       "4": "Start Transcensions/Challenges with Worker Autobuyer unlocked.",
       "5": "Gain +1 Accelerator per 500 Workers owned.",
-      "6": "Gain +1 Multiplier per 1,000 Workers owned.",
-      "7": "Gain +1 Accelerator Boost per 2,000 workers owned.",
+      "6": "Gain +1 Multiplier per num:((1000)) Workers owned.",
+      "7": "Gain +1 Accelerator Boost per num:((2000)) workers owned.",
       "10": "Gain +.15% to Accelerator Power.",
       "11": "Start Transcensions/Challenges with Investment Autobuyer unlocked.",
       "12": "Gain +1 Accelerator per 500 Investments owned.",
-      "13": "Gain +1 Multiplier per 1,000 Investments owned.",
-      "14": "Gain +1 Accelerator Boost per 2,000 Investments owned.",
+      "13": "Gain +1 Multiplier per num:((1000)) Investments owned.",
+      "14": "Gain +1 Accelerator Boost per num:((2000)) Investments owned.",
       "17": "Gain +.20% to Accelerator Power.",
       "18": "Start Transcensions/Challenges with Printer Autobuyer unlocked.",
       "19": "Gain +1 Accelerator per 500 Printers owned.",
-      "20": "Gain +1 Multiplier per 1,000 Printers owned.",
-      "21": "Gain +1 Accelerator Boost per 2,000 Printers owned.",
+      "20": "Gain +1 Multiplier per num:((1000)) Printers owned.",
+      "21": "Gain +1 Accelerator Boost per num:((2000)) Printers owned.",
       "24": "Gain +.25% to Accelerator Power.",
       "25": "Start Transcensions/Challenges with Coin Mint Autobuyer unlocked.",
       "26": "Gain +1 Accelerator per 500 Mints owned.",
-      "27": "Gain +1 Multiplier per 1,000 Mints owned.",
-      "28": "Gain +1 Accelerator Boost per 2,000 Mints owned.",
+      "27": "Gain +1 Multiplier per num:((1000)) Mints owned.",
+      "28": "Gain +1 Accelerator Boost per num:((2000)) Mints owned.",
       "31": "Gain +.30% to Accelerator Power.",
       "32": "Start Transcensions/Challenges with Alchemy Autobuyer unlocked.",
       "33": "Gain 10% more Offerings from resets || +1 Accelerator per 500 Alchemies!",
-      "34": "Gain 15% more Offerings from resets (stacks multiplicatively!) || +1 Multiplier per 1,000 Alchemies!",
-      "35": "Gain 25% more Offerings from resets (stacks multiplicatively!) || +1 Accelerator Boost per 2,000 Alchemies!",
+      "34": "Gain 15% more Offerings from resets (stacks multiplicatively!) || +1 Multiplier per num:((1000)) Alchemies!",
+      "35": "Gain 25% more Offerings from resets (stacks multiplicatively!) || +1 Accelerator Boost per num:((2000)) Alchemies!",
       "36": "Multiply Crystal Production by 2x.",
       "37": "Multiply Crystal Production by the common logarithm of owned Diamonds. Prestiges give more Offerings based on time spent (Up to +15 at 1800 seconds)",
       "38": "Unlock the Duplication rune!",
@@ -1677,7 +1677,7 @@
       "50": "Unlock new Atomic production and unlock 3 new incredibly difficult Challenges! Gain 2x particles on all future Reincarnations!",
       "51": "Manual Reincarnations give +4 Obtainium (unaffected by multipliers except time multiplier)!",
       "52": "Reincarnations give more Offerings based on time spent (Up to +25 at 1800 seconds)",
-      "53": "Increase the amount of Obtainium gained through all features by 0.125% additive for each rune level.",
+      "53": "Increase the amount of Obtainium gained through all features by num:((0.125))% additive for each rune level.",
       "57": "Gain +1, +1% free Multipliers!",
       "58": "Gain +1, +1% more free Multipliers!",
       "59": "Gain +1, +1% more, MORE free Multipliers!",
@@ -1718,27 +1718,27 @@
       "110": "Delay tax growth by 4%.",
       "112": "+9% Obtainium (stacks additively with other achievement rewards)",
       "115": "+5% Offering recycle.",
-      "117": "Delay tax growth by 5.66%.",
-      "118": "Each Reincarnation Challenge completion delays tax growth by 0.75% per level, multiplicative. Effect: {{x}}x",
+      "117": "Delay tax growth by num:((5.66))%.",
+      "118": "Each Reincarnation Challenge completion delays tax growth by num:((0.75))% per level, multiplicative. Effect: {{x}}x",
       "119": "+11% Obtainium. Unlock a nice trinket somewhere...",
-      "122": "+7.5% Offering recycle.",
-      "124": "Delay tax growth by 5.66%. Unlock 5 new incredibly powerful Researches!",
+      "122": "+num:((7.5))% Offering recycle.",
+      "124": "Delay tax growth by num:((5.66))%. Unlock 5 new incredibly powerful Researches!",
       "126": "+13% Obtainium. You get an accessory to commemorate this moment!",
       "127": "Unlock 20 new incredibly expensive yet good Researches. Unlock the [Anthill] feature!",
-      "128": "Make Researches go Cost-- with 1.5x Obtainium!",
-      "129": "+7.5% Offering recycle. Gain another 1.25x Obtainium multiplier!",
-      "131": "Delay tax growth by 5.66%.",
+      "128": "Make Researches go Cost-- with num:((1.5))x Obtainium!",
+      "129": "+num:((7.5))% Offering recycle. Gain another num:((1.25))x Obtainium multiplier!",
+      "131": "Delay tax growth by num:((5.66))%.",
       "132": "Permanently gain +25% more sacrifice reward!",
       "133": "+15% Obtainium. Obtain the gift of Midas himself.",
       "134": "Unlock 10 newer incredibly expensive yet good Researches. Unlock <Talismans> in the Runes Tab!",
-      "135": "Talisman positive bonuses are now +0.02 stronger per level.",
-      "136": "Talisman positive bonuses are now +0.02 even stronger per level.",
+      "135": "Talisman positive bonuses are now +num:((0.02)) stronger per level.",
+      "136": "Talisman positive bonuses are now +num:((0.02)) even stronger per level.",
       "137": "Permanently gain +25% more sacrifice reward!",
       "140": "+17% Obtainium. Lazy joke about not leaking talismans here [You get a new one]",
       "141": "Unlock a new reset tier!",
       "147": "+19% Obtainium (Achievement total is up to 100%!). Gain the Polymath Talisman!",
       "169": "ALL Ant speed multiplied by {{x}}",
-      "171": "+16.666% ALL Ant speed!",
+      "171": "+num:((16.666))% ALL Ant speed!",
       "172": "Gain more Ants the longer your Reincarnation lasts (Max speed achieved in 2 hours)",
       "173": "Unlock Ant Sacrifice, allowing you to reset your Ants and Ant upgrades in exchange for amazing rewards! Automatically buy Worker Ants.",
       "174": "Ant Multiplier from sacrifice is multiplied by another logarithm: x{{x}}",
@@ -1754,8 +1754,8 @@
       "188": "Gain +100 Ascension count for all Ascensions longer than 10 seconds. Also: Obtainium +{{x}}% [Max: 100% at 5M Ascensions]",
       "189": "Gain 20% of Excess time after 10 seconds each Ascension as a linear multiplier to Ascension count. Also: Cubes +{{x}}% [Max: 200% at 500M Ascensions]",
       "193": "Gain {{x}}% more Cubes on Ascension!",
-      "195": "Gain {{x}}% more Cubes and Tesseracts on Ascension! Multiplicative with the other Ach. bonus [MAX: 25,000% at e100,000 Const]",
-      "196": "Gain {{x}}% more Platonic Cubes on Ascension! [MAX: 2,000% at e100,000 Const]",
+      "195": "Gain {{x}}% more Cubes and Tesseracts on Ascension! Multiplicative with the other Ach. bonus [MAX: num:((25000))% at enum:((100000)) Const]",
+      "196": "Gain {{x}}% more Platonic Cubes on Ascension! [MAX: num:((2000))% at enum:((100000)) Const]",
       "197": "You will unlock a stat tracker for Ascensions.",
       "198": "Gain +4% Cubes on Ascension!",
       "199": "Gain +4% Cubes on Ascension!",
@@ -1779,16 +1779,16 @@
       "220": "Gain +4% Platonic Cubes on Ascension!",
       "221": "Gain +4% Platonic Cubes on Ascension!",
       "222": "Gain +3% Platonic Cubes on Ascension!",
-      "223": "Gain 20% of Excess time after 10 seconds each Ascensions as a linear multiplier to Ascension count. Also: Platonic Cubes +{{x}}% [Max: 200% at 2.674B Ascensions]",
-      "240": "Ascension Cube Gain Multipliers is VERY slightly affected by global speed multipliers: {{x}}x (Min: 1.10x, Max: 1.50x)",
-      "250": "You gain a permanent +60% Obtainium and Offering bonus, with +6% all Cube types! Quark Gain x1.05!",
-      "251": "You gain a permanent +100% Obtainium and Offering bonus, with +10% all Cube types! Quark Gain x1.05!",
+      "223": "Gain 20% of Excess time after 10 seconds each Ascensions as a linear multiplier to Ascension count. Also: Platonic Cubes +{{x}}% [Max: 200% at num:((2.674))B Ascensions]",
+      "240": "Ascension Cube Gain Multipliers is VERY slightly affected by global speed multipliers: {{x}}x (Min: num:((1.10))x, Max: num:((1.50))x)",
+      "250": "You gain a permanent +60% Obtainium and Offering bonus, with +6% all Cube types! Quark Gain xnum:((1.05))!",
+      "251": "You gain a permanent +100% Obtainium and Offering bonus, with +10% all Cube types! Quark Gain xnum:((1.05))!",
       "253": "You will gain +10% Hypercubes! Why? I don't know.",
-      "254": "Cube Gain +{{x}}% [Max: +15% at 1e25 Ascension Score]",
-      "255": "Tesseract Gain +{{x}}% [Max: +15% at 1e25 Ascension Score], and allow gain of Hepteracts.",
-      "256": "Hypercube Gain +{{x}}% [Max: +15% at 1e25 Ascension Score]. Also, Overflux Powder conversion rate is 5% better!",
-      "257": "Platonic Gain +{{x}}% [Max: +15% at 1e25 Ascension Score]. Also, Overflux Powder conversion rate is 5% better!",
-      "258": "Hepteract Gain +{{x}}% [Max: +15% at 1e25 Ascension Score]",
+      "254": "Cube Gain +{{x}}% [Max: +15% at num:((1e25)) Ascension Score]",
+      "255": "Tesseract Gain +{{x}}% [Max: +15% at num:((1e25)) Ascension Score], and allow gain of Hepteracts.",
+      "256": "Hypercube Gain +{{x}}% [Max: +15% at num:((1e25)) Ascension Score]. Also, Overflux Powder conversion rate is 5% better!",
+      "257": "Platonic Gain +{{x}}% [Max: +15% at num:((1e25)) Ascension Score]. Also, Overflux Powder conversion rate is 5% better!",
+      "258": "Hepteract Gain +{{x}}% [Max: +15% at num:((1e25)) Ascension Score]",
       "259": "Corruption score is increased by 1% for every expansion of Abyss Hepteract!",
       "260": "You will gain 10% more Ascension count, forever!",
       "261": "You will gain 10% more Ascension count, forever!",
@@ -1796,10 +1796,10 @@
       "263": "Ascensions are {{x}}% faster! Max: +10%",
       "264": "Hepteracts +{{x}}% [Max: 40% at 8T Ascensions]!",
       "265": "Hepteracts +{{x}}% [Max: 20% at 160T Ascensions]!",
-      "266": "Quarks +{{x}}% [Max: 1.10x at 1Qa (1e15) Ascensions]!",
-      "267": "Ascension Score is boosted by {{x}}% [Max: 100% at 1e100,000 Const]",
-      "270": "Hepteract Gain is boosted by {{x}}% [Max: 100% at 1e1,000,000 const], Constant Upgrade 1 boosted to 1.06 (from 1.05), Constant Upgrade 2 boosted to 1.11 (from 1.10).",
-      "271": "When you open a Platonic Cube, gain {{x}} Hypercubes, rounded down [Max: 1 at 1e1,000,000 Const]"
+      "266": "Quarks +{{x}}% [Max: num:((1.10))x at 1Qa (num:((1e15))) Ascensions]!",
+      "267": "Ascension Score is boosted by {{x}}% [Max: 100% at num:((1e100000)) Const]",
+      "270": "Hepteract Gain is boosted by {{x}}% [Max: 100% at num:((1e1000000)) const], Constant Upgrade 1 boosted to num:((1.06)) (from num:((1.05))), Constant Upgrade 2 boosted to num:((1.11)) (from num:((1.10))).",
+      "271": "When you open a Platonic Cube, gain {{x}} Hypercubes, rounded down [Max: 1 at num:((1e1000000)) Const]"
     },
     "groupNames": {
       "firstOwnedCoin": "Workers",
@@ -1925,17 +1925,17 @@
       },
       "quarks": {
         "name": "Quark Multiplier",
-        "description": "Every 20 Synergism levels, multiply your Quark gain by 1.01(!)",
+        "description": "Every 20 Synergism levels, multiply your Quark gain by num:((1.01))(!)",
         "effect": "Current Effect: +{{mult}} Quark Gain"
       },
       "offerings": {
         "name": "Offerings Multiplier",
-        "description": "Every level, gain 1.01x Offerings. After level 100, multiply it by another 1.02 per level!",
+        "description": "Every level, gain num:((1.01))x Offerings. After level 100, multiply it by another num:((1.02)) per level!",
         "effect": "Current Effect: +{{mult}} Offerings Gain"
       },
       "obtainium": {
         "name": "Obtainium Multiplier",
-        "description": "For each level past 14, multiply your Obtainium gain by 1.01. After level 100, multiply it by another 1.02 per level!",
+        "description": "For each level past 14, multiply your Obtainium gain by num:((1.01)). After level 100, multiply it by another num:((1.02)) per level!",
         "effect": "Current Effect: +{{mult}} Obtainium Gain"
       },
       "ants": {
@@ -1945,32 +1945,32 @@
       },
       "wowCubes": {
         "name": "Wow! Cube Production",
-        "description": "For each level past 60 (yes, this does unlock at level 70, but just trust me), gain +5% more Wow! Cubes. Every 10 levels past 60, multiply the bonus by 1.07.",
+        "description": "For each level past 60 (yes, this does unlock at level 70, but just trust me), gain +5% more Wow! Cubes. Every 10 levels past 60, multiply the bonus by num:((1.07)).",
         "effect": "Current Effect: +{{mult}} Wow! Cube Gain"
       },
       "wowTesseracts": {
         "name": "Wow! Tesseract Production",
-        "description": "For each level past 80, gain +5% more Wow! Tesseracts. Every 10 levels past 80, multiply the bonus by 1.07.",
+        "description": "For each level past 80, gain +5% more Wow! Tesseracts. Every 10 levels past 80, multiply the bonus by num:((1.07)).",
         "effect": "Current Effect: +{{mult}} Wow! Tesseract Gain"
       },
       "wowHyperCubes": {
         "name": "Wow! Hypercube Production",
-        "description": "For each level past 100, gain +5% more Wow! Hypercubes. Every 10 levels past 100, multiply the bonus by 1.07.",
+        "description": "For each level past 100, gain +5% more Wow! Hypercubes. Every 10 levels past 100, multiply the bonus by num:((1.07)).",
         "effect": "Current Effect: +{{mult}} Wow! Hypercube Gain"
       },
       "wowPlatonicCubes": {
         "name": "Wow! Platonic Cube Production",
-        "description": "For each level past 120, gain +5% more Wow! Platonic Cubes. Every 10 levels past 120, multiply the bonus by 1.07.",
+        "description": "For each level past 120, gain +5% more Wow! Platonic Cubes. Every 10 levels past 120, multiply the bonus by num:((1.07)).",
         "effect": "Current Effect: +{{mult}} Wow! Platonic Cube Gain"
       },
       "wowHepteractCubes": {
         "name": "Wow! Hepteract Production",
-        "description": "For each level past 150, gain +5% more Wow! Hepteracts. Every 10 levels past 150, multiply the bonus by 1.07.",
+        "description": "For each level past 150, gain +5% more Wow! Hepteracts. Every 10 levels past 150, multiply the bonus by num:((1.07)).",
         "effect": "Current Effect: +{{mult}} Wow! Hepteract Gain"
       },
       "wowOcteracts": {
         "name": "Wow! Octeracts!... Wait, what?",
-        "description": "For each level past 209, gain +5% more Wow! Octeracts. What's more, multiply this by 1.02 per level as well!",
+        "description": "For each level past 209, gain +5% more Wow! Octeracts. What's more, multiply this by num:((1.02)) per level as well!",
         "effect": "Current Effect: +{{mult}} Wow! Octeract Gain"
       },
       "ambrosiaLuck": {
@@ -1992,27 +1992,27 @@
       },
       "duplicationRune": {
         "name": "Duplication Rune XL!",
-        "description": "Power up your Duplication Rune! Each level 40+ grants +0.4 to Duplication Rune's <i>Rune Coefficient</i>.",
+        "description": "Power up your Duplication Rune! Each level 40+ grants +num:((0.4)) to Duplication Rune's <i>Rune Coefficient</i>.",
         "effect": "Current Effect: Duplication Rune - Rune Coefficient +{{duplicationRune}}"
       },
       "speedRune": {
         "name": "Speed Rune XL",
-        "description": "Power up your Speed Rune! Each level 20+ grants +0.5 to Speed Rune's <i>Rune Coefficient</i>.",
+        "description": "Power up your Speed Rune! Each level 20+ grants +num:((0.5)) to Speed Rune's <i>Rune Coefficient</i>.",
         "effect": "Current Effect: Speed Rune - Rune Coefficient +{{speedRune}}"
       },
       "prismRune": {
         "name": "Prism Rune XL",
-        "description": "Power up your Prism Rune! Each level 60+ grants +0.3 to Prism Rune's <i>Rune Coefficient</i>.",
+        "description": "Power up your Prism Rune! Each level 60+ grants +num:((0.3)) to Prism Rune's <i>Rune Coefficient</i>.",
         "effect": "Current Effect: Prism Rune - Rune Coefficient +{{prismRune}}"
       },
       "thriftRune": {
         "name": "Thrift Rune XL",
-        "description": "Power up your Thrift Rune! Each level 80+ grants +0.2 to Thrift Rune's <i>Rune Coefficient</i>.",
+        "description": "Power up your Thrift Rune! Each level 80+ grants +num:((0.2)) to Thrift Rune's <i>Rune Coefficient</i>.",
         "effect": "Current Effect: Thrift Rune - Rune Coefficient +{{thriftRune}}"
       },
       "SIRune": {
         "name": "SI Rune XL",
-        "description": "Power up your SI Rune! Each level 100+ grants +0.1 to SI Rune's <i>Rune Coefficient</i>.",
+        "description": "Power up your SI Rune! Each level 100+ grants +num:((0.1)) to SI Rune's <i>Rune Coefficient</i>.",
         "effect": "Current Effect: SI Rune - Rune Coefficient +{{siRune}}"
       },
       "autoPrestige": {
@@ -2090,12 +2090,12 @@
       "runeLevel": {
         "name": "Progressive Achievement - Purchased Rune Levels",
         "description": "Gain AP based on the sum of all rune levels purchased! <br> Best Total: <<gold|{{x}}>>",
-        "apSource": "Gain +1 AP per 1,000 Rune Levels purchased, up to 200,000 Levels. <br> Gain +1 AP per 2,500 Rune Levels purchased, up to 1,000,000 Levels. <br> Gain +1 AP per 12,500 Rune Levels purchased, up to 5,000,000 Levels."
+        "apSource": "Gain +1 AP per num:((1000)) Rune Levels purchased, up to num:((200000)) Levels. <br> Gain +1 AP per num:((2500)) Rune Levels purchased, up to num:((1000000)) Levels. <br> Gain +1 AP per num:((12500)) Rune Levels purchased, up to num:((5000000)) Levels."
       },
       "freeRuneLevel": {
         "name": "Progressive Achievement - Free Rune Levels",
         "description": "Gain AP based on the sum of all your free rune levels! <br> Best Total: <<gold|{{x}}>>",
-        "apSource": "Gain +1 AP per 250 Free Rune Levels owned, up to 25,000 Levels. <br> Gain +1 AP per 750 Free Rune Levels owned, up to 150,000 Levels. <br> Gain +1 AP per 2,500 Free Rune Levels owned, up to 500,000 Levels."
+        "apSource": "Gain +1 AP per 250 Free Rune Levels owned, up to num:((25000)) Levels. <br> Gain +1 AP per 750 Free Rune Levels owned, up to num:((150000)) Levels. <br> Gain +1 AP per num:((2500)) Free Rune Levels owned, up to num:((500000)) Levels."
       },
       "antMasteries": {
         "name": "Progressive Achievement - Ant Masteries",
@@ -2105,7 +2105,7 @@
       "rebornELO": {
         "name": "Progressive Achievement - Reborn ELO",
         "description": "Gain AP based on the total weighted value of your best Reborn ELO, lifetime! <br> Best Total: <<gold|{{x}}>> <br> (Check the \"Ants to Quark Corner\" in the Altar Subtab)",
-        "apSource": "Gain +1 AP per 100 Reborn ELO, up to 10,000. <br> Gain +1 AP per 1000 Reborn ELO, up to 150,000. <br> Gain +1 AP per 9,000 Reborn ELO, up to 1,350,000. <br> Gain +1 AP per 75,000 Reborn ELO, up to 15,000,000. <br> Gain +1 AP per 150,000 Reborn ELO, up to 60,000,000."
+        "apSource": "Gain +1 AP per 100 Reborn ELO, up to num:((10000)). <br> Gain +1 AP per 1000 Reborn ELO, up to num:((150000)). <br> Gain +1 AP per num:((9000)) Reborn ELO, up to num:((1350000)). <br> Gain +1 AP per num:((75000)) Reborn ELO, up to num:((15000000)). <br> Gain +1 AP per num:((150000)) Reborn ELO, up to num:((60000000))."
       },
       "singularityCount": {
         "name": "Progressive Achievement - Singularity Count",
@@ -2115,12 +2115,12 @@
       "ambrosiaCount": {
         "name": "Progressive Achievement - Lifetime Ambrosia",
         "description": "Gain AP based on your lifetime Ambrosia! <br> Lifetime Ambrosia: <<gold|{{x}}>>",
-        "apSource": "Gain +1 AP per 100 Ambrosia, up to 20,000. <br> Gain +1 AP per 10,000 Ambrosia, up to 2,000,000. <br> Gain up to 400 MORE AP, by reaching 100,000,000 total Lifetime Ambrosia!"
+        "apSource": "Gain +1 AP per 100 Ambrosia, up to num:((20000)). <br> Gain +1 AP per num:((10000)) Ambrosia, up to num:((2000000)). <br> Gain up to 400 MORE AP, by reaching num:((100000000)) total Lifetime Ambrosia!"
       },
       "redAmbrosiaCount": {
         "name": "Progressive Achievement - Lifetime Red Ambrosia",
         "description": "Gain AP based on your lifetime Red Ambrosia! <br> Lifetime Red Ambrosia: <<gold|{{x}}>>",
-        "apSource": "Gain +1 AP per 25 Red Ambrosia, up to 5,000. <br> Gain +1 AP per 2,500 Red Ambrosia, up to 500,000. <br> Gain +1 AP per 12,500 Ambrosia, up to 5,000,000. <br> Finally, Gain +1 AP per 62,500 Red Ambrosia, up to 12,500,000."
+        "apSource": "Gain +1 AP per 25 Red Ambrosia, up to num:((5000)). <br> Gain +1 AP per num:((2500)) Red Ambrosia, up to num:((500000)). <br> Gain +1 AP per num:((12500)) Ambrosia, up to num:((5000000)). <br> Finally, Gain +1 AP per num:((62500)) Red Ambrosia, up to num:((12500000))."
       },
       "exalts": {
         "name": "Progressive Achievement - EXALT Completions",
@@ -2151,7 +2151,7 @@
     "alerts": {
       "36": "Congratulations on your first Prestige. The first of many. You obtain Offerings. You can use them in the new Runes tab! [Unlocked Runes, Achievements, Diamond Buildings and some Upgrades!]",
       "38": "Hmm, it seems you are getting richer, being able to get 1 Googol diamonds in a single Prestige. How about we give you another Rune? [Unlocked Duplication Rune in Runes tab!]",
-      "255": "Wow! You gained 1e15 (100 Quadrillion) score in a single Ascension. For that, you can now generate Hepteracts if you get above 1.66e17 (166.6 Quadrillion) score in an Ascension. Good luck!"
+      "255": "Wow! You gained num:((1e15)) (100 Quadrillion) score in a single Ascension. For that, you can now generate Hepteracts if you get above num:((1.66e17)) (num:((166.6)) Quadrillion) score in an Ascension. Good luck!"
     },
     "hover": "Hover over an achievement to view information.",
     "tieredExtraRewards": "This Tiered Achievement has extra rewards!",
@@ -2183,9 +2183,9 @@
       "singularity": "Enter the Singularity"
     },
     "details": {
-      "prestige": "Coins, Coin Producers, Coin Upgrades, and Crystals are reset, but in return you gain diamonds and a few Offerings. Required: {{amount}}/1e16 Coins || TIME SPENT: {{timeSpent}} Seconds.",
-      "transcension": "Reset all Coin and Diamond Upgrades/Features, Crystal Upgrades & Producers, for Mythos/Offerings. Required: {{amount}}/1e100 Coins || TIME SPENT: {{timeSpent}} Seconds.",
-      "reincarnation": "Reset ALL previous reset tiers, but you will gain Particles, Obtainium and Offerings! Required: {{amount}}/1e300 Mythos Shards || TIME SPENT: {{timeSpent}} Seconds.",
+      "prestige": "Coins, Coin Producers, Coin Upgrades, and Crystals are reset, but in return you gain diamonds and a few Offerings. Required: {{amount}}/num:((1e16)) Coins || TIME SPENT: {{timeSpent}} Seconds.",
+      "transcension": "Reset all Coin and Diamond Upgrades/Features, Crystal Upgrades & Producers, for Mythos/Offerings. Required: {{amount}}/num:((1e100)) Coins || TIME SPENT: {{timeSpent}} Seconds.",
+      "reincarnation": "Reset ALL previous reset tiers, but you will gain Particles, Obtainium and Offerings! Required: {{amount}}/num:((1e300)) Mythos Shards || TIME SPENT: {{timeSpent}} Seconds.",
       "acceleratorBoost": "Reset Coin Producers/Upgrades, Crystals and Diamonds in order to increase the power of your Accelerators. Required: {{amount}}/{{required}} Diamonds.",
       "transcensionChallenge": {
         "in": "Are you tired of being in your Challenge or stuck? Click to leave Challenge {{n}}. Progress: {{amount}}/{{required}} Coins. TIME SPENT: {{timeSpent}} Seconds.",
@@ -2234,21 +2234,21 @@
         "flavor": "The mother of them all. Produces Mega-Breeders.",
         "generates": "Generates {{x}} Mega-Breeder Ants per second",
         "eloMult": "<<orchid | ☇>> Buying your first Queen Ant this Sacrifice increases your <<orchid|Ant ELO>> this Sacrifice by 1%",
-        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first Queen Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> 1.15x as fast!"
+        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first Queen Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> num:((1.15))x as fast!"
       },
       "5": {
         "name": "Lord Royal Ants - Tier VI",
         "flavor": "A King Ant. Produces Queens. Wait, what?",
         "generates": "Generates {{x}} Queen Ants per second",
         "eloMult": "<<orchid | ☇>> Buying your first Lord Royal Ant this Sacrifice increases your <<orchid|Ant ELO>> this Sacrifice by 1%",
-        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first Lord Royal Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> 1.25x as fast!"
+        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first Lord Royal Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> num:((1.25))x as fast!"
       },
       "6": {
         "name": "ALMIGHTY Ants - Tier VII",
         "flavor": "The stuff of legends. Produces Lord Royals.",
         "generates": "Generates {{x}} Lord Royal Ants per second",
         "eloMult": "<<orchid | ☇>> Buying your first ALMIGHTY Ant this Sacrifice increases your <<orchid|Ant ELO>> this Sacrifice by 1%",
-        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first ALMIGHTY Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> 1.4x as fast!"
+        "eloSpeedup": "<<#00DDFF | 🝘>> Buying your first ALMIGHTY Ant this Sacrifice creates <<#00DDFF|Reborn ELO>> num:((1.4))x as fast!"
       },
       "7": {
         "name": "DISCIPLE OF ANT GOD - Tier VIII",
@@ -2360,7 +2360,7 @@
       "taxes": {
         "name": "Tributum Formicidae",
         "intro": "Pocket ants!",
-        "description": "Pocket ants! Reduce your taxes by up to 99.5%.",
+        "description": "Pocket ants! Reduce your taxes by up to num:((99.5))%.",
         "lockedAutomation": "Unlock the <i>Tributum Formicidae</i> autobuyer from the <<gold|<i>Ant Sacrifice</i> >> Achievement Group",
         "effect": "Taxes are reduced by <<lightgrey | {{x}}>>"
       },
@@ -2381,14 +2381,14 @@
       "offerings": {
         "name": "Sacrificium Formicidae",
         "intro": "Binds the sweet influences of Pleiades.",
-        "description": "Offering gain is multiplied by (1 + level / 10)^0.5",
+        "description": "Offering gain is multiplied by (1 + level / 10)^num:((0.5))",
         "lockedAutomation": "Unlock the <i>Sacrificium Formicidae</i> autobuyer from the <<gold|<i>Ant Sacrifice</i> >> Achievement Group",
         "effect": "Gain <<orange | +{{x}} Offerings>> from all sources!"
       },
       "obtainium": {
         "name": "Experientia Formicidae",
         "intro": "An example of the <i>infinite ant theorem</i>",
-        "description": "Obtainium gain is multiplied by (1 + level / 10)^0.5",
+        "description": "Obtainium gain is multiplied by (1 + level / 10)^num:((0.5))",
         "lockedAutomation": "Unlock the <i>Experientia Formicidae</i> autobuyer from the <<gold|<i>Challenge 9</i> >> Achievement Group",
         "effect": "Gain <<pink | +{{x}} Obtainium>> from all sources!"
       },
@@ -2410,14 +2410,14 @@
       "freeRunes": {
         "name": "Praemoenio Formicidae",
         "intro": "It's giving some mixed signals.",
-        "description": "+1 Free Rune Level for Runes 1-5 per level, up to +3,000",
+        "description": "+1 Free Rune Level for Runes 1-5 per level, up to +num:((3000))",
         "lockedAutomation": "Unlock the <i>Praemoenio Formicidae</i> autobuyer from the <<gold|<i>Anthills Sacrificed</i> >> Achievement Group",
         "effect": "Those Runes? <<cyan | +{{x}} Free Levels>>, nice!"
       },
       "antSacrifice": {
         "name": "Phylacterium Formicidae",
         "intro": "Your soul feels a little heavier near this one.",
-        "description": "Ant Sacrifice rewards are multiplied by (1 + level / 25)^0.5. The first 200 levels also grant +5 ELO each!",
+        "description": "Ant Sacrifice rewards are multiplied by (1 + level / 25)^num:((0.5)). The first 200 levels also grant +5 ELO each!",
         "lockedAutomation": "Unlock the <i>Phylacterium Formicidae</i> autobuyer from the <<gold|<i>Anthills Sacrificed</i> >> Achievement Group",
         "effect": "Ant Sacrifice gives <<crimson | +{{x}} rewards>>",
         "effect2": "Ant ELO <<orchid | +{{x}}>>"
@@ -2441,7 +2441,7 @@
       "mortuus2": {
         "name": "Mortuus Iterum Formicidae",
         "intro": "The cyan glow... it's... Reborn?",
-        "description": "Improve your Mortuus Talisman! Up to +75% Effect, +1,200 Max Level, and gain some Ascension Speed on the side.",
+        "description": "Improve your Mortuus Talisman! Up to +75% Effect, +num:((1200)) Max Level, and gain some Ascension Speed on the side.",
         "lockedAutomation": "Unlock the <i>Mortuus Iterum Formicidae</i> autobuyer from reaching Synergism Level <<gold|225>>",
         "effect": "Mortuus Talisman Max Level: <<royalblue | +{{x}}>>",
         "effect2": "Mortuus Talisman Effect: <<royalblue | +{{x}}>>",
@@ -2472,7 +2472,7 @@
       },
       "locked": {
         "crumbsMade": "You have made <<gold|{{x}}>> Galactic Crumbs.",
-        "altarRequirements": "This Altar will open when you have made <<gold|1e40>>."
+        "altarRequirements": "This Altar will open when you have made <<gold|num:((1e40))>>."
       },
       "autoSacrificeLocked": {
         "info": "Unlock Auto Sacrifice from the Ant Sacrifice Count Achievements!",
@@ -2512,14 +2512,14 @@
       "dailyQuarkModal": {
         "intro": "You've gained <<cyan|{{x}}>> Quarks from Ant Sacrifice today!",
         "quarkLine": "<<turquoise|{{x}}>> Stages, worth <<cyan|{{y}}>> Quarks (<<cyan|{{z}}>> per Stage)",
-        "bonusMult": "Get 1.002x the Quarks per stage, up until Stage 1,000. Current: <<cyan|x{{x}}>>",
+        "bonusMult": "Get num:((1.002))x the Quarks per stage, up until Stage num:((1000)). Current: <<cyan|x{{x}}>>",
         "allTimeMult": "All-Time Leaderboard Quark Multiplier: <<cyan|x{{x}}>>",
         "globalQuarkMult": "Global Quark Multiplier: <<cyan|x{{x}}>>"
       },
       "allTimeQuarkModal": {
         "intro": "Your all-time leaderboard multiplies Quark gain from Ant Sacrifice by <<cyan|{{x}}>>.",
-        "formula": "Formula: <<orchid|2 - 0.8^(Stage / 100)>>",
-        "specificMult": "Stage <<turquoise|{{x}}>>: <<orchid|2 - 0.8^{{y}}>> = <<cyan|{{z}}>>"
+        "formula": "Formula: <<orchid|2 - num:((0.8))^(Stage / 100)>>",
+        "specificMult": "Stage <<turquoise|{{x}}>>: <<orchid|2 - num:((0.8))^{{y}}>> = <<cyan|{{z}}>>"
       }
     },
     "maxBuy": {
@@ -2612,17 +2612,17 @@
     "rebornELOInfo2": "• Limited by your <<crimson|Immortal ELO>>. <<orchid | Ant ELO>> speeds up generation!",
     "rebornELOInfo3": "• The more <<#00DDFF|Reborn ELO>> you have, the slower it generates.",
     "stageInfo": "<<#00DDFF|Reborn ELO>> gives you a <<turquoise | Stage>>.",
-    "stageInfo2": "Each <<turquoise|Stage>> gives you <<gold|1.05x>> <<orange|Offerings>>, <<gold|1.05x>> <<pink|Obtainium>>, and <<gold|1.20x>> <<lightgray|Talisman Fragments>>! <<#00DDFF|Reborn ELO>> generates <<gold|{{percentage}}%>> slower per <<turquoise|Stage>>.",
+    "stageInfo2": "Each <<turquoise|Stage>> gives you <<gold|num:((1.05))x>> <<orange|Offerings>>, <<gold|num:((1.05))x>> <<pink|Obtainium>>, and <<gold|num:((1.20))x>> <<lightgray|Talisman Fragments>>! <<#00DDFF|Reborn ELO>> generates <<gold|{{percentage}}%>> slower per <<turquoise|Stage>>.",
     "stageTranche1": "Stages 1-100: 100 <<#00DDFF|Reborn ELO>> Each",
-    "stageTranche2": "Stages 101-200: 1,000 <<#00DDFF|Reborn ELO>> Each",
-    "stageTranche3": "Stages 201-300: 3,000 <<#00DDFF|Reborn ELO>> Each",
-    "stageTranche4": "Stages 301-1,000: 20,000 <<#00DDFF|Reborn ELO>> Each",
-    "stageTranche5": "Stages 1,001+: 100,000 <<#00DDFF|Reborn ELO>> Each",
+    "stageTranche2": "Stages 101-200: num:((1000)) <<#00DDFF|Reborn ELO>> Each",
+    "stageTranche3": "Stages 201-300: num:((3000)) <<#00DDFF|Reborn ELO>> Each",
+    "stageTranche4": "Stages 301-num:((1000)): num:((20000)) <<#00DDFF|Reborn ELO>> Each",
+    "stageTranche5": "Stages num:((1001))+: num:((100000)) <<#00DDFF|Reborn ELO>> Each",
     "autoReset": "This resets your Crumbs, Ant Producers and Ant Upgrades in exchange for Immortal ELO and some worldly items. Continue?",
     "itemReward": "+{{x}}",
     "eloRequirement": "{{x}} ELO",
     "antSacrifice": "Ant Sacrifice",
-    "minimumTimeToSacrifice": "Minimum interval between Sacrifices: <<gold|0.05>> real-life seconds",
+    "minimumTimeToSacrifice": "Minimum interval between Sacrifices: <<gold|num:((0.05))>> real-life seconds",
     "timeElapsed": "Time elapsed: <<gold|{{x}}>> real-life seconds",
     "buyAllUpgrades": "Buy All Upgrades",
     "buyAllProducers": "Buy All Producers and Masteries",
@@ -2639,9 +2639,9 @@
       "restrictions": "Transcend and reach the goal except Multipliers count as Accelerators. <br> ☆ Multiplier Power = <<gold|1>> at all times! <br> ☆ Accelerator Power is reduced. Each completion reduces it more! <br> ☆ Each Multiplier gives a Coin Producer production multiplier equal to Accelerator Power.",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
-        "1": "+2 base Multiplier Boosts! [+0.02 to power!] Current: ",
-        "2": "Duplication Rune level scaling coefficient is increased by 0.75! Current: ",
-        "3": "+0.04 base Rune exp per Offering! Current: "
+        "1": "+2 base Multiplier Boosts! [+num:((0.02)) to power!] Current: ",
+        "2": "Duplication Rune level scaling coefficient is increased by num:((0.75))! Current: ",
+        "3": "+num:((0.04)) base Rune exp per Offering! Current: "
       },
       "first": "+1 free Multiplier! +1 Base EXP per offering used!",
       "start": "Start [No Multipliers]",
@@ -2654,12 +2654,12 @@
     "2": {
       "name": "No Accelerators Challenge || {{- value}} Completions",
       "flavor": "Who needs accelerators? They do basically nothing now.",
-      "restrictions": "Transcend and reach the goal except Accelerators do nothing! <br> ☆ Accelerator Power = <<gold|1>> at all times! <br> ☆ Multiplier Power is reduced to be <<gold|1.25, +0.0012>> per Multiplier Boost",
+      "restrictions": "Transcend and reach the goal except Accelerators do nothing! <br> ☆ Accelerator Power = <<gold|1>> at all times! <br> ☆ Multiplier Power is reduced to be <<gold|num:((1.25)), +num:((0.0012))>> per Multiplier Boost",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
         "1": "+5 Free Accelerators! Current: ",
         "2": "+5% Accelerator Boost Power! Current: ",
-        "3": "+0.25% Accelerator Power! Current: "
+        "3": "+num:((0.25))% Accelerator Power! Current: "
       },
       "first": "+1 base offering for Prestige and Transcensions.",
       "start": "Start [No Accelerators]",
@@ -2675,9 +2675,9 @@
       "restrictions": "Transcend and reach the goal except you do not produce Crystals or Mythos Shards. <br> ☆ Refineries do not produce Crystals <br> ☆ Augments do not produce Mythos Shards. <br> ☆ Accelerator Power above 1 is reduced by <<gold|50%>> ",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
-        "1": "Crystal --> Coin conversion exponent +0.04! Current: ",
-        "2": "+0.5% to Grandmaster production per Mythos producer bought. Current: ",
-        "3": "When you use a rune, all other runes gain +0.01 EXP. Current: "
+        "1": "Crystal --> Coin conversion exponent +num:((0.04))! Current: ",
+        "2": "+num:((0.5))% to Grandmaster production per Mythos producer bought. Current: ",
+        "3": "When you use a rune, all other runes gain +num:((0.01)) EXP. Current: "
       },
       "first": "Gain an offering automatically every 2 seconds!",
       "start": "Start [No Shards]",
@@ -2690,12 +2690,12 @@
     "4": {
       "name": "Cost+ Challenge || {{- value}} Completions",
       "flavor": "You're getting rich now, but inflation hasn't happened yet? I don't think so!",
-      "restrictions": "Transcend and reach the goal except Coin + Diamond Buildings, Accelerators, and Multipliers cost more. <br> ☆ Prices grow super-exponentially after <<gold|1,000>> of each Building. <br> ☆ Each completion lowers the above number by <<gold|10>> <br> ☆ Accelerator and Multiplier prices <<gold|immediately>> grow super-exponentially!",
+      "restrictions": "Transcend and reach the goal except Coin + Diamond Buildings, Accelerators, and Multipliers cost more. <br> ☆ Prices grow super-exponentially after <<gold|num:((1000))>> of each Building. <br> ☆ Each completion lowers the above number by <<gold|10>> <br> ☆ Accelerator and Multiplier prices <<gold|immediately>> grow super-exponentially!",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
         "1": "Accelerator Cost scale slows down by +5 purchases. Current: ",
         "2": "Multiplier Cost scale slows down by +2 purchases. Current: ",
-        "3": "Building Cost Delay +0.5%. Current: "
+        "3": "Building Cost Delay +num:((0.5))%. Current: "
       },
       "first": "None",
       "start": "Start [Cost+]",
@@ -2708,10 +2708,10 @@
     "5": {
       "name": "Reduced Diamonds Challenge || {{- value}} Completions",
       "flavor": "You ever wonder how you get so many diamonds?",
-      "restrictions": "Transcend and reach the goal except Prestiging gives you much fewer Diamonds! <br> ☆ Diamond gain is reduced to <<gold | Coins^0.01>>",
+      "restrictions": "Transcend and reach the goal except Prestiging gives you much fewer Diamonds! <br> ☆ Diamond gain is reduced to <<gold | Coins^num:((0.01))>>",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
-        "1": "+0.01 Coin --> Diamond conversion exponent on Prestige! Current: ",
+        "1": "+num:((0.01)) Coin --> Diamond conversion exponent on Prestige! Current: ",
         "2": "Multiply Crystal production by 10! Current: ",
         "3": "+5% Prestige Count when Prestiging! Current: "
       },
@@ -2726,14 +2726,14 @@
     "6": {
       "name": "Higher Tax Challenge || {{- value}} Completions",
       "flavor": "The tax man caught wind that you reincarnated recently...",
-      "restrictions": "Reincarnate and reach the goal except you pay more Tax! <br> ☆ Your Tax burden is multiplied by <<gold|3 * (1 + completions / 25)^2>> <br> ☆ Your Coin production is divided by <<gold | 1e250>>",
+      "restrictions": "Reincarnate and reach the goal except you pay more Tax! <br> ☆ Your Tax burden is multiplied by <<gold|3 * (1 + completions / 25)^2>> <br> ☆ Your Coin production is divided by <<gold | num:((1e250))>>",
       "goal": "Goal: Gain {{value}} Mythos Shards in challenge.",
       "per": {
-        "1": "-3.5% Taxes [Multiplicative]! Current: ",
-        "2": "+0.3 Salvage! Current: ",
+        "1": "-num:((3.5))% Taxes [Multiplicative]! Current: ",
+        "2": "+num:((0.3)) Salvage! Current: ",
         "3": "Offerings +2%! Current: "
       },
-      "first": "-7.5% Taxes!",
+      "first": "-num:((7.5))% Taxes!",
       "start": "Start <Higher Tax>",
       "current": {
         "1": "Tax multiplier x{{value}}",
@@ -2744,11 +2744,11 @@
     "7": {
       "name": "No Multipliers/Accelerators Challenge || {{- value}} Completions",
       "flavor": "You're really going to hate this one.",
-      "restrictions": "Reincarnate and reach the goal except Accelerators and Multipliers do nothing. <br> ☆ Accelerator Power = <<gold|1>> at all times! <br> ☆ Multiplier Power = <<gold|1>> at all times! <br> ☆ Building Power above 1 is reduced by <<gold|95%>> <br> ☆ Your Coin production is divided by <<gold | 1e1,250>>",
+      "restrictions": "Reincarnate and reach the goal except Accelerators and Multipliers do nothing. <br> ☆ Accelerator Power = <<gold|1>> at all times! <br> ☆ Multiplier Power = <<gold|1>> at all times! <br> ☆ Building Power above 1 is reduced by <<gold|95%>> <br> ☆ Your Coin production is divided by <<gold | num:((1e1250))>>",
       "goal": "Goal: Gain {{value}} Mythos Shards in challenge.",
       "per": {
-        "1": "Accelerator/Multiplier boost power exponent +0.04! Current: ",
-        "2": "+0.3 Salvage! Current: ",
+        "1": "Accelerator/Multiplier boost power exponent +num:((0.04))! Current: ",
+        "2": "+num:((0.3)) Salvage! Current: ",
         "3": "+15% more Transcension Count when Transcending! Current: "
       },
       "first": "Multiplier Boost power +25%! The first Discord-Booster Global Diamond Upgrade.",
@@ -2765,8 +2765,8 @@
       "restrictions": "Reincarnate and reach the goal except you run an even tougher version of Cost+! <br> ☆ Accelerator and Multiplier prices increase <<gold|50x>> faster than in Cost+ <br> ☆ Building cost increases also affect Mythos Buildings! <br> ☆ Building costs start growing super-exponentially after <<gold|1000 + 1000 per completion>> purchased. <br> ",
       "goal": "Goal: Gain {{value}} Mythos Shards in challenge.",
       "per": {
-        "1": "Base Building Power +0.25! Current: ",
-        "2": "+0.4 Salvage! Current: ",
+        "1": "Base Building Power +num:((0.25))! Current: ",
+        "2": "+num:((0.4)) Salvage! Current: ",
         "3": "Offerings +4% (additive with other Challenge bonuses) ! Current: "
       },
       "first": "Unlock the Anthill feature! Includes 20 new Researches. A Global Diamond Upgrade.",
@@ -2780,12 +2780,12 @@
     "9": {
       "name": "No Runes Challenge || {{- value}} Completions",
       "flavor": "Bet you won't even notice Prism Rune's disappearance.",
-      "restrictions": "Reincarnate and reach the goal except Runes always have level 1 effects. <br> ☆ Your Coin production is divided by <<gold | 1e2,000,000>>. You may want a few Galactic Crumbs. <br> ☆ Your Tax burden is reduced by <<pink|99.5%>> to compensate",
+      "restrictions": "Reincarnate and reach the goal except Runes always have level 1 effects. <br> ☆ Your Coin production is divided by <<gold | num:((1e2000000))>>. You may want a few Galactic Crumbs. <br> ☆ Your Tax burden is reduced by <<pink|num:((99.5))%>> to compensate",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
         "1": "+1 free Ant level! Current: ",
         "2": "+10% Ant speed [Multiplicative!] Current: ",
-        "3": "+0.5 Salvage! Current: "
+        "3": "+num:((0.5)) Salvage! Current: "
       },
       "first": "Unlock Talismans and Blessings, in the rune Tab. A Global Diamond Upgrade.",
       "start": "Start <No Runes>",
@@ -2797,8 +2797,8 @@
     },
     "10": {
       "name": "Sadistic Challenge I || {{- value}} Completions",
-      "flavor": "I'm sorry for what I've unleashed onto the world. You read a note on the floor: \"You probably want about 1e300 Galactic Crumbs before you fully embrace the challenge. Try to Sacrifice some more Anthills, master your Ants and become one with the Ant God to achieve this.\"",
-      "restrictions": "Reincarnate and reach the goal, but run a mix of the first five Challenges, all at once! <br> ☆ Acceleration Power = <<gold|1>> at all times! <br> ☆ Multiplier Power = <<gold|1>> at all times! <br> ☆ Building Costs grow super-exponentially after <<gold|25,000>> purchased. This is affected by Building Cost Delay <br> ☆ Diamond gain is reduced to <<gold | Coins^0.0001>> <br> ☆ Mythos gain is reduced to <<gold | Coins^0.001>>",
+      "flavor": "I'm sorry for what I've unleashed onto the world. You read a note on the floor: \"You probably want about num:((1e300)) Galactic Crumbs before you fully embrace the challenge. Try to Sacrifice some more Anthills, master your Ants and become one with the Ant God to achieve this.\"",
+      "restrictions": "Reincarnate and reach the goal, but run a mix of the first five Challenges, all at once! <br> ☆ Acceleration Power = <<gold|1>> at all times! <br> ☆ Multiplier Power = <<gold|1>> at all times! <br> ☆ Building Costs grow super-exponentially after <<gold|num:((25000))>> purchased. This is affected by Building Cost Delay <br> ☆ Diamond gain is reduced to <<gold | Coins^num:((0.0001))>> <br> ☆ Mythos gain is reduced to <<gold | Coins^num:((0.001))>>",
       "goal": "Goal: Gain {{value}} Coins in challenge.",
       "per": {
         "1": "+100 base ELO for sacrificing ants! Current: ",
@@ -2820,7 +2820,7 @@
       "goal": "Goal: Complete Challenge 10 [Sadistic Challenge I] {{value}} times.",
       "per": {
         "1": "+12 free Ant Levels! Current: ",
-        "2": "Ant Speed x(1e5)^completions! Current: ",
+        "2": "Ant Speed x(num:((1e5)))^completions! Current: ",
         "3": "+1 to the Rune Level Coefficient of the first five runes! Current: "
       },
       "first": "Unlock 15 Researches, and unlock the ability to open Tesseracts! You also get to 'Corrupt' your game... and explore this in the Campaigns feature.",
@@ -2834,7 +2834,7 @@
     "12": {
       "name": "No Reincarnation Challenge || {{- value}} Completions",
       "flavor": "For some reason, you just can't do it.",
-      "restrictions": "Ascend and reach the goal but you do not gain Particles and you cannot Reincarnate at all! <br> ☆ Ant Speed <<gold|^0.75>>",
+      "restrictions": "Ascend and reach the goal but you do not gain Particles and you cannot Reincarnate at all! <br> ☆ Ant Speed <<gold|^num:((0.75))>>",
       "goal": "Goal: Complete Challenge 10 [Sadistic Challenge I] {{value}} times.",
       "per": {
         "1": "+50% Obtainium! Current: ",
@@ -2852,10 +2852,10 @@
     "13": {
       "name": "Tax+++ Challenge || {{- value}} Completions",
       "flavor": "Good luck with the IRS, buddy.",
-      "restrictions": "Ascend and reach the goal, but taxes are much higher and grow with challenge completions. <br> ☆ Ant Speed <<gold|^0.23>> <br> ☆ Each Transcension and Reincarnation Challenge completed multiplies your tax burden by <<gold|1.05>>",
+      "restrictions": "Ascend and reach the goal, but taxes are much higher and grow with challenge completions. <br> ☆ Ant Speed <<gold|^num:((0.23))>> <br> ☆ Each Transcension and Reincarnation Challenge completed multiplies your tax burden by <<gold|num:((1.05))>>",
       "goal": "Goal: Complete Challenge 10 [Sadistic Challenge I] {{value}} times.",
       "per": {
-        "1": "Taxes -3.33%! Multiplicative! Current: ",
+        "1": "Taxes -num:((3.33))%! Multiplicative! Current: ",
         "2": "+6 maximum to Talisman Level Cap! Current: ",
         "3": "+3% Spirit Power effectiveness! Current: "
       },
@@ -2870,12 +2870,12 @@
     "14": {
       "name": "No Research Challenge || {{- value}} Completions",
       "flavor": "The dimension that never progressed past the dark ages. Many fear to even step foot.",
-      "restrictions": "Ascend and reach the goal but you do not gain Obtainium nor are any Researches purchasable. <br> ☆ Ant Speed <<gold|^0.2>>",
+      "restrictions": "Ascend and reach the goal but you do not gain Obtainium nor are any Researches purchasable. <br> ☆ Ant Speed <<gold|^num:((0.2))>>",
       "goal": "Goal: Complete Challenge 10 [Sadistic Challenge I] {{value}} times.",
       "per": {
         "1": "+50% stronger effect on Researches 1x1 through 1x5. Current: ",
         "2": "+1 Research purchased per roomba tick! Current: ",
-        "3": "+1.5 to the Rune Level Coefficient of the first five runes! Current: "
+        "3": "+num:((1.5)) to the Rune Level Coefficient of the first five runes! Current: "
       },
       "first": "Unlock 15 Researches, and discover a new type of ideal cube - a Platonic one perhaps? Plus more Campaigns and Corruptions of course.",
       "start": "Start <[(No Research)]>",
@@ -2888,7 +2888,7 @@
     "15": {
       "name": "SADISTIC CHALLENGE II || {{- value}} Completions",
       "flavor": "The worst atrocity a man can commit is witnessing, without anguish, the suffering of others.",
-      "restrictions": "Ascend and reach the goal but you're stuck in all Corruptions at level 11. <br> ☆ Ant Speed <<gold|^0.5>> <br> ☆ Fortunae Formicidae effect is multiplied by <<gold|0.0001>> <br> ☆ Your Tax burden is reduced by <<pink|99.9995%>>",
+      "restrictions": "Ascend and reach the goal but you're stuck in all Corruptions at level 11. <br> ☆ Ant Speed <<gold|^num:((0.5))>> <br> ☆ Fortunae Formicidae effect is multiplied by <<gold|num:((0.0001))>> <br> ☆ Your Tax burden is reduced by <<pink|num:((99.9995))%>>",
       "goal": "Goal: {{value}} Coins, but get bonuses based on your best attempt.",
       "per": {
         "1": "Folly of mankind: ",
@@ -2926,7 +2926,7 @@
     "timeExitChallenge": "Time before exiting challenge: <<var(--orchid-text-color)|{{time}}>>s",
     "timeEnterChallenge": "Time before entering challenge: <<var(--orchid-text-color)|{{time}}>>s",
     "autoTimer": "<<orange|Auto Timer:>> <<var(--orchid-text-color)|{{time}}s>>",
-    "minimumTimer": "Minimum Timers: <<var(--orchid-text-color)|0.1s>>",
+    "minimumTimer": "Minimum Timers: <<var(--orchid-text-color)|num:((0.1))s>>",
     "perCompletionBonus": "Per Completion Bonuses || <<var(--orchid-text-color)|Softcapped past {{x}}! Effective completion count: {{y}}>>",
     "perCompletionBonusEmpty": "Per Completion Bonuses",
     "hypercubeOneTimeBonus": "Gain 1 Wow! HYPERCUBE for completing this challenge (First Time Bonus)",
@@ -3018,7 +3018,7 @@
       "80": "Wow! A Singular Cookie of the Grandma at the end of the Universe."
     },
     "upgradeDescriptions": {
-      "1": "[1x1] You got it! +16.666% 3D Cubes from Ascending per level.",
+      "1": "[1x1] You got it! +num:((16.666))% 3D Cubes from Ascending per level.",
       "2": "[1x2] Plutus grants you +3 Salvage per level!",
       "3": "[1x3] Athena grants you +10% more Obtainium, and +80% Auto Obtainium per level.",
       "4": "[1x4] You keep those 5 useful automation upgrades in the upgrades tab!",
@@ -3028,8 +3028,8 @@
       "8": "[1x8] Automatically buy Particle upgrades.",
       "9": "[1x9] The Research automator in shop now automatically buys cheapest when enabled. It's like a roomba kinda! <br> Like a roomba, it may backtrack in order to find cheaper Researches if they are unlocked later!",
       "10": "[1x10] Unlock some tools to automate Ascensions or whatever. Kinda expensive but cool. <br> <<gold|⚠>> You must clear Challenge 11 for this mechanic to be useful!",
-      "11": "[2x1] You got it again! +9.09% 3D Cubes from Ascending per level.",
-      "12": "[2x2] Raise Building Power to the power of (1 + level * 0.09).",
+      "11": "[2x1] You got it again! +num:((9.09))% 3D Cubes from Ascending per level.",
+      "12": "[2x2] Raise Building Power to the power of (1 + level * num:((0.09))).",
       "13": "[2x3] For each 20 Cubes opened at once, you get 1 additional Tribute at random.",
       "14": "[2x4] Iris shines her light on you. Each level increases the amount of Salvage she gives by 1%!",
       "15": "[2x5] Ares teaches you the Art of War. The effect of Ares Tributes is raised to the power of (1 + level / 100).",
@@ -3049,14 +3049,14 @@
       "29": "[3x9] Add +4 to Reincarnation Challenge cap per level. Completions after 25 scale faster in requirement!",
       "30": "[3x10] You now get +40% Cubes and Tesseracts forever!",
       "31": "[4x1] You again? +5% more Ascension Score per level.",
-      "32": "[4x2] Gain +0.1% Rune EXP per second you have spent in an Ascension. This has no cap!",
+      "32": "[4x2] Gain +num:((0.1))% Rune EXP per second you have spent in an Ascension. This has no cap!",
       "33": "[4x3] For each 20 Cubes opened at once, you get yet another additional Tribute at random.",
       "34": "[4x4] Chronos overclocks the universe for your personal benefit. The effect of Chronos Tributes is raised to the power of (1 + level / 100).",
       "35": "[4x5] Aphrodite increases the fertility of your coins. The effect of Aphrodite Tributes is raised to the power of (1 + level / 100).",
-      "36": "[4x6] Raise Building Power to (1 + 0.05 * Level) once more.",
+      "36": "[4x6] Raise Building Power to (1 + num:((0.05)) * Level) once more.",
       "37": "[4x7] For Thrift and Superior Intellect runes, add +1 to the Rune Level Coefficient per level!",
-      "38": "[4x8] Gain +0.5% more Tesseracts on Ascension for each additional level in a Corruption you enable.",
-      "39": "[4x9] Instead of the Ascension Score multiplier being 1.03^(C10 completions), it is now 1.035^(C10 completions)!",
+      "38": "[4x8] Gain +num:((0.5))% more Tesseracts on Ascension for each additional level in a Corruption you enable.",
+      "39": "[4x9] Instead of the Ascension Score multiplier being num:((1.03))^(C10 completions), it is now num:((1.035))^(C10 completions)!",
       "40": "[4x10] Athena is very smart. The effect of Athena Tributes is raised to the power of (1 + level / 100).",
       "41": "[5x1] Yeah yeah yeah, +5% Ascension Score per level. Isn't it enough?",
       "42": "[5x2] You now gain +4% Immaculate Obtainium per level, which is not dependent on corruptions!",
@@ -3067,35 +3067,35 @@
       "47": "[5x7] Wish granted. Auto Obtainium now gives Obtainium based on your Ant Sacrifice rewards, if it is greater than Reincarnation-based Obtainium gain.",
       "48": "[5x8] Your Worker Ant at the start of Ascensions can now generate crumbs, even without having Challenge 8 cleared!",
       "49": "[5x9] Immortal ELO is now automatically gained, without having to Sacrifice your ants!",
-      "50": "[5x10] What doesn't this boost? +0.01% Accelerators, Multipliers, Accelerator Boosts, +0.02% Obtainium, +0.02% Offerings, 0.00066% Tax reduction per level. Every 10,000 levels grant +0.6% Talisman Power!",
+      "50": "[5x10] What doesn't this boost? +num:((0.01))% Accelerators, Multipliers, Accelerator Boosts, +num:((0.02))% Obtainium, +num:((0.02))% Offerings, num:((0.00066))% Tax reduction per level. Every num:((10000)) levels grant +num:((0.6))% Talisman Power!",
       "51": "[Cx1] Wow! Bakery is open!!! Immediately unlock all automations in the Wow! Cubes tab, and Research as well.",
       "52": "[Cx2] These sugar cookies sure boost your blood sugar. Gain +1% Global Speed per level.",
-      "53": "[Cx3] What a hearty snack. Gain +0.1% Quarks per level.",
+      "53": "[Cx3] What a hearty snack. Gain +num:((0.1))% Quarks per level.",
       "54": "[Cx4] Pretty dry, but they suffice. Gain +1% Offerings per level.",
       "55": "[Cx5] An inventive take on the original chip cookie. Gain +1% Obtainium per level.",
       "56": "[Cx6] These are a little more exotic. Gain +1 more raw score from Challenge 1 completions per level.",
       "57": "[Cx7] Yum yum! Now we're talking... or maybe not. Increase the cap of Cube Upgrades 1x1, 2x1, 3x1, 4x1, 5x1 by 1.",
-      "58": "[Cx8] A bit festive! If there is an event, All Cube gain is multiplied by 1.25.",
-      "59": "[Cx9] Quite sour for a cookie. But it increases your Ascension Speed by +0.25% per level, so who is to complain?",
-      "60": "[Cx10] Wow! Bakery had extra ginger from their christmas sale. Reduce the cost of buying Golden Quarks by 0.003% per level.",
+      "58": "[Cx8] A bit festive! If there is an event, All Cube gain is multiplied by num:((1.25)).",
+      "59": "[Cx9] Quite sour for a cookie. But it increases your Ascension Speed by +num:((0.25))% per level, so who is to complain?",
+      "60": "[Cx10] Wow! Bakery had extra ginger from their christmas sale. Reduce the cost of buying Golden Quarks by num:((0.003))% per level.",
       "61": "[Cx11] Edible but prone to mistakes. Adds 25 whole milliseconds to the tolerance of code 'time', and increases its reward by +2% per level. When maxxed, code 'time' always gives its reward, even if you fail it!",
       "62": "[Cx12] Platonic loves toffee. 8x your Obtainium and Offering gain in Challenge 15.",
       "63": "[Cx13] Brownie Cookies, the best of both worlds. Increase 3D Cube Gain by 1% based on owned Hepteracts (+3% per OOM).",
       "64": "[Cx14] Some say the Ant God itself penned these fortunes. When you gain a statue from Platonic Cubes, you gain two instead.",
-      "65": "[Cx15] That's amore, but is quite a crumbful! Multiply Ant Speed by 1.004 per purchased Worker Ant.",
+      "65": "[Cx15] That's amore, but is quite a crumbful! Multiply Ant Speed by num:((1.004)) per purchased Worker Ant.",
       "66": "[Cx16] You just wish you could have one more cookie baked by her. Gain 2x all Cubes until you purchase OMEGA.",
-      "67": "[Cx17] What the hell are in these??? Anyway, Metaphysics Talisman level cap is increased by 1,337.",
-      "68": "[Cx18] What the heck! These aren't even cookies. +0.01% Quarks per level purchased of this upgrade. +5% more at level 1,000!",
+      "67": "[Cx17] What the hell are in these??? Anyway, Metaphysics Talisman level cap is increased by num:((1337)).",
+      "68": "[Cx18] What the heck! These aren't even cookies. +num:((0.01))% Quarks per level purchased of this upgrade. +5% more at level num:((1000))!",
       "69": "[Cx19] Cookies that you'll never remember again. +12% Golden Quarks this Singularity.",
-      "70": "[Cx20] The pinnacle of baking. Nothing you'll eat will taste better than this. For each total Corruption level, including free ones, gain 1.016x the Octeracts per second!",
-      "71": "[Cx21] For each Talisman Rarity, multiply Obtainium gain by 1.04.",
-      "72": "[Cx22] For each Talisman Rarity, multiply Offering gain by 1.04.",
+      "70": "[Cx20] The pinnacle of baking. Nothing you'll eat will taste better than this. For each total Corruption level, including free ones, gain num:((1.016))x the Octeracts per second!",
+      "71": "[Cx21] For each Talisman Rarity, multiply Obtainium gain by num:((1.04)).",
+      "72": "[Cx22] For each Talisman Rarity, multiply Offering gain by num:((1.04)).",
       "73": "[Cx23] Each level adds 1 bonus level to the Infinite Ascent rune!",
-      "74": "[Cx24] Add +0.30 to all Corruption Multiplier values.",
-      "75": "[Cx25] Each level adds +0.3% effectiveness to free Golden Quark upgrades per level! (additive with all other boosts)",
+      "74": "[Cx24] Add +num:((0.30)) to all Corruption Multiplier values.",
+      "75": "[Cx25] Each level adds +num:((0.3))% effectiveness to free Golden Quark upgrades per level! (additive with all other boosts)",
       "76": "[Cx26] Each level gives <<lightblue | +1% Ambrosia Bar Points >> for each time threshold you have reached!",
-      "77": "[Cx27] Each level adds <<green | +2 +0.1% Ambrosia Luck>>!",
-      "78": "[Cx28] Each level adds +0.3% effectiveness to free Octeract Upgrades per level!",
+      "77": "[Cx27] Each level adds <<green | +2 +num:((0.1))% Ambrosia Luck>>!",
+      "78": "[Cx28] Each level adds +num:((0.3))% effectiveness to free Octeract Upgrades per level!",
       "79": "[Cx29] Gain Ambrosia Luck when this upgrade is purchased, based on your Lifetime Red Ambrosia! [Formula is 10 * (Log_10(x))^2]",
       "80": "[Cx30] You intercept a singular message: <<gray|'Why don't you visit more often?'>>..."
     },
@@ -3128,7 +3128,7 @@
       "2": "[1x2] Increase the number of free Multipliers gained by 20% from all sources.",
       "3": "[1x3] Increase the number of free Accelerator Boosts gained by 20% from all sources.",
       "4": "[1x4] +10% Rune Power to the first five Runes! (Yes, there are more than five runes)",
-      "5": "[1x5] Multiply the production of all Crystal producers by 1e4.",
+      "5": "[1x5] Multiply the production of all Crystal producers by num:((1e4)).",
       "6": "[1x6] Gain +5% free Accelerators per level.",
       "7": "[1x7] Gain +4% free Accelerators per level.",
       "8": "[1x8] Gain +3% free Accelerators per level.",
@@ -3136,32 +3136,32 @@
       "10": "[1x10] Gain +2% free Accelerators per level.",
       "11": "[1x11] Gain +5% free Multipliers per level.",
       "12": "[1x12] Gain +4% free Multipliers per level.",
-      "13": "[1x13] Gain +2.5% free Multipliers per level.",
-      "14": "[1x14] Gain +1.5% free Multipliers per level.",
-      "15": "[1x15] Gain +0.5% free Multipliers per level.",
+      "13": "[1x13] Gain +num:((2.5))% free Multipliers per level.",
+      "14": "[1x14] Gain +num:((1.5))% free Multipliers per level.",
+      "15": "[1x15] Gain +num:((0.5))% free Multipliers per level.",
       "16": "[1x16] Gain +5% free Accelerator Boosts per level.",
       "17": "[1x17] Gain +5% free Accelerator Boosts per level.",
       "18": "[1x18] Gain +2 free Accelerator per Accelerator Boost.",
       "19": "[1x19] Gain +2 free Accelerator per Accelerator Boost.",
       "20": "[1x20] Gain +3 free Accelerator per Accelerator Boost!",
       "21": "[1x21] +1% Rune Power to the first five Runes per level.",
-      "22": "[1x22] Each Offering used increases Rune EXP by 0.6 per level.",
-      "23": "[1x23] Each Offering used increases Rune EXP by another 0.3 per level!",
-      "24": "[1x24] Increase your Base Offerings by 0.4 per level.",
-      "25": "[1x25] Increase your Base Offerings by 0.6 per level.",
+      "22": "[1x22] Each Offering used increases Rune EXP by num:((0.6)) per level.",
+      "23": "[1x23] Each Offering used increases Rune EXP by another num:((0.3)) per level!",
+      "24": "[1x24] Increase your Base Offerings by num:((0.4)) per level.",
+      "25": "[1x25] Increase your Base Offerings by num:((0.6)) per level.",
       "26": "[2x1] Multiply all Crystal producer production by 150% per level (Multiplicative).",
       "27": "[2x2] Multiply all Crystal producer production by 150% per level (Multiplicative).",
-      "28": "[2x3] You know the formula for the Crystal multiplier to Coins? Add 0.08 to its Exponent per level!",
-      "29": "[2x4] Same as [2x3]. Add 0.08 to its Exponent per level!",
-      "30": "[2x5] Half of [2x3]. Add 0.04 to its Exponent per level!",
+      "28": "[2x3] You know the formula for the Crystal multiplier to Coins? Add num:((0.08)) to its Exponent per level!",
+      "29": "[2x4] Same as [2x3]. Add num:((0.08)) to its Exponent per level!",
+      "30": "[2x5] Half of [2x3]. Add num:((0.04)) to its Exponent per level!",
       "31": "[2x6] Want to bake cookies instead? You can go offline for 4 additional hours per level (Base 72hr).",
       "32": "[2x7] Want to bake a lot of cookies instead? Extend the offline maximum timer by another 4 hours per level!",
       "33": "[2x8] Gain +11% more Multiplier Boosts from Mythos Shards per level.",
       "34": "[2x9] Gain another +11% more Multiplier Boosts from Mythos Shards per level.",
       "35": "[2x10] Gain ANOTHER +11% more Multiplier Boosts from Mythos Shards per level.",
       "36": "[2x11] Building power scales 5% faster per level.",
-      "37": "[2x12] Building power scales 2.5% faster per level.",
-      "38": "[2x13] Building power scales 2.5% faster per level.",
+      "37": "[2x12] Building power scales num:((2.5))% faster per level.",
+      "38": "[2x13] Building power scales num:((2.5))% faster per level.",
       "39": "[2x14] Building power affects Crystal production at a reduced rate.",
       "40": "[2x15] Building power affects Mythos Shard production at a reduced rate.",
       "41": "[2x16] Start Reincarnations with automatic A.Boosts unlocked. Note: this Research doesn't affect earning achievements.",
@@ -3170,20 +3170,20 @@
       "44": "[2x19] Start Reincarnations with automatic D.Upgrades unlocked.",
       "45": "[2x20] Start Reincarnations with automatic Diamond production unlocked.",
       "46": "[2x21] Unlock the ability to automatically Reincarnate!",
-      "47": "[2x22] Unlock Reincarnation upgrades 1-5. [Upgrades cost between 1 and 1,000 Particles]",
-      "48": "[2x23] Unlock Reincarnation upgrades 6-10. [Upgrades cost between 100,000 and 1e22 Particles]",
-      "49": "[2x24] Unlock Reincarnation upgrades 11-15. [Upgrades cost between 1e30 and 1e60 Particles]",
+      "47": "[2x22] Unlock Reincarnation upgrades 1-5. [Upgrades cost between 1 and num:((1000)) Particles]",
+      "48": "[2x23] Unlock Reincarnation upgrades 6-10. [Upgrades cost between num:((100000)) and num:((1e22)) Particles]",
+      "49": "[2x24] Unlock Reincarnation upgrades 11-15. [Upgrades cost between num:((1e30)) and num:((1e60)) Particles]",
       "50": "[2x25] Unlock Reincarnation upgrades 16-20. [You might want to wait until Challenge 8 is doable!]",
       "51": "[3x1] Reduces your tax burden by 6% per level.",
       "52": "[3x2] Reduces your tax burden by 5% per level (stacks multiplicative to other tax reductions).",
       "53": "[3x3] Reduces your tax burden by 5% per level (stacks multiplicative to other tax reductions).",
       "54": "[3x4] Reduces your tax burden by 5% per level (stacks multiplicative to other tax reductions).",
       "55": "[3x5] Reduces your tax burden by 5% per level (stacks multiplicative to other tax reductions).",
-      "56": "[3x6] Building Cost Scale is delayed by 0.5% per level.",
-      "57": "[3x7] Building Cost Scale is delayed by 0.5% per level.",
-      "58": "[3x8] Building Cost Scale is delayed by 0.5% per level.",
-      "59": "[3x9] Building Cost Scale is delayed by 0.5% per level.",
-      "60": "[3x10] Building Cost Scale is delayed by 0.5% per level.",
+      "56": "[3x6] Building Cost Scale is delayed by num:((0.5))% per level.",
+      "57": "[3x7] Building Cost Scale is delayed by num:((0.5))% per level.",
+      "58": "[3x8] Building Cost Scale is delayed by num:((0.5))% per level.",
+      "59": "[3x9] Building Cost Scale is delayed by num:((0.5))% per level.",
+      "60": "[3x10] Building Cost Scale is delayed by num:((0.5))% per level.",
       "61": "[3x11] Waiting to Reincarnate gives you more Obtainium when you finally do. Gain 50% of that amount increase, without having to Reincarnate! This does <b>NOT</b> affect Obtainium you would gain on Reincarnation, so it's like double dipping!",
       "62": "[3x12] Adds a flat +10% to [3x11]'s effect per level.",
       "63": "[3x13] If your Reincarnation lasts at least 2 seconds you gain +1 Base Obtainium per level.",
@@ -3207,8 +3207,8 @@
       "81": "[4x6] You thought the previous Researches are expensive? You're going to need this! [+10% Obtainium per level]",
       "82": "[4x7] Permanently UNLOCK the Rune of Superior Intellect! [Bonuses: Offerings, Obtainium and Ant Speed]",
       "83": "[4x8] Taking forever to level up that new Rune? Here's +5% Superior Intellect Rune EXP per level.",
-      "84": "[4x9] Does the Superior Intellect Rune kinda suck? Power it up! +0.5% Rune Power <b>only for SI Rune</b> per level!",
-      "85": "[4x10] Gain +0.01% more Offerings per level per Challenge completion!",
+      "84": "[4x9] Does the Superior Intellect Rune kinda suck? Power it up! +num:((0.5))% Rune Power <b>only for SI Rune</b> per level!",
+      "85": "[4x10] Gain +num:((0.01))% more Offerings per level per Challenge completion!",
       "86": "[4x11] Yeah, going back to basics. +5% Accelerators per level.",
       "87": "[4x12] 0/5 Multipliers SUCK: +5% Multipliers per level.",
       "88": "[4x13] -1/5 A.Boosts SUCK: +5% Accelerator Boosts per level.",
@@ -3219,7 +3219,7 @@
       "93": "[4x18] +1 Accelerator Boost per 20 Rune Levels, per level.",
       "94": "[4x19] +20 Multiplier per 8 Rune Levels, per level.",
       "95": "[4x20] Gain +4 base Offerings from by purchasing this. Easy Shmeezy.",
-      "96": "[4x21] Ants slow? Multiply Ant Speed by (1 + 0.0002 * level) per Worker Ant purchased.",
+      "96": "[4x21] Ants slow? Multiply Ant Speed by (1 + num:((0.0002)) * level) per Worker Ant purchased.",
       "97": "[4x22] Add +2 free levels to Ant Upgrades per level! Free levels require a corresponding purchased level to work!",
       "98": "[4x23] Add +2 more free levels to Ant Upgrades per level!",
       "99": "[4x24] Are the Quark Upgrades too hot to resist? Get +1 Quark per hour from Exporting for each level!",
@@ -3228,22 +3228,22 @@
       "102": "[5x2] Gain +1 free level to ALL Ants per level! A rainbow attack!",
       "103": "[5x3] Pray to Ant God for +5% Ant Sacrifice rewards per level!",
       "104": "[5x4] You're beginning to feel like an Ant God (Ant God): +5% Ant Sacrifice reward per level!",
-      "105": "[5x5] Buy this and be able to run the first five Challenges up to 9,001 times! (Note that requirements scale a LOT faster after 75, and again after 1,000)",
-      "106": "[5x6] Engrave your talismans with Obtainium to get +0.1% Talisman Power per level (increases the amount of free levels you get for Runes)!",
-      "107": "[5x7] Refine your talismans with the powder of Obtainium to get +0.1% Talisman Power per level, again!",
+      "105": "[5x5] Buy this and be able to run the first five Challenges up to num:((9001)) times! (Note that requirements scale a LOT faster after 75, and again after num:((1000)))",
+      "106": "[5x6] Engrave your talismans with Obtainium to get +num:((0.1))% Talisman Power per level (increases the amount of free levels you get for Runes)!",
+      "107": "[5x7] Refine your talismans with the powder of Obtainium to get +num:((0.1))% Talisman Power per level, again!",
       "108": "[5x8] A simple trick makes your base Ant ELO increase by 25 per level!",
       "109": "[5x9] A more convoluted trick makes your base Ant ELO increase by 25 per level again!",
-      "110": "[5x10] Each Reborn ELO multiplies Ant Speed by 1.02. Woah! You should create these 2% faster per level.",
+      "110": "[5x10] Each Reborn ELO multiplies Ant Speed by num:((1.02)). Woah! You should create these 2% faster per level.",
       "111": "[5x11] Here's another +1 Rune Coefficient to Speed Rune, per level!",
       "112": "[5x12] Here's another +1 Rune Coefficient to Duplication Rune, per level!",
       "113": "[5x13] Here's another +1 Rune Coefficient to Prism Rune, per level!",
       "114": "[5x14] Here's another +1 Rune Coefficient to Thrift Rune, per level!",
       "115": "[5x15] Here's +1 Rune Coefficient to Superior Intellect Rune, per level! I realize you didn't have an earlier Research for this, so this has twice as many levels.",
       "116": "[5x16] When you Sacrifice your Anthill, increment the Anthill count by 1 more per level!",
-      "117": "[5x17] Past lives couldn't ever hold your Ants down. Gain +0.01% Ant Speed per Anthill Count, per level!",
-      "118": "[5x18] Try this for size: gain +0.2% Talisman Power per level! It's like <b>twice as good</b> as the other upgrades.",
-      "119": "[5x19] Gain +0.10% Wow! Cubes per level. These are earned on Ascension.<br>Also, gain +0.5% Offerings per level.<br>ALSO! Gain +0.5% Obtainium per level.",
-      "120": "[5x20] Gain +0.50% Wow! Cubes per level.<br>Also, create Reborn ELO 0.4% faster per level.<br>ALSO! Gain +2 ELO per level.",
+      "117": "[5x17] Past lives couldn't ever hold your Ants down. Gain +num:((0.01))% Ant Speed per Anthill Count, per level!",
+      "118": "[5x18] Try this for size: gain +num:((0.2))% Talisman Power per level! It's like <b>twice as good</b> as the other upgrades.",
+      "119": "[5x19] Gain +num:((0.10))% Wow! Cubes per level. These are earned on Ascension.<br>Also, gain +num:((0.5))% Offerings per level.<br>ALSO! Gain +num:((0.5))% Obtainium per level.",
+      "120": "[5x20] Gain +num:((0.50))% Wow! Cubes per level.<br>Also, create Reborn ELO num:((0.4))% faster per level.<br>ALSO! Gain +2 ELO per level.",
       "121": "[5x21] Bend (global) time to your will, gaining +2% Global Speed per level.",
       "122": "[5x22] +2% Ant Sacrifice rewards per level.",
       "123": "[5x23] +40 Ant ELO per level.",
@@ -3252,78 +3252,78 @@
       "126": "[6x1] 6 rows? That can't be... (+1% Accelerators / level)",
       "127": "[6x2] Another +1% Accelerator Boosts / level!",
       "128": "[6x3] The trifecta! +1% Multipliers / level.",
-      "129": "[6x4] Crystal Upgrade 3 has a higher cap (+0.001 per Level * log4(Common Fragments + 1)).<br>Crystal Upgrade 4 also gets a higher cap (+0.05 per Level * log4(Common Fragments + 1)).",
+      "129": "[6x4] Crystal Upgrade 3 has a higher cap (+num:((0.001)) per Level * log4(Common Fragments + 1)).<br>Crystal Upgrade 4 also gets a higher cap (+num:((0.05)) per Level * log4(Common Fragments + 1)).",
       "130": "[6x5] Unlock automation for leveling Talismans! Activates every 2 real life seconds.",
-      "131": "[6x6] Turn some Ant Disciples against Ant God, giving +0.5% Rune Power per level. False prophets, or false profits?",
+      "131": "[6x6] Turn some Ant Disciples against Ant God, giving +num:((0.5))% Rune Power per level. False prophets, or false profits?",
       "132": "[6x7] Recruit a couple other Ants towards your side as well, giving +2 free Ant upgrade levels per level.",
       "133": "[6x8] Using some coalesced Obtainium, you can make Ant Sacrifice +3% more bountiful per level.",
-      "134": "[6x9 lol] The funny number. Gain a +6.9% bonus to Blessing Power.",
+      "134": "[6x9 lol] The funny number. Gain a +num:((6.9))% bonus to Blessing Power.",
       "135": "[6x10] Makes it so that the Talisman autobuyer automatically buys to Rarity increase!",
-      "136": "[6x11] It may be time to look back. Increase your Global Speed by +1.5% per level.",
+      "136": "[6x11] It may be time to look back. Increase your Global Speed by +num:((1.5))% per level.",
       "137": "[6x12] Paying off Wow! Industries, they'll sponsor +1% Cubes per level towards your Ascension bank.",
-      "138": "[6x13] When you open Wow! Cubes you will get +0.1% Tributes per level!",
+      "138": "[6x13] When you open Wow! Cubes you will get +num:((0.1))% Tributes per level!",
       "139": "[6x14] Make all Tesseract buildings produce 2% faster per level.",
-      "140": "[6x15] The first of a tetralogy, this tome reduces the base requirements of Challenge 10 by dividing it by 1e100M! A must-read!",
-      "141": "[6x16] The Ant God has infiltrated your mind. Run away from your conscience! +0.8% Accelerators per level",
-      "142": "[6x17] Run... RUN FASTER from your nightmares! +0.8% Accelerator Boosts per level",
-      "143": "[6x18] Your resilience somehow gives you +0.8% Multipliers per level!",
+      "140": "[6x15] The first of a tetralogy, this tome reduces the base requirements of Challenge 10 by dividing it by num:((1e100))M! A must-read!",
+      "141": "[6x16] The Ant God has infiltrated your mind. Run away from your conscience! +num:((0.8))% Accelerators per level",
+      "142": "[6x17] Run... RUN FASTER from your nightmares! +num:((0.8))% Accelerator Boosts per level",
+      "143": "[6x18] Your resilience somehow gives you +num:((0.8))% Multipliers per level!",
       "144": "[6x19] Your Obtainium gain is increased by 3 * Log4(Uncommon Fragments + 1) * level%! Why is this? I don't know.",
       "145": "[6x20] Your knowledge from the ant war will help you automatically gain Mortuus Est Ant levels.",
-      "146": "[6x21] Feed your Disciples pure Obtainium to make them produce +0.4% Rune Power (to the first five runes) per level.",
+      "146": "[6x21] Feed your Disciples pure Obtainium to make them produce +num:((0.4))% Rune Power (to the first five runes) per level.",
       "147": "[6x22] Feed your Ants their own crumbs to make them Log(Crumbs + 10)x faster!",
       "148": "[6x23] Create Reborn ELO 2% faster per level. Reborn ELO is created 2% slower per Stage. This Research doesn't quite cancel that out.",
-      "149": "[6x24] You will gain +0.03% more Offerings per level per level in the Midas Talisman!",
+      "149": "[6x24] You will gain +num:((0.03))% more Offerings per level per level in the Midas Talisman!",
       "150": "[6x25] Auto Challenge. Enough said. Lets you automatically run and complete Challenges!",
-      "151": "[7x1] A new row, old upgrade. Increase your Global Speed by +1.2% per level.",
-      "152": "[7x2] Wow! Industries sponsors another +0.9% Cubes per level towards your Ascension bank!",
+      "151": "[7x1] A new row, old upgrade. Increase your Global Speed by +num:((1.2))% per level.",
+      "152": "[7x2] Wow! Industries sponsors another +num:((0.9))% Cubes per level towards your Ascension bank!",
       "153": "[7x3] Hey, I totally didn't steal this idea. You gain 12 Tributes of Wow! Cube tier for every Tesseract opened.",
       "154": "[7x4] Make all Tesseract buildings produce 3% faster per level. Hey, isn't that more than the last Research tier?",
       "155": "[7x5] Tome 2 of 4: How to win over the Ant universe. Another e100M Divider to Challenge 10 Base Requirement on purchase.",
-      "156": "[7x6] What, again? Alright. +0.6% Accelerators per level.",
-      "157": "[7x7] Gas, gas, gas. +0.6% Accelerator Boosts per level.",
-      "158": "[7x8] Dupe DUPE DUPE. +0.6% Multipliers per level.",
+      "156": "[7x6] What, again? Alright. +num:((0.6))% Accelerators per level.",
+      "157": "[7x7] Gas, gas, gas. +num:((0.6))% Accelerator Boosts per level.",
+      "158": "[7x8] Dupe DUPE DUPE. +num:((0.6))% Multipliers per level.",
       "159": "[7x9] Somehow, I can't explain why, you reduce your Taxes by 2% multiplicative, based on 3/5 * log10(Rare Fragments)!",
       "160": "[7x10] Want a permanent Blessing boost? I know you do. A permanent +25% Blessing Power increase.",
-      "161": "[7x11] SIGMA KAPPA: +0.3% Rune Power each level!",
-      "162": "[7x12] More exponentiation! +0.0001% more Inceptus power per level!",
+      "161": "[7x11] SIGMA KAPPA: +num:((0.3))% Rune Power each level!",
+      "162": "[7x12] More exponentiation! +num:((0.0001))% more Inceptus power per level!",
       "163": "[7x13] Ant God's wanting blood: +2% Ant Sacrifice rewards / level",
       "164": "[7x14] Spirits suck, so add +8% Spirit Power per level!",
       "165": "[7x15] Gain 2x Spirit Power in Ascension Challenges!",
-      "166": "[7x16] < T I M E >: +0.9% Global Speed per level.",
-      "167": "[7x17] Because of sponsorships, Wow! Industries is increasing Cubes gained in Ascension by 0.8% per level.",
-      "168": "[7x18] Gain +0.08% Tributes from Cubes per level. You know, you should expect it at this point.",
-      "169": "[7x19] A great wave of Ant ELO! +0.02 per level. Wow! that's a lot of levels.",
+      "166": "[7x16] < T I M E >: +num:((0.9))% Global Speed per level.",
+      "167": "[7x17] Because of sponsorships, Wow! Industries is increasing Cubes gained in Ascension by num:((0.8))% per level.",
+      "168": "[7x18] Gain +num:((0.08))% Tributes from Cubes per level. You know, you should expect it at this point.",
+      "169": "[7x19] A great wave of Ant ELO! +num:((0.02)) per level. Wow! that's a lot of levels.",
       "170": "[7x20] Tome 3 of 4: How to totally ROCK Challenge 10. e100m divisor!",
-      "171": "[7x21] You should know how this goes. +0.4% Accelerators per level",
-      "172": "[7x22] Accelerator Boosts += 0.004 * Accelerator Boosts * player.researches[172]",
-      "173": "[7x23] A lot of a small +0.4% Multipliers per level",
+      "171": "[7x21] You should know how this goes. +num:((0.4))% Accelerators per level",
+      "172": "[7x22] Accelerator Boosts += num:((0.004)) * Accelerator Boosts * player.researches[172]",
+      "173": "[7x23] A lot of a small +num:((0.4))% Multipliers per level",
       "174": "[7x24] Epic Fragments boost Blessing Power by +10% * Log10(Epic Shards + 1)",
       "175": "[7x25] Automatically buy Constant Upgrades, if they are affordable! They also no longer subtract from your Constant.",
-      "176": "[8x1] Row 8 baby! +0.2% Rune Power per level.",
+      "176": "[8x1] Row 8 baby! +num:((0.2))% Rune Power per level.",
       "177": "[8x2] +Log10(Crumbs)% to Ant Speed per level. Pretty cool buff ain't it?",
       "178": "[8x3] +666 Base ELO per level! Spooky number of the devil.",
-      "179": "[8x4] +0.04% more Offerings per level per Midas Talisman level!",
+      "179": "[8x4] +num:((0.04))% more Offerings per level per Midas Talisman level!",
       "180": "[8x5] +1 Export Quark per hour per level, yet again.",
-      "181": "[8x6] +0.6% Global Speed per level because why not? You're already the speed of light.",
-      "182": "[8x7] +0.7% Cubes in Ascension bank per level, from dividends in Wow! Stock.",
+      "181": "[8x6] +num:((0.6))% Global Speed per level because why not? You're already the speed of light.",
+      "182": "[8x7] +num:((0.7))% Cubes in Ascension bank per level, from dividends in Wow! Stock.",
       "183": "[8x8] When you open a Hypercube, you also open 100 Tesseracts! (This works with 7x3, if you were curious.)",
       "184": "[8x9] +5% faster Tesseract Buildings per level. ASCENDED.",
       "185": "[8x10] Tome 4 of 4: How to Train your Ascendant. e100m divisor!",
-      "186": "[8x11] Something something +0.2% Accelerators per level... pretty cool!",
-      "187": "[8x12] Something somewhere, +0.2% Accelerator Boosts per level.",
-      "188": "[8x13] You are a DUPLICATE. +0.2% Multipliers per level",
+      "186": "[8x11] Something something +num:((0.2))% Accelerators per level... pretty cool!",
+      "187": "[8x12] Something somewhere, +num:((0.2))% Accelerator Boosts per level.",
+      "188": "[8x13] You are a DUPLICATE. +num:((0.2))% Multipliers per level",
       "189": "[8x14] Legendary Fragments increase Spirit Power by +15% * Log10(Legendary Fragments + 1)",
       "190": "[8x15] Unlock Automations for all 5 of the Tesseract buildings.",
-      "191": "[8x16] +0.1% Rune Power per level. Woah!",
-      "192": "[8x17] Each purchased level of Mortuus Est (the Ant Upgrade) also increases Wow! Cube reward by +0.20%",
+      "191": "[8x16] +num:((0.1))% Rune Power per level. Woah!",
+      "192": "[8x17] Each purchased level of Mortuus Est (the Ant Upgrade) also increases Wow! Cube reward by +num:((0.20))%",
       "193": "[8x18] +1% Ant Sacrifice reward per level.",
       "194": "[8x19] Increases both Spirit Power AND Blessing Power by +2% per level.",
       "195": "[8x20] Gain +1 export Quark per level, and increases the max timer to redeem Quarks by 5 hours each!",
-      "196": "[8x21] +0.3% Global Speed per level. Faster than the speed of light?",
-      "197": "[8x22] +0.6% Cubes in Ascension Bank per level. No one knows how. Bank error perhaps.",
-      "198": "[8x23] +0.06% Tributes from Cubes per level! Wow! Cubes really has a lot of manufacturing errors in your favor.",
+      "196": "[8x21] +num:((0.3))% Global Speed per level. Faster than the speed of light?",
+      "197": "[8x22] +num:((0.6))% Cubes in Ascension Bank per level. No one knows how. Bank error perhaps.",
+      "198": "[8x23] +num:((0.06))% Tributes from Cubes per level! Wow! Cubes really has a lot of manufacturing errors in your favor.",
       "199": "[8x24] +10% faster Tesseract Buildings / level. THE ARISEN. WITH THE PRAISE OF THE [[REDACTED]].",
-      "200": "[8x25] Gain the power of a thousand moons! +0.01% Accelerators, A. Boosts, Multipliers, Offerings per level. +0.004% Cubes per level, +(level/200) free Ant upgrade levels, 0.000666% Tax reduction per level. Every 10,000 levels grant +0.4% more Talisman Power!"
+      "200": "[8x25] Gain the power of a thousand moons! +num:((0.01))% Accelerators, A. Boosts, Multipliers, Offerings per level. +num:((0.004))% Cubes per level, +(level/200) free Ant upgrade levels, num:((0.000666))% Tax reduction per level. Every num:((10000)) levels grant +num:((0.4))% more Talisman Power!"
     },
     "thanksToResearches": "[Research 3x11] grants you this much Obtainium per second: <br> <<gold|<b>{{x}}</b> >>",
     "level": "Level {{x}}/{{y}}",
@@ -3345,86 +3345,86 @@
     "upgradeDescriptions": {
       "offeringPotion": "Instantly gain 2 real life hours of Offerings, based on your all time best Offerings/sec and speed acceleration!",
       "obtainiumPotion": "Instantly gain 2 real life hours of Obtainium, based on your all time best Obtainium/sec and speed acceleration!",
-      "offeringEX": "Each level, get +6% more Offerings! Every 10th level multiplies the effect of this upgrade by 1.08.",
+      "offeringEX": "Each level, get +6% more Offerings! Every 10th level multiplies the effect of this upgrade by num:((1.08)).",
       "offeringAuto": "Automatically pour Offerings into a Rune. Unlock the mechanic with the first level, and make it 1% faster per level!",
-      "obtainiumEX": "Each level, get +6% more Obtainium! Every 10th level multiplies the effect of this upgrade by 1.08.",
-      "obtainiumAuto": "Automatically pour Obtainium into a Research. Unlock the mechanic with the first level. Each level also reduces the cost of Researches by 0.1% per level! (Cost is rounded up)",
+      "obtainiumEX": "Each level, get +6% more Obtainium! Every 10th level multiplies the effect of this upgrade by num:((1.08)).",
+      "obtainiumAuto": "Automatically pour Obtainium into a Research. Unlock the mechanic with the first level. Each level also reduces the cost of Researches by num:((0.1))% per level! (Cost is rounded up)",
       "instantChallenge": "T and R Challenges don't cause resets if retry is enabled and gain up to 10 completions per tick. Additionally, instantly gain T Challenge completions up to highest completed when exiting R Challenges.",
       "antSpeed": "Each level grants +4 Ant ELO per level. Don't ask where it comes from.",
       "cashGrab": "This is a cash grab but it gives a couple cool stats. +1% production per level to Offerings and Obtainium.",
       "shopTalisman": "Permanently unlock a Shop talisman!",
-      "seasonPass": "Wow! Cubes is giving you a deal: Buy this totally fair Season Pass and gain +2.25% Cubes and Tesseracts per level when you Ascend!",
+      "seasonPass": "Wow! Cubes is giving you a deal: Buy this totally fair Season Pass and gain +num:((2.25))% Cubes and Tesseracts per level when you Ascend!",
       "challengeExtension": "Using some amazing trick, you manage to increase your Reincarnation Challenge cap by 2 for each level!",
       "challengeTome": "The extended cut: This fifth forgotten tome gives you an additional 20 Million exponent reduction on the Challenge 10 requirement per level. Past 60 completions of Challenge 9 or 10, this will also reduce the scaling factor by 1% per level.",
       "cubeToQuark": "Are your Quark gains from Cubes wimpy? Well, buy this for +50% Quarks from opening Wow! Cubes, forever! Additional levels grant up to +50% more, with exponential decay.",
       "tesseractToQuark": "Are your Quark gains from Tesseracts wimpy? Well, buy this for +50% Quarks from opening Wow! Tesseracts, forever! Additional levels grant up to +50% more, with exponential decay.",
       "hypercubeToQuark": "Are your Quark gains from Hypercubes wimpy? Well, buy this for +50% Quarks from opening Wow! Hypercubes, forever! Additional levels grant up to +50% more, with exponential decay.",
-      "seasonPass2": "Five times the price gouge, twice the fun! +1.5% Wow! Hypercubes and Platonic Cubes per level.",
-      "seasonPass3": "Okay, now this is just ridiculous. +1.5% Wow! Hepteracts and Octeracts per level!",
-      "chronometer": "You know, those Ascensions are kinda slow. Why don't I give you a +1.2% speedup to the timer per level?",
-      "infiniteAscent": "Okay, for an exorbitant amount, you can obtain the 6th rune, which gives +0.2% Quarks and +1% all Cube types per level!",
+      "seasonPass2": "Five times the price gouge, twice the fun! +num:((1.5))% Wow! Hypercubes and Platonic Cubes per level.",
+      "seasonPass3": "Okay, now this is just ridiculous. +num:((1.5))% Wow! Hepteracts and Octeracts per level!",
+      "chronometer": "You know, those Ascensions are kinda slow. Why don't I give you a +num:((1.2))% speedup to the timer per level?",
+      "infiniteAscent": "Okay, for an exorbitant amount, you can obtain the 6th rune, which gives +num:((0.2))% Quarks and +1% all Cube types per level!",
       "calculator": "The PL-AT can do addition in the blink of an eye. Not much else though. +14% Quarks from using code 'add' per level, the first level provides the answer and the final level does it automatically!",
       "calculator2": "The PL-AT X has improved memory capacity, allowing you to store 2 additional uses to code 'add' per level. Final level makes 'add' give 25% more Quarks!",
       "calculator3": "The PL-AT Ω is infused with some Unobtainium, which is epic! But furthermore, it reduces the variance of Quarks by code 'add' by 10% per level, which makes you more likely to get the maximum multiplier. It also has the ability to give +60 seconds to Ascension Timer per level using that code.",
-      "calculator4": "The PL-AT δ runs at 4,096Hz, which is a huge improvement over previous models. Reduce the interval between 'Add' code uses by 4% per level! Final level adds 32 additional capacity!",
+      "calculator4": "The PL-AT δ runs at num:((4096))Hz, which is a huge improvement over previous models. Reduce the interval between 'Add' code uses by 4% per level! Final level adds 32 additional capacity!",
       "calculator5": "The PL-AT Γ model somehow performs more 'powerful' computations, whatever that means. +6 seconds of GQ Export timer per level. +1 capacity every 10 levels, with 6 more at final level!",
       "calculator6": "The PL-AT _ model was made by Derpsmith, before he was banished from the industry forever. Gain 1 second of Octeract per usage per level. Final level grants 24 additional capacity!",
       "calculator7": "The PL-AT ΩΩ model was made by Derpsmith Ω, before he was banished from the industry forever. Gain 1 real-life second of Ambrosia Bar Points per usage per level. Final level grants 48 additional capacity!",
       "constantEX": "The merchant has one last trick up its sleeve: It can augment your second constant upgrade to be marginally better, but it'll cost an arm and a leg! Instead of the cap being 10% (or 11% with achievements) it will be raised by 1% per level.",
       "powderEX": "Platonic himself gives you 2% better conversion rate on Overflux Orbs to Powder per level. This activates when Orbs expire.",
-      "chronometer2": "Okay, fine. Here's another +0.6% Ascension Speed per level, stacks multiplicatively with the first upgrade!",
-      "chronometer3": "OKAY. FINE. Here's yet ANOTHER +1.5% Ascension Speed per level, stacking multiplicatively like always.",
-      "seasonPassY": "This is even more insane than the last one, but you'll buy it anyway. +0.75% ALL Cubes per level.",
+      "chronometer2": "Okay, fine. Here's another +num:((0.6))% Ascension Speed per level, stacks multiplicatively with the first upgrade!",
+      "chronometer3": "OKAY. FINE. Here's yet ANOTHER +num:((1.5))% Ascension Speed per level, stacking multiplicatively like always.",
+      "seasonPassY": "This is even more insane than the last one, but you'll buy it anyway. +num:((0.75))% ALL Cubes per level.",
       "seasonPassZ": "This one is arguably very good. Gain +1% ALL Cubes per level, per Singularity!",
       "challengeTome2": "You find the final pages of the lost tome. It functionally acts the same as the rest of the pages, but you can have up to five more!",
       "instantChallenge2": "Completing an Ascension Challenge doesn't cause a reset (if retry is enabled) and you gain 1 more completion per tick per Singularity.",
-      "cubeToQuarkAll": "First up on the menu, why not gain +0.2% Quarks from Cube opening per level?",
-      "cashGrab2": "This isn't even as good as the original. +0.5% Offerings and Obtainium per level.",
-      "chronometerZ": "Gain +0.1% Ascension Speed per level per Singularity. It needs a lot of fuel to power up.",
+      "cubeToQuarkAll": "First up on the menu, why not gain +num:((0.2))% Quarks from Cube opening per level?",
+      "cashGrab2": "This isn't even as good as the original. +num:((0.5))% Offerings and Obtainium per level.",
+      "chronometerZ": "Gain +num:((0.1))% Ascension Speed per level per Singularity. It needs a lot of fuel to power up.",
       "offeringEX2": "Gain +1% Offerings per level per Singularity. Putting the Singularity Debuff industry out of business.",
       "powderAuto": "Your grandparents had to wait a full day for powder, but not you! Per level gain +1% of orbs to powder based on the conversion rate.",
-      "seasonPassLost": "One would be advised not to touch this. +0.1% Octeracts per level, whatever those are...",
+      "seasonPassLost": "One would be advised not to touch this. +num:((0.1))% Octeracts per level, whatever those are...",
       "challenge15Auto": "Your grandparents had to bend dimensions to gain Challenge 15 score, but not you! Updates Challenge 15 Exponent every tick while in challenge 15!",
       "extraWarp": "\"Hey dude, get in this portal I built up last night in my shed!\" said the Quack Merchant. <<crimson | With this, you can use the Daily Warp twice a day... however, it might require waiting for the next day to activate.>>",
       "autoWarp": "With the power of Quacks Warp machine will now be able to go into overdrive",
-      "improveQuarkHept": "That exponent on your Quark Hepteracts is nice, but what if it was better? Gain +0.01 power per level to the Quark Hept Exponent!",
-      "improveQuarkHept2": "Want even stronger Quark Hepts? Gain +0.01 power per level to the Quark Hept Exponent!",
-      "improveQuarkHept3": "You are probably asking why I would sell this to you instead of using it for myself. Well... here's +0.01 power per level!",
-      "improveQuarkHept4": "+0.01 power per level... You know that 10^0.01 is about 1.023, right?",
+      "improveQuarkHept": "That exponent on your Quark Hepteracts is nice, but what if it was better? Gain +num:((0.01)) power per level to the Quark Hept Exponent!",
+      "improveQuarkHept2": "Want even stronger Quark Hepts? Gain +num:((0.01)) power per level to the Quark Hept Exponent!",
+      "improveQuarkHept3": "You are probably asking why I would sell this to you instead of using it for myself. Well... here's +num:((0.01)) power per level!",
+      "improveQuarkHept4": "+num:((0.01)) power per level... You know that 10^num:((0.01)) is about num:((1.023)), right?",
       "shopImprovedDaily": "Hey you. Yeah, you! Quarks make seal merchant happy. Get +5% more of them from code 'daily' per level.",
       "shopImprovedDaily2": "Gain 1 additional free Golden Quark Upgrade and 20% more Golden Quarks per use of 'daily' per level!",
       "shopImprovedDaily3": "Gain 1 additional free Golden Quark Upgrade and 15% more Golden Quarks per use of 'daily' per level!",
       "shopImprovedDaily4": "Gain 1 additional free Golden Quark Upgrade and 100% more Golden Quarks per use of 'daily' per level!",
-      "offeringEX3": "[Supplied by - Infinity CO.] Gain 1.2% more Offerings per level, multiplicative! (Multiplier is 1.012^level). Every 25 levels, gain +1 Base Offering!",
-      "obtainiumEX3": "[Supplied by - Infinity CO.] Gain 1.2% more Obtainium per level, multiplicative! (Multiplier is 1.012^level). Every 25 levels, gain 6% more Immaculate Obtainium Multiplier! (1.06^[level/25])",
-      "chronometerInfinity": "[Supplied by - Infinity CO.] Gain 0.6% more Ascension Speed per level, multiplicative! (Multiplier is 1.006^level). Every 40 levels, gain +0.001 spread on Ascension Speed exponent modifiers on speeds greater than or less than 1 (Check Stats for Nerds for this one)!",
-      "seasonPassInfinity": "[Supplied by - Infinity CO.] Gain 1.2% more cubes per level, multiplicative! (Multiplier is 1.012^level). This effect is raised to the power of 1.25 for Octeract calculations!",
+      "offeringEX3": "[Supplied by - Infinity CO.] Gain num:((1.2))% more Offerings per level, multiplicative! (Multiplier is num:((1.012))^level). Every 25 levels, gain +1 Base Offering!",
+      "obtainiumEX3": "[Supplied by - Infinity CO.] Gain num:((1.2))% more Obtainium per level, multiplicative! (Multiplier is num:((1.012))^level). Every 25 levels, gain 6% more Immaculate Obtainium Multiplier! (num:((1.06))^[level/25])",
+      "chronometerInfinity": "[Supplied by - Infinity CO.] Gain num:((0.6))% more Ascension Speed per level, multiplicative! (Multiplier is num:((1.006))^level). Every 40 levels, gain +num:((0.001)) spread on Ascension Speed exponent modifiers on speeds greater than or less than 1 (Check Stats for Nerds for this one)!",
+      "seasonPassInfinity": "[Supplied by - Infinity CO.] Gain num:((1.2))% more cubes per level, multiplicative! (Multiplier is num:((1.012))^level). This effect is raised to the power of num:((1.25)) for Octeract calculations!",
       "shopSingularityPenaltyDebuff": "Derpsmith was so proud of your performance in the first EXALT that he wants to make your singularity debuffs weaker. At a cost. A big cost.",
       "obtainiumEX2": "Gain +1% Obtainium per level per Singularity!!!",
-      "improveQuarkHept5": "[Supplied by - Infinity CO.] Adds +0.0001 Quark Hept Exponent per level. The effect is 1% of the originals... for balancing reasons. Yes.",
+      "improveQuarkHept5": "[Supplied by - Infinity CO.] Adds +num:((0.0001)) Quark Hept Exponent per level. The effect is 1% of the originals... for balancing reasons. Yes.",
       "shopAmbrosiaGeneration1": "Buying this charm grants +1% more Ambrosia Bar Points per level, for more Ambrosia!",
       "shopAmbrosiaGeneration2": "Newly fortified Obtainium Dust makes your charm more powerful, giving +1% more Ambrosia Bar Points per level, stacking multiplicatively.",
       "shopAmbrosiaGeneration3": "It turns out adding more Obtainium Dust makes your charm more powerful, go figure. +1% more Ambrosia Bar Points per level, stacking multiplicatively.",
-      "shopAmbrosiaGeneration4": "What if you also added Quark Dust??? You will find out. +0.1% more Ambrosia Bar Points per level, stacking multiplicatively.",
+      "shopAmbrosiaGeneration4": "What if you also added Quark Dust??? You will find out. +num:((0.1))% more Ambrosia Bar Points per level, stacking multiplicatively.",
       "shopAmbrosiaLuck1": "Buying this charm grants +2 Ambrosia luck per level, for more Ambrosia!",
       "shopAmbrosiaLuck2": "You get a slightly larger four leaf clover, giving +2 Ambrosia luck per level, stacking additively.",
       "shopAmbrosiaLuck3": "You get a slightly greener four leaf clover, giving +2 Ambrosia luck per level, stacking additively.",
-      "shopAmbrosiaLuck4": "You get a slightly 'better' four leaf clover, what ever that means, giving +0.6 Ambrosia luck per level, stacking additively.",
-      "shopRedLuck1": "A small, lesser dice from the tactician of gambling himself. +0.05 Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by 0.01.",
-      "shopRedLuck2": "This one seems to have a heavy side. I wonder what that is about. +0.075 Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by 0.01.",
-      "shopRedLuck3": "When you pick up this dice, it phases out of existence, then returns, the six face-up. +0.1 Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by 0.01.",
+      "shopAmbrosiaLuck4": "You get a slightly 'better' four leaf clover, what ever that means, giving +num:((0.6)) Ambrosia luck per level, stacking additively.",
+      "shopRedLuck1": "A small, lesser dice from the tactician of gambling himself. +num:((0.05)) Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by num:((0.01)).",
+      "shopRedLuck2": "This one seems to have a heavy side. I wonder what that is about. +num:((0.075)) Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by num:((0.01)).",
+      "shopRedLuck3": "When you pick up this dice, it phases out of existence, then returns, the six face-up. +num:((0.1)) Red Luck per level. Every 20 levels, reduce the conversion ratio of Ambrosia Luck to Red Luck by num:((0.01)).",
       "shopAmbrosiaLuckMultiplier4": "Gain +1% Ambrosia Luck per level! Simple as that.",
       "shopOcteractAmbrosiaLuck": "Gain +1 Ambrosia Luck per level, multiplied by the number of digits in your lifetime produced Octeracts!",
-      "shopCashGrabUltra": "For a nominal price, gain up to +15% Ambrosia Bar Points, +120% Cubes and +8% Quarks per level based on Ambrosia, scaling nonlinearly until 10,000,000 lifetime earned.",
-      "shopAmbrosiaAccelerator": "For each level of this Accelerator, reduce Ambrosia Bar Point requirements for Ambrosia generation by 0.6% per completion of EXALT 5 - No Ambrosia Upgrades.",
-      "shopEXUltra": "With this EX Upgrade, every 1,000 owned Ambrosia adds +0.1% <<orchid|Obtainium>>, <<orange|Offerings>> and <<white|Cubes>>! This effect caps at 125,000 * (level of shop upgrade)!",
+      "shopCashGrabUltra": "For a nominal price, gain up to +15% Ambrosia Bar Points, +120% Cubes and +8% Quarks per level based on Ambrosia, scaling nonlinearly until num:((10000000)) lifetime earned.",
+      "shopAmbrosiaAccelerator": "For each level of this Accelerator, reduce Ambrosia Bar Point requirements for Ambrosia generation by num:((0.6))% per completion of EXALT 5 - No Ambrosia Upgrades.",
+      "shopEXUltra": "With this EX Upgrade, every num:((1000)) owned Ambrosia adds +num:((0.1))% <<orchid|Obtainium>>, <<orange|Offerings>> and <<white|Cubes>>! This effect caps at num:((125000)) * (level of shop upgrade)!",
       "shopChronometerS": "With this upgrade, you gain +1% Ascension Speed and Global Speed per Singularity number above 200 your Singularity takes place!",
       "shopAmbrosiaUltra": "For this absurdly expensive EX Upgrade, every EXALT completion grants +2 permanent Ambrosia Luck, per level.",
       "shopSingularitySpeedup": "You know all those time-gated Singularity Perks and Upgrades? Now they accumulate 50 times faster! Thanks to this weird clock that somehow alters even <<gray | Singular Time>>...",
-      "shopSingularityPotency": "You know all those free Golden Quark Upgrades? They are now 266% more effective (so, each is worth the equivalent to 3.66 levels, before softcaps). Why? This kinda weird <<gray | Singularity Transmission Ritual Device>>! Don't question it.",
+      "shopSingularityPotency": "You know all those free Golden Quark Upgrades? They are now 266% more effective (so, each is worth the equivalent to num:((3.66)) levels, before softcaps). Why? This kinda weird <<gray | Singularity Transmission Ritual Device>>! Don't question it.",
       "shopSadisticRune": "What a weird rune; The shopkeeper (who you know no longer can see) says telepathically that it is an Infinite Ascent rune drenched in some <<gray | Singularity Matter>>. Were there other Ascents? Or maybe a <<gray | Descent?>>",
-      "shopInfiniteShopUpgrades": "A Shop Voucher, printed on a blue tablet. Each grants +0.01 effective levels of the 'Infinity CO.' Quark shop upgrades, multiplied by the sum of your EXALT completions, all rounded down.",
-      "shopHorseShoe": "Horse Shoes make good protection! Add 3 free levels of Horse Shoe rune, and each level of Horse Shoe rune decreases effects of Singularity Debuffs (except Salvage) by 0.1% per level additive (Max -30%)!",
+      "shopInfiniteShopUpgrades": "A Shop Voucher, printed on a blue tablet. Each grants +num:((0.01)) effective levels of the 'Infinity CO.' Quark shop upgrades, multiplied by the sum of your EXALT completions, all rounded down.",
+      "shopHorseShoe": "Horse Shoes make good protection! Add 3 free levels of Horse Shoe rune, and each level of Horse Shoe rune decreases effects of Singularity Debuffs (except Salvage) by num:((0.1))% per level additive (Max -30%)!",
       "shopPanthema": "Ace from space!"
     },
     "maxed": "Maxed!",
@@ -3672,8 +3672,8 @@
       },
       "xyz": {
         "name": "XYZ: Xtra dailY rewardZ",
-        "hasLevel2": "In addition to GQ and guaranteed free levels to GQ 1/2/3 at +0.2/+0.2/+1, you get DOUBLE the amount of free upgrade levels from the Daily Special Action!",
-        "hasLevel1": "In addition to GQ and free upgrade levels, the Daily Special Action gives you additional free levels to GQ 1/2/3 at +0.2/+0.2/+1 levels respectively.",
+        "hasLevel2": "In addition to GQ and guaranteed free levels to GQ 1/2/3 at +num:((0.2))/+num:((0.2))/+1, you get DOUBLE the amount of free upgrade levels from the Daily Special Action!",
+        "hasLevel1": "In addition to GQ and free upgrade levels, the Daily Special Action gives you additional free levels to GQ 1/2/3 at +num:((0.2))/+num:((0.2))/+1 levels respectively.",
         "default": "The Daily Special Action now rewards you with Golden Quarks and free levels for random Golden Quark upgrades, both scaling with your singularity count!"
       },
       "generousOrbs": {
@@ -3711,10 +3711,10 @@
       },
       "antGodsCornucopia": {
         "name": "Ant God's Cornucopia",
-        "hasLevel3": "Ant God gives you <<crimson | 1,000,000,000,000x Ant Speed>>!",
-        "hasLevel2": "Ant God gives you <<crimson | 1,000,000x Ant Speed>>!",
-        "hasLevel1": "Ant God gives you <<crimson | 1,000x Ant Speed>>!",
-        "default": "Ant God gives you <<crimson | 4.44x Ant Speed>>!"
+        "hasLevel3": "Ant God gives you <<crimson | num:((1000000000000))x Ant Speed>>!",
+        "hasLevel2": "Ant God gives you <<crimson | num:((1000000))x Ant Speed>>!",
+        "hasLevel1": "Ant God gives you <<crimson | num:((1000))x Ant Speed>>!",
+        "default": "Ant God gives you <<crimson | num:((4.44))x Ant Speed>>!"
       },
       "bringToLife": {
         "name": "Bring to Life",
@@ -3727,8 +3727,8 @@
       "invigoratedSpirits": {
         "name": "Invigorated Spirits!",
         "default": "Your ants feel a greater emotional weight from their lost bretheren of Sacrifices past.",
-        "line2": "For your first 200,000 Immortal ELO, <<orchid|{{x}}%>> of it gets added to your Ant ELO!",
-        "line3": "For the next 1,800,000 Immortal ELO, <<orchid|{{x}}%>> of it gets added."
+        "line2": "For your first num:((200000)) Immortal ELO, <<orchid|{{x}}%>> of it gets added to your Ant ELO!",
+        "line3": "For the next num:((1800000)) Immortal ELO, <<orchid|{{x}}%>> of it gets added."
       },
       "sweepomatic": {
         "name": "Automatic Sweep-o-matic Mk.2",
@@ -3737,9 +3737,9 @@
       },
       "superStart": {
         "name": "Super Start",
-        "hasLevel4": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, 2.22e2222 Particles and 500 Obtainium",
-        "hasLevel3": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, 1e100 Particles and 500 Obtainium",
-        "hasLevel2": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, 1e16 Particles and 500 Obtainium",
+        "hasLevel4": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, num:((2.22e2222)) Particles and 500 Obtainium",
+        "hasLevel3": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, num:((1e100)) Particles and 500 Obtainium",
+        "hasLevel2": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos, num:((1e16)) Particles and 500 Obtainium",
         "hasLevel1": "You start each Ascension with 1 Transcension, 1 Reincarnation, 1001 Mythos and 10 Particles",
         "default": "You start each Ascension with 1 Transcension and 1001 Mythos"
       },
@@ -3777,7 +3777,7 @@
       },
       "forTheLoveOfTheAntGod": {
         "name": "For the love of (the Ant) God!",
-        "hasLevel2": "You permanently keep Ants unlocked and start Anthills with 40 Worker Ants, 20 Breeder Ants, 25 Meta-Breeder Ants, 25 Inceptus Formicidae levels, 1 Mortuus Est Formicidae level, and 1e50 Galactic Crumbs",
+        "hasLevel2": "You permanently keep Ants unlocked and start Anthills with 40 Worker Ants, 20 Breeder Ants, 25 Meta-Breeder Ants, 25 Inceptus Formicidae levels, 1 Mortuus Est Formicidae level, and num:((1e50)) Galactic Crumbs",
         "hasLevel1": "You permanently keep Ants unlocked and start Anthills with 40 Worker Ants, 20 Breeder Ants, and 10 Inceptus Formicidae levels",
         "default": "You permanently keep Ants unlocked and start Anthills with 20 Worker Ants and 10 Inceptus Formicidae levels"
       },
@@ -3831,11 +3831,11 @@
       },
       "goldenRevolution": {
         "name": "Golden Revolution",
-        "default": "Singularity grants 0.4% more Golden Quarks per Singularity. Currently: +{{current}}% (MAX: +100%)"
+        "default": "Singularity grants num:((0.4))% more Golden Quarks per Singularity. Currently: +{{current}}% (MAX: +100%)"
       },
       "goldenRevolutionII": {
         "name": "Golden Revolution II",
-        "default": "Golden Quarks are 0.2% cheaper per Singularity. Currently: -{{current}}% (MAX: -50%)"
+        "default": "Golden Quarks are num:((0.2))% cheaper per Singularity. Currently: -{{current}}% (MAX: -50%)"
       },
       "goldenRevolutionIII": {
         "name": "Golden Revolution III",
@@ -3851,7 +3851,7 @@
       },
       "midasMilleniumAgedGold": {
         "name": "Midas' Millennium-Aged Gold",
-        "default": "Every use of the 'Add' Special Action gives 0.01 free levels of GQ1 and 0.05 free levels of GQ3."
+        "default": "Every use of the 'Add' Special Action gives num:((0.01)) free levels of GQ1 and num:((0.05)) free levels of GQ3."
       },
       "goldenRevolution4": {
         "name": "Golden Revolution IV",
@@ -3859,8 +3859,8 @@
       },
       "octeractMetagenesis": {
         "name": "Octeract Metagenesis",
-        "hasLevel1": "Gives free levels of Octeract Cogenesis AND Trigenesis based on your current free levels and purchased levels: (level * free / 640)^0.5, (level^2 * free/125000)^0.333 respectively ",
-        "default": "Gives free levels of Octeract Cogenesis based on your current free levels and purchased levels: (level * free / 1000)^0.5"
+        "hasLevel1": "Gives free levels of Octeract Cogenesis AND Trigenesis based on your current free levels and purchased levels: (level * free / 640)^num:((0.5)), (level^2 * free/125000)^num:((0.333)) respectively ",
+        "default": "Gives free levels of Octeract Cogenesis based on your current free levels and purchased levels: (level * free / 1000)^num:((0.5))"
       },
       "immaculateAlchemy": {
         "name": "Immaculate Alchemy",
@@ -3883,8 +3883,8 @@
       },
       "infiniteShopUpgrades": {
         "name": "Orange Infinity Shop Voucher",
-        "default": "Gain +0.5 effective levels of the 'Infinity CO.' Quark Upgrades per highest Singularity, minus 200, rounded down! Currently: {{amt}}",
-        "level2": "Gain +0.8 effective levels of the 'Infinity CO.' Quark Upgrades per highest Singularity, minus 200, rounded down! Currently: {{amt}}"
+        "default": "Gain +num:((0.5)) effective levels of the 'Infinity CO.' Quark Upgrades per highest Singularity, minus 200, rounded down! Currently: {{amt}}",
+        "level2": "Gain +num:((0.8)) effective levels of the 'Infinity CO.' Quark Upgrades per highest Singularity, minus 200, rounded down! Currently: {{amt}}"
       },
       "taxReduction": {
         "name": "Accountants Clicking at Your Desktop",
@@ -3896,7 +3896,7 @@
       },
       "infiniteRecycling": {
         "name": "Infinite Recycling",
-        "default": "Your Infinite Ascent Rune gains a third perk: +0.025 <<green|Salvage>> per level, per tier! Currently: +{{salvage}}"
+        "default": "Your Infinite Ascent Rune gains a third perk: +num:((0.025)) <<green|Salvage>> per level, per tier! Currently: +{{salvage}}"
       },
       "recyclistsDesktop": {
         "name": "Recyclists Clicking at Your Desktop",
@@ -3925,7 +3925,7 @@
       },
       "goldenQuarks2": {
         "name": "Golden Quarks II",
-        "description": "Buying GQ is 0.2% cheaper per level! [After 50%, effect grows much slower]",
+        "description": "Buying GQ is num:((0.2))% cheaper per level! [After 50%, effect grows much slower]",
         "effect": "Purchasing Golden Quarks in the shop is {{n}}% cheaper."
       },
       "goldenQuarks3": {
@@ -4024,7 +4024,7 @@
       },
       "singCubes1": {
         "name": "Cube Flame",
-        "description": "Upgrade this to get +0.6% Cubes per level, forever!",
+        "description": "Upgrade this to get +num:((0.6))% Cubes per level, forever!",
         "effect": "Permanently gain {{n}} more Cubes."
       },
       "singCubes2": {
@@ -4065,31 +4065,31 @@
       },
       "intermediatePack": {
         "name": "Intermediate Pack",
-        "description": "Double Global Speed, Multiply Ascension Speed by 1.5, and gain +2% Quarks forever. Yum... 2% Quark Milk.",
+        "description": "Double Global Speed, Multiply Ascension Speed by num:((1.5)), and gain +2% Quarks forever. Yum... 2% Quark Milk.",
         "effectHave": "You have upgraded your package to intermediate.",
         "effectHaveNot": "You have not upgraded your package to intermediate."
       },
       "advancedPack": {
         "name": "Advanced Pack",
-        "description": "Now we're cooking with kerosene! Gain +4% Quarks, additive with intermediate pack, +0.33 to all Corruption score multipliers, regardless of level!",
+        "description": "Now we're cooking with kerosene! Gain +4% Quarks, additive with intermediate pack, +num:((0.33)) to all Corruption score multipliers, regardless of level!",
         "effectHave": "You have bought our advanced package.",
         "effectHaveNot": "You have not bought our advanced package."
       },
       "expertPack": {
         "name": "Expert Pack",
-        "description": "That's a handful! Gain +6% Quarks, additive with other packs, 1.5x Ascension Score, Code 'add' gives 1.2x Ascension Timer.",
+        "description": "That's a handful! Gain +6% Quarks, additive with other packs, num:((1.5))x Ascension Score, Code 'add' gives num:((1.2))x Ascension Timer.",
         "effectHave": "You have switched to the expert provider.",
         "effectHaveNot": "You have not switched to the expert provider."
       },
       "masterPack": {
         "name": "Master Pack",
-        "description": "A tad insane. Gain +8% Quarks, additive with other packs. Multiply your overall Ascension Score by 1.5. Wow!",
+        "description": "A tad insane. Gain +8% Quarks, additive with other packs. Multiply your overall Ascension Score by num:((1.5)). Wow!",
         "effectHave": "You have mastered your inner chakras.",
         "effectHaveNot": "You have not mastered your inner chakras."
       },
       "divinePack": {
         "name": "Divine Pack",
-        "description": "OHHHHH. Gain +10% Quarks, additive with other packs, and multiply Octeract gain by 1.25 for each Corruption at level 14 or higher (1.3 for >=15 and 1.4 for >=16)!",
+        "description": "OHHHHH. Gain +10% Quarks, additive with other packs, and multiply Octeract gain by num:((1.25)) for each Corruption at level 14 or higher (num:((1.3)) for >=15 and num:((1.4)) for >=16)!",
         "effectHave": "You have found the reason for existence. Current Octeract Bonus: +{{n}}",
         "effectHaveNot": "You have not found the reason for existence."
       },
@@ -4137,12 +4137,12 @@
       },
       "singQuarkImprover1": {
         "name": "Marginal Quark Gain Improver Thingy",
-        "description": "A doohickey that I forgot what it looked like. +0.5% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
+        "description": "A doohickey that I forgot what it looked like. +num:((0.5))% Quarks per level, multiplicative with all other bonuses! Seems like it grows in cost a lot faster than anything else though. Also, did you know these descriptions can be arbitrarily long?",
         "effect": "You gain {{n}} more Quarks!"
       },
       "singQuarkHepteract": {
         "name": "I wish my Quark Hepteract was marginally better.",
-        "description": "Wrong game, oops. Anyway, would you like more exponent on your Quark Hepteract. +0.01 per level, to be precise.",
+        "description": "Wrong game, oops. Anyway, would you like more exponent on your Quark Hepteract. +num:((0.01)) per level, to be precise.",
         "effect": "Quark Hepteract Exponent +{{n}}"
       },
       "singQuarkHepteract2": {
@@ -4157,17 +4157,17 @@
       },
       "singOcteractGain": {
         "name": "Octeract Absinthe",
-        "description": "You would have never known this tonic can boost your Octeracts! [+1.25% per level, in fact!]",
+        "description": "You would have never known this tonic can boost your Octeracts! [+num:((1.25))% per level, in fact!]",
         "effect": "Octeract Gain +{{n}}"
       },
       "singOcteractGain2": {
         "name": "Pieces of Eight",
-        "description": "There is indeed eight of them, but each only gives +0.625% bonus, so each level gives +5% Octeract per level.",
+        "description": "There is indeed eight of them, but each only gives +num:((0.625))% bonus, so each level gives +5% Octeract per level.",
         "effect": "Octeract Gain +{{n}}"
       },
       "singOcteractGain3": {
         "name": "The Obelisk Shaped like an Octagon.",
-        "description": "Platonic had to reach pretty far here. +2.5% Octeracts yeah!",
+        "description": "Platonic had to reach pretty far here. +num:((2.5))% Octeracts yeah!",
         "effect": "Octeract Gain +{{n}}"
       },
       "singOcteractGain4": {
@@ -4182,7 +4182,7 @@
       },
       "platonicTau": {
         "name": "Platonic TAU",
-        "description": "Placed in the wrong upgrade section, this will remove any restrictions on corruptions or corruption level caps! Also raises 3d cube gain to the power of 1.01!",
+        "description": "Placed in the wrong upgrade section, this will remove any restrictions on corruptions or corruption level caps! Also raises 3d cube gain to the power of num:((1.01))!",
         "effectHave": "This upgrade has been purchased",
         "effectHaveNot": "This upgrade has not been purchased"
       },
@@ -4206,24 +4206,24 @@
       },
       "singFastForward": {
         "name": "Etherflux Singularities",
-        "description": "Golden Quark gained by Singularity is increased by 2.5% (additive), and lets you 'look ahead' an extra Singularity. This means you can choose (from the Elevator) to skip a Singularity if you do one at your all time highest!",
+        "description": "Golden Quark gained by Singularity is increased by num:((2.5))% (additive), and lets you 'look ahead' an extra Singularity. This means you can choose (from the Elevator) to skip a Singularity if you do one at your all time highest!",
         "effectHave": "You've transformed the Etherflux!",
         "effectHaveNot": "You haven't transformed the Etherflux!"
       },
       "singFastForward2": {
         "name": "Aetherflux Singularities",
-        "description": "Golden Quark gained by Singularity is increased by 2.5% (additive) and lets you 'look ahead' yet another Singularity!",
+        "description": "Golden Quark gained by Singularity is increased by num:((2.5))% (additive) and lets you 'look ahead' yet another Singularity!",
         "effectHave": "You've transformed the Aetherflux!",
         "effectHaveNot": "You haven't transformed the Aetherflux!"
       },
       "singAscensionSpeed": {
         "name": "A hecking good Ascension speedup!",
-        "description": "Ascension Speed is raised to the power of 1.03, raised to 0.97 if less than 1x.",
+        "description": "Ascension Speed is raised to the power of num:((1.03)), raised to num:((0.97)) if less than 1x.",
         "effect": "Ascension Speed ^{{n}}, ^{{m}} if < 1x"
       },
       "singAscensionSpeed2": {
         "name": "Ascended Ascension Speedup!",
-        "description": "The first upgrade gave 0.03 of what we in the business call 'exponent spread'. This adds +0.001 per level!",
+        "description": "The first upgrade gave num:((0.03)) of what we in the business call 'exponent spread'. This adds +num:((0.001)) per level!",
         "effect": "Exponent Spread on Ascension Speed +{{n}}"
       },
       "ultimatePen": {
@@ -4233,7 +4233,7 @@
       },
       "halfMind": {
         "name": "HALF MIND",
-        "description": "A note, you found on the 'ground': seems like an advertisement for a cult. \"Lock your global speed to 1,000,000x, and multiply all obtainium and offerings based on the difference.\" Hmm...",
+        "description": "A note, you found on the 'ground': seems like an advertisement for a cult. \"Lock your global speed to num:((1000000))x, and multiply all obtainium and offerings based on the difference.\" Hmm...",
         "effectHave": "You have joined the cult!",
         "effectHaveNot": "You haven't joined the cult!"
       },
@@ -4341,7 +4341,7 @@
       },
       "favoriteUpgrade": {
         "name": "Your Favorite Upgrades' Favorite Upgrade",
-        "description": "This upgrade gets stronger for every upgrade from the following list that is maxed! (+0.02% Quarks per level, per maxed upgrade + 6)",
+        "description": "This upgrade gets stronger for every upgrade from the following list that is maxed! (+num:((0.02))% Quarks per level, per maxed upgrade + 6)",
         "upgrade1": "Golden Quarks I: {{checkMark}}",
         "upgrade2": "Platonic DELTA: {{checkMark}}",
         "upgrade3": "ONE MIND: {{checkMark}}",
@@ -4483,7 +4483,7 @@
       "9": "Gain 1 free Multiplier per 10 purchased Accelerators.",
       "10": "Improve Workers based on the first 750 purchased Investments.",
       "11": "Accelerators improve generation production by 2% each.",
-      "12": "Each Prestige multiplies production by 1.01, multiplicatively (Max: 1e4x).",
+      "12": "Each Prestige multiplies production by num:((1.01)), multiplicatively (Max: num:((1e4))x).",
       "13": "Augments buff the production of Investments.",
       "14": "Free Accelerators buff generation of Printers.",
       "15": "Free Accelerators buff generation of Mints.",
@@ -4502,20 +4502,20 @@
       "28": "Gain a free level of Duplication Rune per 400 Coin producers bought. (Max: +100)",
       "29": "Gain a free level of Speed Rune per 400 Coin producers bought. (Max: +100)",
       "30": "Gain free levels of Duplication Rune based on unspent Coins. (Max: +100)",
-      "31": "Gain 1 free Accelerator Boost per 2,000 Coin producers bought.",
+      "31": "Gain 1 free Accelerator Boost per num:((2000)) Coin producers bought.",
       "32": "Gain free Accelerators based on Unspent Diamonds.",
       "33": "Gain 1 free Multiplier for each Accelerator Boost owned.",
       "34": "Gain 3% more free Multipliers.",
       "35": "Gain 2% more free Multipliers.",
-      "36": "Multiply Crystal production by Diamonds, maximum 1e5000x.",
+      "36": "Multiply Crystal production by Diamonds, maximum num:((1e5000))x.",
       "37": "Multiply Mythos Shard production by the squared logarithm of Diamonds.",
       "38": "Gain +20% more Offerings thanks to generous Discord Server Boosters!",
       "39": "Gain +60% more Ant Speed thanks to generous Discord Server Boosters!",
       "40": "Gain +25% more Ant Sacrifice rewards thanks to generous Discord Server Boosters!",
       "41": "Multiply production based on unspent Mythos.",
       "42": "Multiply Mythos Shard production based on unspent Diamonds.",
-      "43": "Multiply coin production by 1.01 per Transcension (Max: 1e30x).",
-      "44": "Multiply Mythos gain on Transcend by 1.01 per Transcension (Max: 1e6x).",
+      "43": "Multiply coin production by num:((1.01)) per Transcension (Max: num:((1e30))x).",
+      "44": "Multiply Mythos gain on Transcend by num:((1.01)) per Transcension (Max: num:((1e6))x).",
       "45": "Gain free Accelerators based on Mythos Shards.",
       "46": "Accelerator Boosts are 5% stronger and do not reset Prestige features.",
       "47": "Multiply Mythos Shard production based on your AP.",
@@ -4523,7 +4523,7 @@
       "49": "Gain free Multipliers based on unspent Mythos.",
       "50": "Gain +25% free Accelerators and Multipliers, but ONLY while doing Challenges.",
       "51": "Increase production of all Mythos buildings based on owned Accelerator Boosts.",
-      "52": "Mythos building exponent +0.025.",
+      "52": "Mythos building exponent +num:((0.025)).",
       "53": "Augments produce more Shards based on Acceleration Multiplier.",
       "54": "Wizards produce more Enchantments based on Multiplier.",
       "55": "Grandmasters produce more Oracles based on Building power.",
@@ -4533,25 +4533,25 @@
       "59": "Coin Mint production is multiplied by 1e+25000.",
       "60": "Alchemies production is multiplied by 1e+35000.",
       "61": "Welcome to Reincarnation! +7 Salvage to get you started.",
-      "62": "Gain +0.02 Base Offerings per Challenge Completion! (Max: +12)",
-      "63": "Crystal Production is multiplied based on Particles to the sixth power [Caps at 1e6000x].",
+      "62": "Gain +num:((0.02)) Base Offerings per Challenge Completion! (Max: +12)",
+      "63": "Crystal Production is multiplied based on Particles to the sixth power [Caps at num:((1e6000))x].",
       "64": "Mythos Shard Production is multiplied by your Particles squared.",
       "65": "Multiply the gain of Particles from Reincarnation by 5x!",
       "66": "Add +2 to the Rune Coefficient of the first five Runes. Reduce how many offerings you need to level up your Runes!",
       "67": "Atom gain is increased by 3% per Particle producer purchased!",
-      "68": "Gain a free Multiplier for every 1e1000x increase in tax.",
+      "68": "Gain a free Multiplier for every num:((1e1000))x increase in tax.",
       "69": "Gain more Obtainium based on your particle gain. [Works with automation at a reduced rate!]",
-      "70": "Time seems to go +0.333*log10(MAX Obtainium +1)% faster when you buy this.",
+      "70": "Time seems to go +num:((0.333))*log10(MAX Obtainium +1)% faster when you buy this.",
       "71": "Runes will gain (Rune Level/25) additional EXP per Offering used.",
       "72": "Obtainium gain from Reincarnations is multiplied (1 + 2C) where C is #Reincarnation Challenges completed, up to 50x!",
       "73": "Gain +100% free Accelerator Boosts and +10 free Crystal Upgrade levels, but only in Reincarnation Challenges.",
-      "74": "Obtainium gain is increased based on highest ever unspent Offerings. [Max: 100,000 Offerings]",
-      "75": "Offering gain is increased based on highest ever unspent Obtainium [Max: 30,000,000 Obtainium]",
+      "74": "Obtainium gain is increased based on highest ever unspent Offerings. [Max: num:((100000)) Offerings]",
+      "75": "Offering gain is increased based on highest ever unspent Obtainium [Max: num:((30000000)) Obtainium]",
       "76": "Ant generation kinda slow? I agree! Multiply Ant Speed by 5.",
-      "77": "This is Synergism, right? Let's make each purchased Worker Ant multiply Ant Speed by 1.004.",
-      "78": "Gain an Ant speed multiplier! x(1 + 0.005 * (log10(MAX Offerings + 1))^2) Ant Speed, to be precise.",
+      "77": "This is Synergism, right? Let's make each purchased Worker Ant multiply Ant Speed by num:((1.004)).",
+      "78": "Gain an Ant speed multiplier! x(1 + num:((0.005)) * (log10(MAX Offerings + 1))^2) Ant Speed, to be precise.",
       "79": "The Ant Speed multiplier from your Global Speed multiplier is raised to the fourth power! If Global Speed multiplier is less than 1 this upgrade does nothing.",
-      "80": "Gain Ant ELO based on your total Sacrifice Count! Up to +1,000 Ant ELO.",
+      "80": "Gain Ant ELO based on your total Sacrifice Count! Up to +num:((1000)) Ant ELO.",
       "81": "Automatically buy Workers if affordable.",
       "82": "Automatically buy Investments if affordable.",
       "83": "Automatically buy Printers if affordable.",
@@ -4577,26 +4577,26 @@
       "103": "Printers will produce Investments.",
       "104": "Investments will produce Workers.",
       "105": "Purchased Workers will produce Alchemies.",
-      "106": "Refineries can produce Alchemies equal to Refineries owned raised to 0.10",
-      "107": "Refinery -> Alchemy exponent increased from 0.10 to 0.25.",
-      "108": "Refinery -> Alchemy exponent increased from 0.25 to 0.50",
-      "109": "Refinery -> Alchemy exponent increased from 0.50 to 0.75",
-      "110": "Refinery -> Alchemy exponent increased from 0.75 to 1",
-      "111": "Augments can produce Pandora Boxes equal to Augments owned raised to 0.08",
-      "112": "Augment -> Box exponent increased from 0.08 to 0.16",
-      "113": "Augment -> Box exponent increased from 0.16 to 0.24",
-      "114": "Augment -> Box exponent increased from 0.24 to 0.32",
-      "115": "Augment -> Box exponent increased from 0.32 to 0.40",
-      "116": "Protons can produce Grandmasters equal to Protons owned raised to 0.05",
-      "117": "Protons -> Grandmaster exponent increased from 0.05 to 0.10",
-      "118": "Protons -> Grandmaster exponent increased from 0.10 to 0.15",
-      "119": "Protons -> Grandmaster exponent increased from 0.15 to 0.20",
-      "120": "Protons -> Grandmaster exponent increased from 0.20 to 0.25",
+      "106": "Refineries can produce Alchemies equal to Refineries owned raised to num:((0.10))",
+      "107": "Refinery -> Alchemy exponent increased from num:((0.10)) to num:((0.25)).",
+      "108": "Refinery -> Alchemy exponent increased from num:((0.25)) to num:((0.50))",
+      "109": "Refinery -> Alchemy exponent increased from num:((0.50)) to num:((0.75))",
+      "110": "Refinery -> Alchemy exponent increased from num:((0.75)) to 1",
+      "111": "Augments can produce Pandora Boxes equal to Augments owned raised to num:((0.08))",
+      "112": "Augment -> Box exponent increased from num:((0.08)) to num:((0.16))",
+      "113": "Augment -> Box exponent increased from num:((0.16)) to num:((0.24))",
+      "114": "Augment -> Box exponent increased from num:((0.24)) to num:((0.32))",
+      "115": "Augment -> Box exponent increased from num:((0.32)) to num:((0.40))",
+      "116": "Protons can produce Grandmasters equal to Protons owned raised to num:((0.05))",
+      "117": "Protons -> Grandmaster exponent increased from num:((0.05)) to num:((0.10))",
+      "118": "Protons -> Grandmaster exponent increased from num:((0.10)) to num:((0.15))",
+      "119": "Protons -> Grandmaster exponent increased from num:((0.15)) to num:((0.20))",
+      "120": "Protons -> Grandmaster exponent increased from num:((0.20)) to num:((0.25))",
       "121": "You probably autobought this. -50% taxes!",
       "122": "Increase Crystal Upgrade 3 cap by 100%! (Adds +100% to the max Diamond Building production bonus)",
-      "123": "Raise coin production to the power of 1.025. More EXPONENTS.",
-      "124": "Immortal ELO becomes Reborn ELO 1.1x as fast!",
-      "125": "Constant Tax divisor is 0.333% stronger per challenge 10 completion. [Divisor^(1 + upgrade)]"
+      "123": "Raise coin production to the power of num:((1.025)). More EXPONENTS.",
+      "124": "Immortal ELO becomes Reborn ELO num:((1.1))x as fast!",
+      "125": "Constant Tax divisor is num:((0.333))% stronger per challenge 10 completion. [Divisor^(1 + upgrade)]"
     },
     "crystalEffects": {
       "1": "Diamond Building Production x{{x}}",
@@ -4629,12 +4629,12 @@
     },
     "constantUpgrades": {
       "1": "Make all Tesseract buildings {{level}}% more productive per level.",
-      "2": "Each Tesseract building bought increases the production of all of them by 0.1% per level [Max {{max}}%].",
+      "2": "Each Tesseract building bought increases the production of all of them by num:((0.1))% per level [Max {{max}}%].",
       "3": "Increase Offering gain +2% per level.",
       "4": "Increase Obtainium gain +4% per level.",
-      "5": "Multiply Ant speed by (1 + 0.1 * level * log10(Constant + 1))",
-      "6": "Add up to 1,000 free Ant Levels! (Each level gives slightly less than the last)",
-      "7": "Provides 7 free rune levels per level, up to +7,000.",
+      "5": "Multiply Ant speed by (1 + num:((0.1)) * level * log10(Constant + 1))",
+      "6": "Add up to num:((1000)) free Ant Levels! (Each level gives slightly less than the last)",
+      "7": "Provides 7 free rune levels per level, up to +num:((7000)).",
       "8": "Increase the rune EXP given by Offerings by 10% per level [Additive]",
       "9": "When bought, Rune Power is increased by Log4(Talisman Shards +1) %",
       "10": "When bought, gain Log4(Constant + 1)% more Wow! Cubes and Tesseracts on Ascension."
@@ -4656,7 +4656,7 @@
       "14": "Effect: Printer Generation x{{x}}",
       "15": "Effect: Mint Generation x{{x}}",
       "16": "Effect: Gain {{x}}x more Diamonds on Prestige",
-      "17": "Effect: Mint Production x1e100 (Duh)",
+      "17": "Effect: Mint Production xnum:((1e100)) (Duh)",
       "18": "Effect: Printer Production x{{x}}",
       "19": "Effect: Investment Production x{{x}}",
       "20": "Effect: All coin production is further multiplied by {{x}} [Stacks with upgrade 1]!",
@@ -4724,7 +4724,7 @@
       "120": "Effect: All you need to know is right above this message!",
       "121": "Effect: -50% Taxes duh!",
       "122": "Effect: +88% cap to Crystal Upgrade 3, duh!",
-      "123": "Effect: Coin Production ^1.025, duh!",
+      "123": "Effect: Coin Production ^num:((1.025)), duh!",
       "124": "Effect: 10% faster Reborn ELO creation!",
       "125": "+{{x}}% Constant Divisor power."
     },
@@ -5211,13 +5211,13 @@
     "spiritBonus": "However, it also multiplies Spirit Power by <<wheat|{{multiplier}}>>.",
     "corruptionBank": "You have <<var(--crimson-text-color)|{{number}}>> Total Wow! Cubes in the Ascension bank. Gain more by finishing Challenges! Ascend to redeem them.",
     "corruptionScore": "Your Ascension Score is <<goldenrod|{{ascScore}}>></span> (base) * <<var(--crimson-text-color)|{{corrMult}}>> (Corruption mult) * <<var(--orchid-text-color)|{{bonusMult}}>> (Bonus mult) = <<var(--darkorchid-text-color)|{{totalScore}}>>",
-    "corruptionScoreDR": "Past 1e23 Ascension Score, further gains are square rooted! You are currently under this penalty.",
+    "corruptionScoreDR": "Past num:((1e23)) Ascension Score, further gains are square rooted! You are currently under this penalty.",
     "ascensionCount": "If you Ascend now, <<darkorange|{{ascCount}}>> will be added to your ascension count.",
     "corruptionCubes": "If you Ascend now, you will gain <<yellow|{{cubeAmount}}>> Wow! Cubes.",
-    "corruptionTesseracts": "If you Ascend now, you will gain <<orange|{{tesseractAmount}}>> Wow! Tesseracts. [<<var(--orange-text-color)|Get more if Score >100,000>>]",
-    "corruptionHypercubes": "If you Ascend now, you will gain <<var(--crimson-text-color)|{{hypercubeAmount}}>> Wow! Hypercubes. [<<var(--red-text-color)|Req Score: >1,000,000,000>>]",
-    "corruptionPlatonics": "If you Ascend now, you will gain <<orchid|{{platonicAmount}}>> PLATONIC CUBES. [<<var(--orchid-text-color)|Req Score: >2,666,000,000,000>>]",
-    "corruptionHepteracts": "If you Ascend now, you will gain <<mediumpurple|{{hepteractAmount}}>> HEPTERACTS. [<<mediumpurple|Req Score: >1.666e17>>]",
+    "corruptionTesseracts": "If you Ascend now, you will gain <<orange|{{tesseractAmount}}>> Wow! Tesseracts. [<<var(--orange-text-color)|Get more if Score >num:((100000))>>]",
+    "corruptionHypercubes": "If you Ascend now, you will gain <<var(--crimson-text-color)|{{hypercubeAmount}}>> Wow! Hypercubes. [<<var(--red-text-color)|Req Score: >num:((1000000000))>>]",
+    "corruptionPlatonics": "If you Ascend now, you will gain <<orchid|{{platonicAmount}}>> PLATONIC CUBES. [<<var(--orchid-text-color)|Req Score: >num:((2666000000000))>>]",
+    "corruptionHepteracts": "If you Ascend now, you will gain <<mediumpurple|{{hepteractAmount}}>> HEPTERACTS. [<<mediumpurple|Req Score: >num:((1.666e17))>>]",
     "autoAscend": {
       "c10Completions": "Ascend when you've completed Sadistic Challenge I a total of <<var(--violet-text-color)|{{input}}>> times, Currently <<gold|{{completions}}>>",
       "realTime": "Ascend when the timer is at least <<var(--violet-text-color)|{{input}}>> seconds (Real-time), Currently <<gold|{{time}}>>",
@@ -5259,16 +5259,16 @@
       "3": "A million coins! Something tells you that being a millionaire here isn't all that impressive.",
       "4": "You're beyond rich, you're loaded! However, it does not feel... <<cyan | prestigious>> enough.",
       "5": "Even with your prestige, it does not do your 1 googol coins justice. You must <<orchid | transcend>> your idea of wealth.",
-      "6": "1e500 coins! Weren't you dirt poor just a couple hours ago?",
-      "7": "1e2500 coins! Even the amount of digits in your wealth is becoming noteworthy to you or I. Might I need to <<limegreen | reincarnate>> to regain consciousness?",
+      "6": "num:((1e500)) coins! Weren't you dirt poor just a couple hours ago?",
+      "7": "num:((1e2500)) coins! Even the amount of digits in your wealth is becoming noteworthy to you or I. Might I need to <<limegreen | reincarnate>> to regain consciousness?",
       "8": "I'm starting to believe that no amount of coins are enough. <<limegreen | Reincarnation>> only strengthens your penchant for wealth accumulation.",
-      "9": "Your wealth now has 100,000 digits. Have you even considered how long it would take to write it out? You should ask <a href=\"https://ivark.github.io/AntimatterDimensions\" target=\"_blank\"><<yellow | Hevipelle>></a>.",
+      "9": "Your wealth now has num:((100000)) digits. Have you even considered how long it would take to write it out? You should ask <a href=\"https://ivark.github.io/AntimatterDimensions\" target=\"_blank\"><<yellow | Hevipelle>></a>.",
       "10": "Remember when you had just a million coins? Pepperidge farm remembers. <<grey | Your Grandma>> remembers...",
       "11": "The three digits at the front of your total coins are called a <<orange | mantissa>>. Do they even matter in your case?",
-      "12": "Your wealth is equal to the number of atoms in the universe, raised to the power of <<gold | 1,250,000>>...",
+      "12": "Your wealth is equal to the number of atoms in the universe, raised to the power of <<gold | num:((1250000))>>...",
       "13": "You see the ants from down here. However, do you see the ants from <<orange | up there>>?",
       "14": "If you had a dollar for every digit in your wealth, you would be the richest person on this thing one would call <<lightblue|\"Earth\">>...",
-      "15": "10^1,000,000,000,000,000 Coins! If the exponent were multiplied by 9, in some alternative <<grey | Realities>> you would overflow the universe with coins.",
+      "15": "10^num:((1000000000000000)) Coins! If the exponent were multiplied by 9, in some alternative <<grey | Realities>> you would overflow the universe with coins.",
       "16": "An exponent so large, many wouldn't know it by name.",
       "17": "Have you ever questioned why the <<gray | Tax Man>> divides your coins? The ultimate creator of this reality, which you believe to be a <<cyan | Platonic>> (ideal) being, instructed as much.",
       "18": "Octillions of digits in your wealth! What if there were other <<green | Octagonal>> objects in this reality? That would be silly.",
@@ -5276,7 +5276,7 @@
       "20": "I think you are long past the point where the <<gray | Tax Man>> is the only thing holding you back. Right?",
       "21": "Sometimes you wonder if the Ant God is better off just feeding off your Coins. You surely have enough.",
       "22": "Ant God, Derpsmith, the Gold Guy, <<cyan | Platonic>>... who are all of these entities anyway?",
-      "23": "10 to the <<gold|10,000,000,000,000,000,000>><<orange|,000,000,000,000,000,000>><<brown|,000,000,000,000,000,000>><<<grey|,000,000,000,000,000>>",
+      "23": "10 to the <<gold|num:((10000000000000000000))>><<orange|,num:((000000000000000000))>><<brown|,num:((000000000000000000))>><<<grey|,num:((000000000000000))>>",
       "24": "They should write stories about your wealth. It only suffices that an <<grey | Ultimate Pen>> will do.",
       "25": "No one will know my name, but the bards' songs will remain.",
       "26": "That's a lot of coins lol"
@@ -5350,7 +5350,7 @@
       "currentEffect": "Current Effect: <<lightblue|{{effect}}>>"
     },
     "mythosYouHave": "You have {{shards}} Mythos Shards, providing {{mult}} Multiplier Power boosts.",
-    "eachMultiplierBoost": "Each Multiplier Boost increases the base effect of Multipliers by 0.02.",
+    "eachMultiplierBoost": "Each Multiplier Boost increases the base effect of Multipliers by num:((0.02)).",
     "costMythos": "Cost: {{mythos}} Mythos",
     "atomsYouHave": "You have <<white|{{atoms}}>> Atoms, providing <<gold|{{power}}>> Building Power.<br>Each Coin Producer purchased multiplies Coin Production by <<gold|{{power}}>><br>Multiplier to Coin Production: <<gold|{{mult}}>><br><<orange|Coin multiplier also increases your Tax Cap, and is further exempt from Taxation>>",
     "costParticles": "Cost: {{particles}} Particles",
@@ -5381,7 +5381,7 @@
     "data": {
       "octeractStarter": {
         "name": "Octeracts for Dummies",
-        "description": "Hello... I Am Derpsmith... The Ancestor Of Ant God... I Did Not Expect You To Get Here. Here Is 25% More Quarks, 40% More Octeracts, And 100,000x Ant Speed...",
+        "description": "Hello... I Am Derpsmith... The Ancestor Of Ant God... I Did Not Expect You To Get Here. Here Is 25% More Quarks, 40% More Octeracts, And num:((100000))x Ant Speed...",
         "effectDisabled": "You have not yet paid your respects to Derpsmith. No rewards for you!",
         "effectEnabled": "You have paid respects to Derpsmith. {{amount}} Quarks, {{amount2}} Octeracts and {{amount3}}x Ant Speed as promised!"
       },
@@ -5397,12 +5397,12 @@
       },
       "octeractQuarkGain": {
         "name": "Quark Octeract",
-        "description": "An altered forme of the hepteract, this gives a 1.1% Quark Bonus per level without Diminishing Return.",
+        "description": "An altered forme of the hepteract, this gives a num:((1.1))% Quark Bonus per level without Diminishing Return.",
         "effect": "Quark gain is increased by {{n}}."
       },
       "octeractQuarkGain2": {
         "name": "Octo-Hepteract Primality Synergism",
-        "description": "For every 111 levels of Quark Octeract, you gain 0.01% more Quarks per digit in your Quark Hepteract count per level!",
+        "description": "For every 111 levels of Quark Octeract, you gain num:((0.01))% more Quarks per digit in your Quark Hepteract count per level!",
         "effectDisabled": "Octo-Hepteract Primality Synergism is not currently occuring.",
         "effectEnabled": "Octo-Hepteract Primality Synergism is granting you {{amount}} more Quarks! <br> +{{amount2}} per digit in your Quark Hepteract count <br> Total digits: {{amount3}}"
       },
@@ -5433,12 +5433,12 @@
       },
       "octeractImprovedDaily3": {
         "name": "CHONKEREREST Daily Code",
-        "description": "It will never satisfy Derpsmith. +1 +0.5% more free Golden Quark upgrades per day from Daily!",
+        "description": "It will never satisfy Derpsmith. +1 +num:((0.5))% more free Golden Quark upgrades per day from Daily!",
         "effect": "Code 'daily' gives +{{n}} more free Golden Quark upgrades per use."
       },
       "octeractImprovedQuarkHept": {
         "name": "I wish for even better Quark Hepteracts.",
-        "description": "The godmother is absent, but Derpsmith is here! +0.01 exponent to your Quark Hepteract per level.",
+        "description": "The godmother is absent, but Derpsmith is here! +num:((0.01)) exponent to your Quark Hepteract per level.",
         "effect": "Quark Hepteract Exponent +{{n}}"
       },
       "octeractImprovedGlobalSpeed": {
@@ -5448,12 +5448,12 @@
       },
       "octeractImprovedAscensionSpeed": {
         "name": "Abstract Photokinetics",
-        "description": "Gain +0.05% Ascension Speed per level per singularity!",
+        "description": "Gain +num:((0.05))% Ascension Speed per level per singularity!",
         "effect": "Ascension Speed per singularity +{{n}}% <br> Total Ascension Speed increase: +{{mult}}"
       },
       "octeractImprovedAscensionSpeed2": {
         "name": "Abstract Exokinetics",
-        "description": "Gain +0.05% Ascension Speed per level per singularity!",
+        "description": "Gain +num:((0.05))% Ascension Speed per level per singularity!",
         "effect": "Ascension Speed per singularity +{{n}}% <br> Total Ascension Speed increase: +{{mult}}"
       },
       "octeractImprovedFree": {
@@ -5464,17 +5464,17 @@
       },
       "octeractImprovedFree2": {
         "name": "Wow! Free upgrades still suck.",
-        "description": "Who said beggars can't be choosers? Increase the exponent of the first upgrade in this set by 0.05.",
+        "description": "Who said beggars can't be choosers? Increase the exponent of the first upgrade in this set by num:((0.05)).",
         "effect": "Exponent of previous upgrade +{{n}}."
       },
       "octeractImprovedFree3": {
         "name": "Wow! Make free upgrades good already, Platonic!",
-        "description": "Increase the exponent of the first upgrade in this set by 0.05",
+        "description": "Increase the exponent of the first upgrade in this set by num:((0.05))",
         "effect": "Exponent of the first upgrade +{{n}}"
       },
       "octeractImprovedFree4": {
         "name": "Coupon of Ultimate Penniless Derpsmiths",
-        "description": "Each level increases the exponent of the first upgrade in this set by 0.001, with the first level adding another 0.01.",
+        "description": "Each level increases the exponent of the first upgrade in this set by num:((0.001)), with the first level adding another num:((0.01)).",
         "effect": "Exponent of the first upgrade +{{n}}"
       },
       "octeractBonusTokens1": {
@@ -5529,7 +5529,7 @@
       },
       "octeractFastForward": {
         "name": "Derpsmith's Singularity Discombobulator",
-        "description": "Each level gives +2.5% more Golden Quarks (additive), and lets you 'look ahead' another Singularity!",
+        "description": "Each level gives +num:((2.5))% more Golden Quarks (additive), and lets you 'look ahead' another Singularity!",
         "effect": "Singularities give {{n100}}% more GQ, 'look ahead' limit +{{n}}"
       },
       "octeractAutoPotionSpeed": {
@@ -5642,26 +5642,26 @@
       "name": "Speed",
       "description": "An energy emanates from this stone. You feel compelled to inscribe power into it with your Offerings.",
       "lockedDescription": "Erm. This should be unlocked. If you see this, please report it as a bug.",
-      "acceleratorPower": "<<cyan | Accelerator Power +{{val}}%>> (+0.02% per Power)",
-      "freeAccelerators": "<<cyan | Free Accelerators +{{val}}>> (+0.25% per Power)",
+      "acceleratorPower": "<<cyan | Accelerator Power +{{val}}%>> (+num:((0.02))% per Power)",
+      "freeAccelerators": "<<cyan | Free Accelerators +{{val}}>> (+num:((0.25))% per Power)",
       "globalSpeed": "<<royalblue | Global Speed +{{val}}>> (Up to +100%)",
-      "values": "+0.02% Accelerator Power, +0.25% Free Accelerators per level. Global Speed (affecting resource production, and most reset timers) is multiplied by up to 2!",
+      "values": "+num:((0.02))% Accelerator Power, +num:((0.25))% Free Accelerators per level. Global Speed (affecting resource production, and most reset timers) is multiplied by up to 2!",
       "effect": "Speed Rune Bonus: +{{val}}% Accelerator Power, +{{val2}} Free Accelerators, +{{val3}} Global Speed."
     },
     "duplication": {
       "name": "Duplication",
       "description": "\"<i>Its ability lies in the world inside of the mirror...</i>\" -some bizarre inscription",
       "lockedDescription": "This rune is locked! To unlock it, Prestige 100 times. You even get an Achievement for it!",
-      "multiplierPower": "<<pink | Multiplier Power Boosts +{{val}}>> (+0.2 per Power)",
-      "freeMultipliers": "<<pink | Free Multipliers +{{val}}>> (+0.25% per Power)",
-      "taxReduction": "<<lightgray | Tax Growth -{{val}}%>> (Up to -99.9%)",
-      "values": "+0.2 Multiplier Power Boost (each gives +0.02 to Multiplier Power), +0.25% Free Multipliers per level. Tax growth is delayed more for each level (cap: 99.9%)!",
+      "multiplierPower": "<<pink | Multiplier Power Boosts +{{val}}>> (+num:((0.2)) per Power)",
+      "freeMultipliers": "<<pink | Free Multipliers +{{val}}>> (+num:((0.25))% per Power)",
+      "taxReduction": "<<lightgray | Tax Growth -{{val}}%>> (Up to -num:((99.9))%)",
+      "values": "+num:((0.2)) Multiplier Power Boost (each gives +num:((0.02)) to Multiplier Power), +num:((0.25))% Free Multipliers per level. Tax growth is delayed more for each level (cap: num:((99.9))%)!",
       "effect": "Duplication Rune Bonus: +{{val}} Multiplier Power Boosts, +{{val2}} Free Multipliers, -{{val3}}% Tax Growth."
     },
     "prism": {
       "name": "Prism",
       "description": "Has all colors of the visible light spectrum. As well as a few you cannot yet fathom.",
-      "lockedDescription": "This rune is locked! To unlock it, Transcend 1,000 times. You even get an Achievement for it!",
+      "lockedDescription": "This rune is locked! To unlock it, Transcend num:((1000)) times. You even get an Achievement for it!",
       "crystalProduction": "<<lightblue | Crystal Production {{val}}x>> (1 + (Power / 2)^2 * 2^(Power / 2) / 256)x",
       "costDivisor": "<<lightblue | Crystal Upgrade Costs /{{val}}>> (Divide by 10 every 10 Power)",
       "values": "~(1 + (Level/2)^2 * 2^(Level/2) / 256)x Crystal Production. Every 10 Rune Power, divide the cost of all Crystal Upgrades by 10.",
@@ -5670,19 +5670,19 @@
     "thrift": {
       "name": "Thrift",
       "description": "It seems with this Rune in tow, you keep making great deals on your purchases, and your Offerings are just a little more reusable.",
-      "lockedDescription": "This rune is locked! To unlock it, Reincarnate 10,000 times. You even get an Achievement for it!",
-      "costDelay": "<<lime | Building Cost Growth Delay +{{val}}%>> (+0.125% per Power, max +1.00e15% at 8e15 Power)",
-      "salvage": "<<limegreen|+{{val}} Salvage>> (+5.756 * log_10(1 + Power / 10))",
+      "lockedDescription": "This rune is locked! To unlock it, Reincarnate num:((10000)) times. You even get an Achievement for it!",
+      "costDelay": "<<lime | Building Cost Growth Delay +{{val}}%>> (+num:((0.125))% per Power, max +num:((1.00e15))% at num:((8e15)) Power)",
+      "salvage": "<<limegreen|+{{val}} Salvage>> (+num:((5.756)) * log_10(1 + Power / 10))",
       "taxReduction": "<<lightgray | Tax Growth -{{val}}%>> (Up to -99%)",
-      "values": "+0.125% building cost growth delay per level, more Salvage per level (log scaling), Tax Growth is delayed more for each level (cap: 99%)!",
+      "values": "+num:((0.125))% building cost growth delay per level, more Salvage per level (log scaling), Tax Growth is delayed more for each level (cap: 99%)!",
       "effect": "Thrift Rune Bonus: Delay all producer cost increases by {{val}}%, Salvage: +{{val2}}. -{{val3}}% Tax Growth"
     },
     "superiorIntellect": {
       "name": "Superior Intellect",
       "description": "Over a hundred times the number of brain cells the average human has, put into one rock. It's probably sentient.",
       "lockedDescription": "This rune is locked! Unlocking it might require some novel Research.",
-      "offeringMult": "<<orange | Offering Gain +{{val}}>> (+0.05% per Power)",
-      "obtainiumMult": "<<pink | Obtainium Gain +{{val}}>> (+0.50% per Power)",
+      "offeringMult": "<<orange | Offering Gain +{{val}}>> (+num:((0.05))% per Power)",
+      "obtainiumMult": "<<pink | Obtainium Gain +{{val}}>> (+num:((0.50))% per Power)",
       "antSpeed": "<<crimson | Ant Speed x{{val}}>> x(1 + Power / 500)^2",
       "values": "(1 + level/2000)x Offerings, (1 + level/200)x Obtainium, (1 + Level^2/2500)x Ant Hatch Speed",
       "effect": "S. Intellect Rune Bonus: Offerings x{{val}}, Obtainium x{{val2}}, Ant Speed x{{val3}}"
@@ -5691,10 +5691,10 @@
       "name": "Infinite Ascent",
       "description": "A staircase you can only climb facing backwards, how weird is that?",
       "lockedDescription": "This rune is locked! You may need some Quarks to unlock this one. Or, head to the <<gold | PseudoCoins>> tab to unlock it instantly!",
-      "quarkBonus": "<<cyan | Quark Gain +{{val}}>> (+0.2% per Power)",
+      "quarkBonus": "<<cyan | Quark Gain +{{val}}>> (+num:((0.2))% per Power)",
       "cubeBonus": "<<white | Cube Gain +{{val}}>> (+1% per Power)",
       "salvage": "BONUS! <<limegreen|+{{val}} Salvage>> (+{{val2}} per Power. see <i>Infinite Recycling</i>)",
-      "values": "+0.2% Quarks, +1% all Cube types per level! Start with +10% Quarks.",
+      "values": "+num:((0.2))% Quarks, +1% all Cube types per level! Start with +10% Quarks.",
       "effect": "IA Rune Bonus: Quark Gain +{{val}}, Ascensions give +{{val2}} more Cubes.",
       "bonusEffect": "PLUS, Salvage +{{val3}} (Infinite Recycling bonus)"
     },
@@ -5706,7 +5706,7 @@
       "offeringBonus": "<<orange | Offering Gain x{{val}}>> (x10 per Power)",
       "obtainiumBonus": "<<pink | Obtainium Gain x{{val}}>> (x10 per Power)",
       "addCode": "<<lightgray | 'Add' Code Refresh Interval {{val}}>> (-20% at 1 Power, up to -50%)",
-      "cubeBonus": "<<white | Wow! Cube Gain +{{val}}>> (1.01x per level (max 5), times your current... Singularity?)",
+      "cubeBonus": "<<white | Wow! Cube Gain +{{val}}>> (num:((1.01))x per level (max 5), times your current... Singularity?)",
       "values": "Level 1 unlocks something <span class=\"rainbowText\">special</span>! Each level gives 10x Offerings, 10x <<cyan | Immaculate>> Obtainium and makes code 'Add' regenerate faster.",
       "effect": "Offerings x{{val}}, <<cyan | Immaculate>> Obtainium x{{val2}}, 'Add' code regeneration interval is {{val3}}% as long."
     },
@@ -5715,19 +5715,19 @@
       "description": "I never realized the world was so easily won, just by realizing you got someone to say you won't be lonely anymore.",
       "lockedDescription": "This rune is locked! To unlock it, you might need to tussle with the <<lightgray|Taxman>> himself.",
       "ambrosiaLuck": "<<limegreen | {{val}} Ambrosia Luck>> (+1 per Power)",
-      "redLuck": "<<red | {{val}} Red Luck>> (+0.2 per Power)",
-      "luckConversion": "<<crimson | Luck Conversion Ratio {{val}}>> (Up to -0.5)",
-      "values": "Each level gives you +1 Ambrosia Luck, +0.2 Red Luck. You also reduce the Luck Conversion Ratio between the two by up to 0.5, depending on level (-0.5 * level / (level + 50))",
+      "redLuck": "<<red | {{val}} Red Luck>> (+num:((0.2)) per Power)",
+      "luckConversion": "<<crimson | Luck Conversion Ratio {{val}}>> (Up to -num:((0.5)))",
+      "values": "Each level gives you +1 Ambrosia Luck, +num:((0.2)) Red Luck. You also reduce the Luck Conversion Ratio between the two by up to num:((0.5)), depending on level (-num:((0.5)) * level / (level + 50))",
       "effect": "Horseshoe Rune Bonus: +{{val}} Ambrosia Luck, +{{val2}} Red Luck, {{val3}} Luck Conversion Ratio."
     },
     "finiteDescent": {
       "name": "Finite Descent",
       "description": "That shopkeep told me it was an Ascent. That <i>liar</i>!",
       "lockedDescription": "This rune is locked! Honestly, I have no idea how you unlock this.",
-      "corruptionLevels": "<<lightgray | +{{val}} Free Corruption Levels>> (up to +0.15)",
+      "corruptionLevels": "<<lightgray | +{{val}} Free Corruption Levels>> (up to +num:((0.15)))",
       "ascensionScore": "<<orange | +{{val}} Ascension Score>> (up to +100%)",
       "infiniteAscentLevels": "<<lightgoldenrodyellow | +{{val}} Free Infinite Ascent levels>> (+1 every 2 Power)",
-      "values": "Gain up to 2x more Ascension Score for your current Ascension, increase your free Corruption levels up to 0.15, and tack on +1 free Infinite Ascent level every two levels. Shweet!",
+      "values": "Gain up to 2x more Ascension Score for your current Ascension, increase your free Corruption levels up to num:((0.15)), and tack on +1 free Infinite Ascent level every two levels. Shweet!",
       "effect": "This Ascension, gain +{{val}} Ascension Score, {{val2}} free Corruption levels, and +{{val3}} Infinite Ascent levels."
     },
     "topHat": {
@@ -5737,12 +5737,12 @@
       "freeLevelTemplate": "{{typeIcon}} Quark Upgrades get +{{val}} free levels! [MAX: {{max}}]"
     },
     "levelup": {
-      "1": "+(Level/4)^1.25 Accelerator, +0.25% Accelerators per level. +1 Accelerator Boost every 20 levels!",
-      "2": "+(Level/10) Multipliers every 10th level, +0.25% Multipliers per level. Tax growth is delayed more for each level!",
+      "1": "+(Level/4)^num:((1.25)) Accelerator, +num:((0.25))% Accelerators per level. +1 Accelerator Boost every 20 levels!",
+      "2": "+(Level/10) Multipliers every 10th level, +num:((0.25))% Multipliers per level. Tax growth is delayed more for each level!",
       "3": "~(1 + (Level/2)^2 * 2^(Level/2) / 256)x Crystal Production. +1 free level for each Crystal upgrade per 16 levels!",
-      "4": "+0.125% building cost growth delay per level, +0.0625% Offering recycle chance per level [MAX: 25%], 2^((1000 - Level)/1100) Tax growth multiplier AFTER level 400",
+      "4": "+num:((0.125))% building cost growth delay per level, +num:((0.0625))% Offering recycle chance per level [MAX: 25%], 2^((1000 - Level)/1100) Tax growth multiplier AFTER level 400",
       "5": "~(1 + level/200)x Obtainium, (1 + Level^2/2500)x Ant Hatch Speed, (1 + level/2000)x Offerings",
-      "6": "+0.2% Quarks, +1% all Cube types per level! Start with +10% Quarks.",
+      "6": "+num:((0.2))% Quarks, +1% all Cube types per level! Start with +10% Quarks.",
       "7": "I wonder what happens if you feed it {{exp}} Rune EXP."
     },
     "power": {
@@ -5759,8 +5759,8 @@
       "enhance": "To Rarity",
       "respec": "MAX",
       "respecAll": "RESPEC ALL",
-      "respecConfirm": "Confirm [-100,000 Offerings]",
-      "respecConfirmAll": "Confirm All [-400,000 Offerings]",
+      "respecConfirm": "Confirm [-num:((100000)) Offerings]",
+      "respecConfirmAll": "Confirm All [-num:((400000)) Offerings]",
       "respecCancel": "Cancel Respec Changes",
       "respecSummary": "+-==-+ Select for 3 GREEN Runes, for Respec! +-==-+",
       "buy": "BUY",
@@ -5809,7 +5809,7 @@
         "name": "Metaphysical Gem",
         "description": "Do you wear this, or does this wear you?",
         "inscription": "<<gold|Inscription>>: This Talismans' Bonus Rune Levels are increased by <<gold|{{val}}>>.",
-        "signature": "<<crimson|Signature>>: This Talismans' Bonus Rune Levels are further multiplied by <<crimson|1.07>>."
+        "signature": "<<crimson|Signature>>: This Talismans' Bonus Rune Levels are further multiplied by <<crimson|num:((1.07))>>."
       },
       "polymath": {
         "name": "Trinket of the Polymath",
@@ -5930,23 +5930,23 @@
       "blessingEXP": "<b>Blessing EXP: {{exp}}</b> <<orange | (+{{perEXP}} per Offering)>>",
       "speed": {
         "description": "A few times, it's been around this track.",
-        "globalSpeed": "<<royalblue | Global Speed +{{val}}>> (+1% per 10,000 Blessing Power)"
+        "globalSpeed": "<<royalblue | Global Speed +{{val}}>> (+1% per num:((10000)) Blessing Power)"
       },
       "duplication": {
         "description": "<i>I control the inside of the mirror... that's my ability.</i>",
-        "multiplierBoosts": "<<pink | Multiplier Power Boosts +{{val}}>> (+1% per 10,000 Blessing Power)"
+        "multiplierBoosts": "<<pink | Multiplier Power Boosts +{{val}}>> (+1% per num:((10000)) Blessing Power)"
       },
       "prism": {
         "description": "If I get with the ultraviolet dream...",
-        "antSacrifice": "<<crimson | Ant Sacrifice Rewards +{{val}}>> (+1% per 10,000 Blessing Power)"
+        "antSacrifice": "<<crimson | Ant Sacrifice Rewards +{{val}}>> (+1% per num:((10000)) Blessing Power)"
       },
       "thrift": {
         "description": "<i>\"Who wishes to fight must first count the cost.\"</i> - Sun Tzu, <i>The Art of War</i>",
-        "acceleratorBoostDelay": "<<cyan | Accelerator Boost Cost Delay +{{val}}>> (+0.01% per 10,000 Blessing Power)"
+        "acceleratorBoostDelay": "<<cyan | Accelerator Boost Cost Delay +{{val}}>> (+num:((0.01))% per num:((10000)) Blessing Power)"
       },
       "superiorIntellect": {
         "description": "-- ANT LEGION -- ANT LEGION -- ANT LEGION --",
-        "obtExponent": "<<crimson | Ant Speed x(Obtainium)^{{val}}>> (Exponent = ln(1 + Blessing Power / 1e6))",
+        "obtExponent": "<<crimson | Ant Speed x(Obtainium)^{{val}}>> (Exponent = ln(1 + Blessing Power / num:((1e6))))",
         "antSpeed": "↳<b><<crimson | Ant Speed x{{val}}>></b>"
       },
       "increaseLevel": "Increase Level By <<orchid|{{amount}}>> [Cost: <<orchid|{{offerings}}>> Offerings]"
@@ -5971,23 +5971,23 @@
       },
       "speed": {
         "description": "Roger Bannister et al. wore this shoe.",
-        "globalSpeed": "<<royalblue | Global Speed +{{val}}>> (+1% per 10,000,000 Spirit Power)"
+        "globalSpeed": "<<royalblue | Global Speed +{{val}}>> (+1% per num:((10000000)) Spirit Power)"
       },
       "duplication": {
         "description": "A male contained within a reflective surface, quite illusive.",
-        "wowCubes": "<<white | Wow! Cubes +{{val}}>> (+1% per 10,000,000 Spirit Power)"
+        "wowCubes": "<<white | Wow! Cubes +{{val}}>> (+1% per num:((10000000)) Spirit Power)"
       },
       "prism": {
         "description": "Hide from the red light beam.",
-        "crystalCaps": "<<lightblue | Crystal Upgrade 4 Max Exponent +{{val}}>> (Spirit Power / 1e9)"
+        "crystalCaps": "<<lightblue | Crystal Upgrade 4 Max Exponent +{{val}}>> (Spirit Power / num:((1e9)))"
       },
       "thrift": {
         "description": "Conjure the ghost of Synergism's Past!",
-        "offerings": "<<orange | Offering Gain +{{val}}>> (+1% per 10,000,000 Spirit Power)"
+        "offerings": "<<orange | Offering Gain +{{val}}>> (+1% per num:((10000000)) Spirit Power)"
       },
       "superiorIntellect": {
         "description": "I too have a theoretical degree in Physics.",
-        "obtainium": "<<pink | Obtainium Gain +{{val}}>> (+1% per 10,000,000 Spirit Power)"
+        "obtainium": "<<pink | Obtainium Gain +{{val}}>> (+1% per num:((10000000)) Spirit Power)"
       },
       "buyUpTo": "Buy up to <<var(--orchid-text-color)|{{amount}}>> Levels per purchase, if affordable. [Input to toggle]",
       "increaseLevel": "Increase Level By <<lightgoldenrodyellow|{{amount}}>> [Cost: <<lightgoldenrodyellow|{{offerings}}>> Offerings]"
@@ -6062,8 +6062,8 @@
       "oneChallengeCap": {
         "name": "One Challenge Caps",
         "description": "Beat the target Singularity, but the first 14 Challenges have a cap of only 1!",
-        "ScalingReward1": "+0.05 increase to <<var(--red-text-color)|Corrupt Multiplier>> values",
-        "ScalingReward2": "+1.66% <<var(--blueberry-box-color)|Ambrosia Bar Points>> gained",
+        "ScalingReward1": "+num:((0.05)) increase to <<var(--red-text-color)|Corrupt Multiplier>> values",
+        "ScalingReward2": "+num:((1.66))% <<var(--blueberry-box-color)|Ambrosia Bar Points>> gained",
         "ScalingReward3": "15 Achievement Points!",
         "UniqueReward1": "1st - +3 <<green|Reincarnation Challenge>> Cap!",
         "UniqueReward2": "12th - +1 Free <<var(--red-text-color)|Corruption Level>>",
@@ -6074,7 +6074,7 @@
         "name": "No Octeract Effects",
         "description": "Beat the target Singularity, but Octeracts and their upgrades do nothing!",
         "effectMod1": "<<gold|⚠>> In this EXALT, your effective Singularity is further multiplied by <<red|{{sing}}>>.",
-        "ScalingReward1": "+0.02 increase to <<var(--lightseagreen-text-color)|OCTERACT to CUBE>> bonus power (Base: 2.00) [effect halved after 10 completions]",
+        "ScalingReward1": "+num:((0.02)) increase to <<var(--lightseagreen-text-color)|OCTERACT to CUBE>> bonus power (Base: num:((2.00))) [effect halved after 10 completions]",
         "ScalingReward2": "20 Achievement Points!",
         "UniqueReward1": "1st - A bonus to <<Gold|Offerings>> based on <<var(--lightseagreen-text-color)|Octeracts>>!",
         "UniqueReward2": "10th - A bonus to <<steelblue|Obtainium>> based on <<var(--lightseagreen-text-color)|Octeracts>>!",
@@ -6086,7 +6086,7 @@
         "effectMod1": "<<red|Ascension Limit: {{ascensions}}>>",
         "effectMod2": "<<gold|⚠>> Each Ascension above {{ascensions}} divides Ascension Speed by 2.",
         "effectMod3": "Platonic DELTA is disabled, and Ascensions only grant 1 Ascension Count.",
-        "ScalingReward1": "<<orange|+0.25% Ascension Speed>> per Digit in your <<orange|Ascension Count!>>",
+        "ScalingReward1": "<<orange|+num:((0.25))% Ascension Speed>> per Digit in your <<orange|Ascension Count!>>",
         "ScalingReward2": "30 Achievement Points!",
         "UniqueReward1": "1st - Permanently double the cap of <<Pink|all Hepteracts>> for free!!! (This is really good!)",
         "UniqueReward2": "8th - A new <<orchid|Quark>> upgrade!",
@@ -6095,7 +6095,7 @@
       "noAmbrosiaUpgrades": {
         "name": "No Ambrosia Upgrades",
         "description": "Gold Guy has lost his muster (and yes, that's his name!) and needs your help.<br/>Clear the Singularity without any effects from Ambrosia or its modules! Red Ambrosia still functions fine.",
-        "ScalingReward1": "+20 & +0.5% <<lime| Ambrosia Luck>>",
+        "ScalingReward1": "+20 & +num:((0.5))% <<lime| Ambrosia Luck>>",
         "ScalingReward2": "+4% <<var(--blueberry-box-color)|Ambrosia Bar Point>> gain",
         "ScalingReward3": "+4 <<red|Red Luck>>",
         "ScalingReward4": "+2% <<red|Red Bar Point>> gain",
@@ -6139,16 +6139,16 @@
         "name": "The Taxman's Last Stand",
         "description": "The Tax Man, wanting the Ultimate Pen, has some devious new tricks up his sleeve. Beat the target Singularity, except:",
         "salvageMod": "<<lime|♽ Positive Salvage past 100 is vastly reduced (Divide by ln(1 + Positive Salvage))>>",
-        "offeringMod": "<<orange|☼ Each digit in your Offering Count divides your Obtainium gain by 2.5>>",
-        "obtainiumMod": "<<pink|☢ Each digit in your Obtainium Count divides your Offering gain by 2.5>>",
+        "offeringMod": "<<orange|☼ Each digit in your Offering Count divides your Obtainium gain by num:((2.5))>>",
+        "obtainiumMod": "<<pink|☢ Each digit in your Obtainium Count divides your Offering gain by num:((2.5))>>",
         "taxMod": "¢ Gain <<orange|4x>> the taxes when you've beaten Challenge 10, and <<red|5x>> more taxes when you've beaten Challenge 14",
         "capMod": "<<white | ▼ You cannot gain more than (100x + 1) your current Obtainium or Offerings from any source>>",
         "tributeMod": "<<gold | ε When you open Wow! Cubes, the amount of Tributes you get is divided by (ln^3(X + 1)), where X is the total number of Tributes plus Tributes you would otherwise gain>>",
         "omegaMod": "<b><<gray | Ω Singularity Penalties are substantially worse until you buy Platonic OMEGA!>></b>",
         "ScalingReward1": "+25 <<var(--red-text-color)|Talisman Level Caps>> for any Talisman that resets on Singularity",
         "ScalingReward2": "+3% <<var(--blueberry-box-color)|Talisman Free Rune Levels>>",
-        "ScalingReward3": "+0.002 <<var(--amber-text-color)|Rune Coefficient>> for Antiquities!",
-        "ScalingReward4": "+0.005 <<var(--amber-text-color)|Rune Coefficient>> for... <<burlywood | something>>...",
+        "ScalingReward3": "+num:((0.002)) <<var(--amber-text-color)|Rune Coefficient>> for Antiquities!",
+        "ScalingReward4": "+num:((0.005)) <<var(--amber-text-color)|Rune Coefficient>> for... <<burlywood | something>>...",
         "ScalingReward5": "50 Achievement Points!",
         "UniqueReward1": "1st - Unlock <<burlywood | Something Cool... and Runelike>>",
         "UniqueReward2": "5th - Unlock a new <<orchid|Quark Upgrade>>!",
@@ -7035,7 +7035,7 @@
       "title": "Red Bar Points",
       "PseudoCoins": "PseudoCoin Upgrade:",
       "Base": "Default Per Second:",
-      "BlueberrySpeed": "Speed from Ambrosia (0.5 DR after 1,000):",
+      "BlueberrySpeed": "Speed from Ambrosia (num:((0.5)) DR after num:((1000))):",
       "RedAmbrosia": "Red Ambrosia - Millennium-Aged Red Ambrosia:",
       "Exalt5": "EXALT - No Ambrosia Effects:",
       "Total": "Total Red Bar Points/s:"
@@ -7316,10 +7316,10 @@
     },
     "platonicUpgrades": {
       "c15Rewards": {
-        "requiredExponent": "Gain <span class=\"challengeNumber\" style=\"color: gold; font-size: 1.2em;\">{{coins}}</span> Coins in Challenge 15 to gain more Exponent!",
+        "requiredExponent": "Gain <span class=\"challengeNumber\" style=\"color: gold; font-size: num:((1.2))em;\">{{coins}}</span> Coins in Challenge 15 to gain more Exponent!",
         "nextReward": "Next reward type requires <<white | {{exponent}}>> Exponent.",
         "allUnlocked": "You have unlocked <<gold | all>> reward types from Challenge 15!",
-        "0": "Best Challenge 15 Exponent: <span class=\"challengeNumber\" style=\"color: gold; font-size: 1.2em;\">{{exponent}}</span>",
+        "0": "Best Challenge 15 Exponent: <span class=\"challengeNumber\" style=\"color: gold; font-size: num:((1.2))em;\">{{exponent}}</span>",
         "cube1": "• All Cube Types I: +{{amount}}",
         "ascensions": "• Ascension Count: +{{amount}}",
         "coinExponent": "• Coin Exponent: +{{amount}}",
@@ -7380,25 +7380,25 @@
         "platonicCanBuyMaxed": "===Maxed==="
       },
       "descriptions": {
-        "1": "+0.0090% Cubes per Corruption level per level!",
-        "2": "+0.018% Tesseracts per Corruption level per level!",
-        "3": "+0.054% Hypercubes per Corruption level per level!",
-        "4": "Gain +2.4% Platonic Cubes per level! It is that simple.",
-        "5": "C10 Exponent: 1.035 --> 1.0375, Constant tax exponent +0.10, 2x faster Constant production, 1.05x Quarks, +10 Reincarnation Challenge Cap, +5 Ascension Challenge Cap, 2x Immaculate Obtainium and Offerings, ^1.10 coin gain in C15, as well +1 Corruption Cap Level!",
+        "1": "+num:((0.0090))% Cubes per Corruption level per level!",
+        "2": "+num:((0.018))% Tesseracts per Corruption level per level!",
+        "3": "+num:((0.054))% Hypercubes per Corruption level per level!",
+        "4": "Gain +num:((2.4))% Platonic Cubes per level! It is that simple.",
+        "5": "C10 Exponent: num:((1.035)) --> num:((1.0375)), Constant tax exponent +num:((0.10)), 2x faster Constant production, num:((1.05))x Quarks, +10 Reincarnation Challenge Cap, +5 Ascension Challenge Cap, 2x Immaculate Obtainium and Offerings, ^num:((1.10)) coin gain in C15, as well +1 Corruption Cap Level!",
         "6": "Viscosity's exponent is multiplied by 1+(level/30), capped at ^1.",
         "7": "Global speed below 1x is raised to ^1-(level/30), ignoring Immaculate multipliers.",
-        "8": "The Hyperchallenge Cube's effect is divided by 1+(level*0.4), with a minimum of 1x.",
-        "9": "Gain 2.5x Immaculate Obtainium and multiply Defunded Education's exponent by 1+log10(Obtainium+1)/100, capped at 1e100 Obtainium.",
-        "10": "C10 Exponent: 1.0375 --> 1.04, Constant tax exponent +0.20, 10x faster Constant production, 1.10x Quarks, +10 Reincarnation Challenge Cap, +5 Ascension Challenge Cap, 3.5x Immaculate Obtainium and Offerings, 2x All Cubes, ^1.25 ant exponent in C15, +1 Corruption Cap Level again!",
+        "8": "The Hyperchallenge Cube's effect is divided by 1+(level*num:((0.4))), with a minimum of 1x.",
+        "9": "Gain num:((2.5))x Immaculate Obtainium and multiply Defunded Education's exponent by 1+log10(Obtainium+1)/100, capped at num:((1e100)) Obtainium.",
+        "10": "C10 Exponent: num:((1.0375)) --> num:((1.04)), Constant tax exponent +num:((0.20)), 10x faster Constant production, num:((1.10))x Quarks, +10 Reincarnation Challenge Cap, +5 Ascension Challenge Cap, num:((3.5))x Immaculate Obtainium and Offerings, 2x All Cubes, ^num:((1.25)) ant exponent in C15, +1 Corruption Cap Level again!",
         "11": "If Crystal Mine Collapse is set to level 11 or higher, Reincarnations will also give Diamonds based on Particle gain!",
-        "12": "For each level of Extinction, gain +0.5% more Ant ELO, per level of this upgrade! (Additive to other sources). Reborn ELO is created 10% faster per level! Also, for each Challenge completion, gain +1% more Ant Speed per level.",
+        "12": "For each level of Extinction, gain +num:((0.5))% more Ant ELO, per level of this upgrade! (Additive to other sources). Reborn ELO is created 10% faster per level! Also, for each Challenge completion, gain +1% more Ant Speed per level.",
         "13": "'Less Fruitful Harvests' reduces your <<green|Salvage>> by 50% less!",
-        "14": "Multiply Great Depression II's coin exponent by 1.55, but only in Challenge 15.",
-        "15": "You begin to find the start of the abyss. Coin Exponent +0.10 in Challenge 15, Challenge 15 Score +25%, Ascension Speed +0.2% per Corruption Level (Max: 20%), +1% to 3D-7D (Cube-Hepteracts) Cubes per C9 Completion (Multiplicative), 1.15x Quarks, 1e250x Tesseract Building Multiplier, 2x Ascension Count, +30 Reincarnation Challenge Cap, +20 Ascension Challenge Cap, 6x Immaculate Obtainium and Offerings! Talk about a deep dive.",
-        "16": "Increase powder conversion rate by 1% per level, gain +2% Ascension count per level and gain up to 2% more Ascension count per level based on powder, up to 100,000. This will also multiply Tesseract Building production by (Powder + 1)^(10 * level), uncapped.",
-        "17": "If this is bought, Viscosity's score multiplier is raised to 3+(level*0.04) if its level is set to 10 or higher.",
-        "18": "Raise the base percentage of Constant Upgrade 1 by 0.1% and increase the base percentage cap of Constant Upgrade 2 by 0.3% per level!",
-        "19": "The Chronos Hepteract's diminishing return exponent is increased by level/750 (roughly 0.00133). (Base: 1/6)",
+        "14": "Multiply Great Depression II's coin exponent by num:((1.55)), but only in Challenge 15.",
+        "15": "You begin to find the start of the abyss. Coin Exponent +num:((0.10)) in Challenge 15, Challenge 15 Score +25%, Ascension Speed +num:((0.2))% per Corruption Level (Max: 20%), +1% to 3D-7D (Cube-Hepteracts) Cubes per C9 Completion (Multiplicative), num:((1.15))x Quarks, num:((1e250))x Tesseract Building Multiplier, 2x Ascension Count, +30 Reincarnation Challenge Cap, +20 Ascension Challenge Cap, 6x Immaculate Obtainium and Offerings! Talk about a deep dive.",
+        "16": "Increase powder conversion rate by 1% per level, gain +2% Ascension count per level and gain up to 2% more Ascension count per level based on powder, up to num:((100000)). This will also multiply Tesseract Building production by (Powder + 1)^(10 * level), uncapped.",
+        "17": "If this is bought, Viscosity's score multiplier is raised to 3+(level*num:((0.04))) if its level is set to 10 or higher.",
+        "18": "Raise the base percentage of Constant Upgrade 1 by num:((0.1))% and increase the base percentage cap of Constant Upgrade 2 by num:((0.3))% per level!",
+        "19": "The Chronos Hepteract's diminishing return exponent is increased by level/750 (roughly num:((0.00133))). (Base: 1/6)",
         "20": "You know, maybe some things should be left unbought."
       },
       "20Bought": "While I strongly recommended you not to buy this, you did it anyway. For that, you have unlocked the Antiquities of Ant God Rune."
@@ -7425,23 +7425,23 @@
       "warps": "Warps:",
       "descriptions": {
         "chronos": {
-          "effect": "This hepteract bends time, in your favor. +0.06% Ascension Speed per Chronos Hepteract.",
+          "effect": "This hepteract bends time, in your favor. +num:((0.06))% Ascension Speed per Chronos Hepteract.",
           "currentEffect": "Current Effect: Ascension Speed +{{x}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Obtainium!"
         },
         "hyperrealism": {
-          "effect": "This bad boy can make hypercube gain skyrocket. +0.06% Hypercubes per Hyperreal Hepteract.",
+          "effect": "This bad boy can make hypercube gain skyrocket. +num:((0.06))% Hypercubes per Hyperreal Hepteract.",
           "currentEffect": "Current Effect: Hypercubes +{{x}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Offerings."
         },
         "quark": {
           "effect": "One pound, two pound fish.",
-          "effect2": "Grants a Quark Multiplier equal to (1 + 0.2 * log2(1 + QHept / 500))^{{x}}",
+          "effect2": "Grants a Quark Multiplier equal to (1 + num:((0.2)) * log2(1 + QHept / 500))^{{x}}",
           "currentEffect": "Current Effect: Quarks +{{x}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Quarks."
         },
         "challenge": {
-          "effect": "That's preposterous. How are you going to gain +0.05% C15 Exponent per Challenge Hepteract? How!?",
+          "effect": "That's preposterous. How are you going to gain +num:((0.05))% C15 Exponent per Challenge Hepteract? How!?",
           "currentEffect": "Current Effect: C15 Exponent +{{x}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts, {{y}} Platonic Cubes and {{z}} Cubes."
         },
@@ -7451,17 +7451,17 @@
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Cubes (lol)"
         },
         "accelerator": {
-          "effect": "Haha, stupid Corruptions. +2,000 +0.03% Immaculate Accelerators per 'Way too many accelerators' Hepteract!",
+          "effect": "Haha, stupid Corruptions. +num:((2000)) +num:((0.03))% Immaculate Accelerators per 'Way too many accelerators' Hepteract!",
           "currentEffect": "Current Effect: Immaculate Accelerators +{{x}} + {{y}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Wow! Tesseracts"
         },
         "acceleratorBoost": {
-          "effect": "Haha, stupid Corruptions. +0.1% Accelerator Boosts per 'Way too many accelerator boosts' Hepteract!",
+          "effect": "Haha, stupid Corruptions. +num:((0.1))% Accelerator Boosts per 'Way too many accelerator boosts' Hepteract!",
           "currentEffect": "Current Effect: Accelerator Boosts +{{x}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Hypercubes"
         },
         "multiplier": {
-          "effect": "Haha, stupid Corruptions. +1,000 +0.03% Immaculate Multipliers per 'Way too many multipliers' Hepteract!",
+          "effect": "Haha, stupid Corruptions. +num:((1000)) +num:((0.03))% Immaculate Multipliers per 'Way too many multipliers' Hepteract!",
           "currentEffect": "Current Effect: Immaculate Multipliers +{{x}} +{{y}}",
           "oneCost": "One of these will cost you {{x}} Hepteracts and {{y}} Obtainium"
         }
@@ -7495,7 +7495,7 @@
     "orbEffect": "Orb Effect: Opening Cubes gives {{x}}% more Quarks.",
     "orbsPurchasedToday": "Orbs Purchased Today: {{x}}.",
     "amalgamate": "You can amalgamate Overflux Orbs here. [NOTE: these expire at the end of your current day]",
-    "cost250k": "Cost: 250,000 Hepteracts per Overflux Orb",
+    "cost250k": "Cost: num:((250000)) Hepteracts per Overflux Orb",
     "craftMaxOrbs": "This will attempt to buy as many orbs as possible. \nYou can buy up to {{x}} with your hepteracts. Are you sure?",
     "hepteractInput": "How many Orbs would you like to purchase?\n You can buy up to {{x}} with your hepteracts.",
     "gainedPowder": "You have also gained {{x}} powder immediately, thanks to your shop upgrades.",
@@ -7794,7 +7794,7 @@
       "consumableSpoiler": "Start an event for everyone, with the Happy Hour Bell!",
       "consumableButton": "Consumables Shop",
       "applyTips": "Use Tips!",
-      "applyTipsPrompt": "How many tips would you like to use? Each tip gives 1 minute of Offline Time. You have {{tips}} tip(s). You may only use up to 1,440 tips at a time.",
+      "applyTipsPrompt": "How many tips would you like to use? Each tip gives 1 minute of Offline Time. You have {{tips}} tip(s). You may only use up to num:((1440)) tips at a time.",
       "confirmActivation": "You are about to activate a {{name}} for {{cost}} PseudoCoins. Continue?",
       "cancelled": "Puchase has been cancelled.",
       "currentAmountNone": "Current Amount: <<#8f8|No active consumable>>",


### PR DESCRIPTION
Fixes:
1. Fixed displayed value in RNG-Based Obtainium Booster and RNG-Based Offering Booster Ambrosia Upgrades.
2. Fixed incorrect rounding for numbers, in particular, for percent values.
3. Fixed Auto-Transcension localization.
4. Fixed `-0` Talisman Fragment amount.
5. Fixed Tributum Formicidae's effect sign.
6. Fixed Ant Auto-Sacrifice Immortal ELO threshold when it's set to a non-integer value.

Other Changes:
1. Removed long exponent number format (redundant and not improving readability).
2. Removed fractional number format (for being confusing).
3. Added truncated number format.
4. Added number locale support in English localization (via a new i18n plugin).
5. Removed long notation for Talisman Fragments (it was not fitting in the element).
6. Removed long notation for Abyss Hepteract cost of Platonic Upgrades (for consistency).
7. Removed long notation of Hepteracts.
8. Added formatting for opened Hepteract percentage.
9. Increased accuracy for daily levels of Octeract Upgrades.
10. Increased accuracy of some other numbers (Rune and Talisman effects, Hepteract effects, etc.).

Find & replace steps applied to `en.json` file:
1. Enable regex mode
2. Find: `(\d{1,3}((\.\d+)?e\d+(,?\d{3})*|(,\d{3})+(\.\d+)?|\.\d+))` => Replace: `num:(($1))`
3. Find: `(num:\(\((?:\d|e)*\d),(\d[^)]*\)\))` => Replace: `$1$2` (repeat until no matches)