### PR TITLE
fix score statue reading wrong count

### DIFF
--- a/src/PlatonicCubes.ts
+++ b/src/PlatonicCubes.ts
@@ -84,16 +84,16 @@ export const calculateAscensionScorePlatonicBlessing = () => {
   const limit2 = 1e20
   const effectPerBlessing = 1 / 1e4
 
-  if (player.platonicBlessings.globalSpeed < limit1) {
-    return 1 + effectPerBlessing * player.platonicBlessings.globalSpeed
-  } else if (limit1 <= player.platonicBlessings.globalSpeed && player.platonicBlessings.globalSpeed < limit2) {
+  if (player.platonicBlessings.scoreBonus < limit1) {
+    return 1 + effectPerBlessing * player.platonicBlessings.scoreBonus
+  } else if (limit1 <= player.platonicBlessings.scoreBonus && player.platonicBlessings.scoreBonus < limit2) {
     const limitMult = Math.pow(limit1, 1 - DR1)
-    return 1 + effectPerBlessing * limitMult * Math.pow(player.platonicBlessings.globalSpeed, DR1)
+    return 1 + effectPerBlessing * limitMult * Math.pow(player.platonicBlessings.scoreBonus, DR1)
   } else {
     // Can derive that this works using algebra (Platonic did it)
     const limitMult1 = Math.pow(limit1, 1 - DR1)
     const limitMult2 = Math.pow(limit2, DR1 - DR2)
-    return 1 + effectPerBlessing * limitMult1 * limitMult2 * Math.pow(player.platonicBlessings.globalSpeed, DR2)
+    return 1 + effectPerBlessing * limitMult1 * limitMult2 * Math.pow(player.platonicBlessings.scoreBonus, DR2)
   }
 }
 


### PR DESCRIPTION
Hi, I was optimizing my settings when i unlocked platonic cubes. I found a small bug 

`calculateAscensionScorePlatonicBlessing` in `src/PlatonicCubes.ts` calc with invalid variable 

maybe this function calc with `scoreBonus` but now `globalSpeed`

I checked it in local with test save file

main
<img width="753" height="98" alt="image" src="https://github.com/user-attachments/assets/4e314eff-4407-445b-8e6c-187ad8f8efff" />


current branch
<img width="773" height="90" alt="Screenshot 2026-09-12 at 3 11 16 AM" src="https://github.com/user-attachments/assets/f7bd8e2a-4aa1-4ec2-bfab-96fe43972563" />


